### PR TITLE
Removed `fixed_point` keyword from `NonlinearSolver` constructor

### DIFF
--- a/src/nonlinear/fixed_point_iterator.jl
+++ b/src/nonlinear/fixed_point_iterator.jl
@@ -29,7 +29,7 @@ end
 - `options_kwargs`: see [`Options`](@ref)
 """
 function FixedPointIterator(x::AT, F::Callable; kwargs...) where {T,AT<:AbstractVector{T}}
-    nlp = NonlinearProblem(F, missing, x, x; fixed_point=true)
+    nlp = NonlinearProblem(F, missing, x, x)
     cache = FixedPointIteratorCache(x)
     FixedPointIterator(x, nlp, cache; kwargs...)
 end
@@ -48,8 +48,6 @@ function solver_step!(it::FixedPointIterator{T}, x::AbstractVector{T}, params) w
     update!(cache(it), x)
     value!(nonlinearproblem(it), x, params)
     x .= value(nonlinearproblem(it))
-    isFixedPointFormat(nonlinearproblem(it)) || (x .-= solution(cache(it)))
-    x
 end
 
 cache(solver::FixedPointIterator)::FixedPointIteratorCache = solver.cache

--- a/src/nonlinear/solver_problems.jl
+++ b/src/nonlinear/solver_problems.jl
@@ -143,7 +143,7 @@ A `NonlinearProblem` describes ``F(x) = y``, where we want to solve for ``x`` an
 - `x_f`: accessed by calling [`f_argument`](@ref)`(nlp)`,
 - `x_j`: accessed by calling [`j_argument`](@ref)`(nlp)`,
 """
-struct NonlinearProblem{T,FixedPoint,TF<:Callable,TJ<:Union{Callable,Missing},Tx<:AbstractVector{T},Tf<:AbstractVector{T},Tj<:AbstractMatrix{T}} <: AbstractProblem
+struct NonlinearProblem{T,TF<:Callable,TJ<:Union{Callable,Missing},Tx<:AbstractVector{T},Tf<:AbstractVector{T},Tj<:AbstractMatrix{T}} <: AbstractProblem
     F::TF
     J::TJ
 
@@ -156,10 +156,9 @@ struct NonlinearProblem{T,FixedPoint,TF<:Callable,TJ<:Union{Callable,Missing},Tx
     function NonlinearProblem(F::Callable, J::Union{Callable,Missing},
         x::Tx,
         f::Tf;
-        j::Tj=alloc_j(x, f),
-        fixed_point::Bool=false) where {T,Tx<:AbstractArray{T},Tf,Tj<:AbstractArray{T}}
+        j::Tj=alloc_j(x, f)) where {T,Tx<:AbstractArray{T},Tf,Tj<:AbstractArray{T}}
         hasmethod(F, Tuple{Tf, Tx, OptionalParameters}) || error("The function needs to have the following signature: F(y, x, params).")
-        nlp = new{T,fixed_point,typeof(F),typeof(J),Tx,Tf,Tj}(F, J, alloc_x(f), j, alloc_x(x), alloc_x(x))
+        nlp = new{T,typeof(F),typeof(J),Tx,Tf,Tj}(F, J, alloc_x(f), j, alloc_x(x), alloc_x(x))
         initialize!(nlp, x)
         nlp
     end
@@ -176,8 +175,6 @@ Set `jacobian` ``\gets`` `missing` and call the [`NonlinearProblem`](@ref) const
 function NonlinearProblem(F::Callable, x::AbstractArray, f::AbstractArray)
     NonlinearProblem(F, missing, x, f)
 end
-
-isFixedPointFormat(::NonlinearProblem{T,FP}) where {T,FP} = FP
 
 function value!!(nlp::NonlinearProblem{T}, x::AbstractArray{T}, params) where {T}
     f_argument(nlp) .= x


### PR DESCRIPTION
The type parameter `FixedPoint` is not used anymore for dispatch. This role is now assumed by the `NonlinearSolverMethod` (in this case `PicardMethod <: NonlinearSolverMethod`). This change was made in #66 (commit https://github.com/JuliaGNI/SimpleSolvers.jl/pull/66/commits/3df4bba50df9a143f0cfa5fc671a664a5a34ea10).