### PR TITLE
Got rid of `__derivative!` and `__value!` (probably a legacy issue).

### DIFF
--- a/obsolete/quadratic.jl
+++ b/obsolete/quadratic.jl
@@ -64,7 +64,7 @@ function (ls::QuadraticState{T})(obj::LinesearchProblem{T}, number_of_iterations
     number_of_iterations != ls.config.max_iterations || error("Maximum number of iterations reached when doing quadratic line search.")
     # determine constant coefficients of polynomial p(α) = p₀ + p₁α + p₂α²
     y₀ = value(obj, x₀)
-    d₀ = derivative!(obj, x₀)
+    d₀ = derivative(obj, x₀)
     p₀ = y₀
     p₁ = d₀
     α = determine_initial_α(obj, α, y₀)

--- a/src/linesearch/backtracking/backtracking.jl
+++ b/src/linesearch/backtracking/backtracking.jl
@@ -113,8 +113,8 @@ LinesearchState(algorithm::Backtracking; T::DataType = Float64, kwargs...) = Bac
 
 function (ls::BacktrackingState{T})(obj::LinesearchProblem{T}, α::T = ls.α₀) where {T}
     x₀ = zero(α)
-    y₀ = __value!(obj, x₀)
-    d(α) = __derivative!(obj, α)
+    y₀ = value(obj, x₀)
+    d(α) = derivative(obj, α)
     d₀ = d(x₀)
 
     # note that we set pₖ ← 0 here as this is the descent direction for the linesearch problem.
@@ -130,8 +130,3 @@ function (ls::BacktrackingState{T})(obj::LinesearchProblem{T}, α::T = ls.α₀)
 
     α
 end
-
-__value!(obj::AbstractOptimizerProblem, x₀) = value(obj, x₀)
-__value!(obj::LinesearchProblem, x₀) = value(obj, x₀)
-__derivative!(obj::AbstractOptimizerProblem, x₀) = derivative!(obj, x₀)
-__derivative!(obj::LinesearchProblem, x₀) = derivative(obj, x₀)

--- a/src/linesearch/backtracking/curvature_condition.jl
+++ b/src/linesearch/backtracking/curvature_condition.jl
@@ -43,11 +43,11 @@ function strong_curvature_condition(cc::CurvatureCondition{T, VT, TVT, OT, GT}, 
 end
 
 function standard_curvature_condition(cc::CurvatureCondition{T, T, T, OT, GT}, xₖ₊₁::T, αₖ::T) where {T, OT, GT}
-    __derivative!(cc.obj, xₖ₊₁)' * cc.pₖ ≥ cc.c * cc.gradₖ' * cc.pₖ
+    derivative(cc.obj, xₖ₊₁)' * cc.pₖ ≥ cc.c * cc.gradₖ' * cc.pₖ
 end
 
 function strong_curvature_condition(cc::CurvatureCondition{T, T, T, OT, GT}, xₖ₊₁::T, αₖ::T) where {T, OT, GT}
-    abs(__derivative!(cc.obj, xₖ₊₁)' * cc.pₖ) < abs(cc.c * cc.gradₖ' * cc.pₖ)
+    abs(derivative(cc.obj, xₖ₊₁)' * cc.pₖ) < abs(cc.c * cc.gradₖ' * cc.pₖ)
 end
 
 function (cc::CurvatureCondition{T, VT, TVT, OT, GT, :Standard})(xₖ₊₁::VT, αₖ::T) where {T, VT, TVT, OT, GT}

--- a/src/linesearch/backtracking/sufficient_decrease_condition.jl
+++ b/src/linesearch/backtracking/sufficient_decrease_condition.jl
@@ -43,7 +43,7 @@ mutable struct SufficientDecreaseCondition{T, VT<:Union{T, AbstractArray{T}}, TV
 end
 
 function (sdc::SufficientDecreaseCondition{T, VT})(xₖ₊₁::VT, αₖ::T) where {T, VT}
-    fₖ₊₁ = __value!(sdc.obj, xₖ₊₁)
+    fₖ₊₁ = value(sdc.obj, xₖ₊₁)
     fₖ₊₁ ≤ sdc.fₖ + sdc.c * αₖ * sdc.pₖ' * sdc.gradₖ
 end
 


### PR DESCRIPTION
This was legacy code taking into account that the `LinesearchProblem` does not store arrays:
https://github.com/JuliaGNI/SimpleSolvers.jl/blob/b524f7a7201cfa04936f06e05369056d3e4cee24/src/optimization/optimizer_problems.jl#L59-L62

The arrays for computations are stored in the `cache` (see https://github.com/JuliaGNI/SimpleSolvers.jl/blob/main/src/nonlinear/linesearch_problem.jl for the solvers).