### PR TITLE
Syntax fix: callable type instead of tuple assignment

### DIFF
--- a/src/linesearch/backtracking/backtracking_condition.jl
+++ b/src/linesearch/backtracking/backtracking_condition.jl
@@ -5,7 +5,7 @@ Abstract type comprising the conditions that are used for checking step sizes fo
 """
 abstract type BacktrackingCondition{T} end
 
-(bc::BCT, xₖ, αₖ, gradₖ) where {BCT<:BacktrackingCondition} = error("Condition $(BCT) not defined for this combination of input arguments.")
+(bc::BacktrackingCondition)(xₖ, αₖ, gradₖ) = error("Condition $(BCT) not defined for this combination of input arguments.")
 
 """
     compute_new_iterate!(xₖ₊₁, xₖ, αₖ, pₖ)


### PR DESCRIPTION
Lowering has a bug where an assignment to a `where`-wrapped tuple is treated like an anonymous function, and it's a very easy typo to make when trying to add a method to a callable type.  I found this syntax in two packages, and both seemed to be typos, so this PR corrects the syntax before I make it a proper error.  Issue reference: https://github.com/JuliaLang/julia/issues/62051