### PR TITLE
Standardise the line-search contract and make it robust at the merit's round-off floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,24 @@ better the initial guess is.
   caller already computed, so neither `Backtracking` nor `StrongWolfe` evaluates the merit twice
   per trial. `StrongWolfe` keeps `τ = 0`. The condition is
   `fα ≤ min(f₀, f₀ + cαd₀ + τ)`: the allowance may reduce the decrease *demanded*, but it never
-  accepts a step whose merit exceeds `f₀`. The `min` is inactive in double precision and
-  necessary in `Float16`, where four ulps of `f₀` is `3.9e-3` — twenty times the `2c₁ = 2e-4`
-  demanded at `α = 1`, so an unbounded `τ` would license a visible uphill step.
+  accepts a step whose merit exceeds `f₀`.
+- `armijo_ulps(T[, c₁])` makes the round-off resolution **precision-aware**, and is what every
+  method now uses in place of the bare `DEFAULT_ARMIJO_τ_ULPS`. `τ` must be at least ~an ulp of
+  `φ(0)` to recognise a merit at its round-off floor, and far below the `2c₁·φ(0)` the condition
+  demands at `α = 1` to leave that condition meaningful; the two are compatible only while
+  `eps(T) ≪ 2c₁`. That holds by ~10 orders of magnitude in `Float64` and by a factor 400 in
+  `Float32`, so the nominal 4 ulps stands in both and their behaviour is bit-identical to before.
+  It fails outright in `Float16`, where `eps(T) = 9.8e-4` already exceeds `2c₁ = 2e-4`: the
+  nominal `τ` was *twenty times* the demanded decrease, which degenerated the Armijo test to
+  plain monotonicity at every `α` and — worse — classified a genuine two-ulp decrease as
+  `LINESEARCH_FLOOR`, which `solver_step!` feeds to `flag_stall!`, so a *converging* half-precision
+  solve could be reported as stagnated. The cap (`ARMIJO_τ_DEMAND_FRACTION = 0.01`, i.e. `τ` may
+  distort the demanded decrease by at most one percent) drops `Float16` to ~2e-3 ulps, in effect
+  the exact condition. Nothing is lost: the floor is still detected without `τ`, both by the
+  condition degenerating to `φ(α) ≤ φ(0)` at a small enough trial step and by `Backtracking`'s
+  two-consecutive-bit-identical-merits check. `Backtracking` applies the cap in its inner
+  constructor, so every path in — including `change_precision` and an explicitly oversized
+  `τ_ulps` — gets a resolution the element type can support.
 - `Options` gained `linesearch_max_iterations` (default `linesearch_iterations(T)`: 60 for
   `Float64`, 31 for `Float32`, 18 for `Float16`) and `max_stalls` (default `MAX_STALLS = 2`).
 - `SimpleSolvers.with_config(ls, config)` returns a `Linesearch` with the problem and method of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to SimpleSolvers.jl are documented here.
 
-## [0.9.3]
+## [0.10.0]
 
 Robustness release for the `Backtracking` line search. Downstream packages
 (GeometricIntegrators, GeometricProblems, ChargedParticleDynamics) were flooded by
@@ -40,33 +40,45 @@ better the initial guess is.
 
 - `LinesearchStatus`, `LinesearchOutcome` (`LINESEARCH_DECREASED`, `LINESEARCH_FLOOR`,
   `LINESEARCH_EXHAUSTED`, `LINESEARCH_NO_DESCENT`, `LINESEARCH_STATIONARY`,
-  `LINESEARCH_UNKNOWN`), `solve_with_status`, `issufficient` and `isfloor`. `solve_with_status`
+  `LINESEARCH_UNKNOWN`) and `solve_with_status` are exported; the accompanying predicates and
+  accessors `issufficient`, `isfloor`, `steplength`, `outcome` and `trials` are *not*, since
+  they are generic names a package doing `using SimpleSolvers` may want for itself — reach them
+  as `SimpleSolvers.steplength` and so on. `solve_with_status`
   returns the step length *plus* why the search stopped, which the step length alone cannot
   express — a tiny `α` may be the right answer or all that is left after the merit turned out
   to be irreducible. All six built-in methods report a genuine outcome (see the contract section
   below); the generic `LINESEARCH_UNKNOWN` fallback remains for user-defined methods.
   `SimpleSolvers.linesearch_warnings` is now the single place a line search emits messages.
-- `Backtracking` gained a `τ_ulps` keyword (default 4): the round-off allowance
-  `τ = τ_ulps·ulp(φ(0))` added to the sufficient decrease condition, from which the smallest
-  *informative* step `αmin = τ/(c₁|φ'(0)|) = 2·τ_ulps·α*` is derived. Because `αmin` is a
-  factor `2·τ_ulps` above `α*`, the search provably never enters the region where the test is
-  decided by rounding. `τ_ulps = 0` recovers the exact condition. New (unexported)
+- `Backtracking` gained a `τ_ulps` keyword (default 4): the round-off *resolution* of the merit,
+  `τ = τ_ulps·ulp(φ(0))`, from which the smallest *informative* step
+  `αmin = τ/(c₁|φ'(0)|) = 2·τ_ulps·α*` is derived. Because `αmin` is a factor `2·τ_ulps` above
+  `α*`, the search does not enter the region where the test is decided by rounding — unless
+  `backtracking_αmin`'s upper clamp at `√eps(T)` binds, which it does for a very flat merit in
+  double precision and for essentially any merit in `Float16`. Trial steps below `α*` are safe
+  there because the condition reduces to plain monotonicity (see below), and such an accept is
+  classified `LINESEARCH_FLOOR`. `τ_ulps = 0` recovers the exact condition. New (unexported)
   `armijo_tolerance`, `backtracking_αmin`, `backtracking_interpolation`, and the constants
   `DEFAULT_ARMIJO_τ_ULPS` and `BACKTRACKING_SHRINK_MIN`.
 - `SufficientDecreaseCondition` gained a keyword-only `τ` field (default `zero(T)`, i.e. the
   exact former condition) and a two-argument call form `sdc(α, fα)` taking a merit value the
-  caller already computed, so a backtracking loop no longer evaluates the merit twice per
-  trial. `StrongWolfe` keeps `τ = 0`.
+  caller already computed, so neither `Backtracking` nor `StrongWolfe` evaluates the merit twice
+  per trial. `StrongWolfe` keeps `τ = 0`. The condition is
+  `fα ≤ min(f₀, f₀ + cαd₀ + τ)`: the allowance may reduce the decrease *demanded*, but it never
+  accepts a step whose merit exceeds `f₀`. The `min` is inactive in double precision and
+  necessary in `Float16`, where four ulps of `f₀` is `3.9e-3` — twenty times the `2c₁ = 2e-4`
+  demanded at `α = 1`, so an unbounded `τ` would license a visible uphill step.
 - `Options` gained `linesearch_max_iterations` (default `linesearch_iterations(T)`: 60 for
   `Float64`, 31 for `Float32`, 18 for `Float16`) and `max_stalls` (default `MAX_STALLS = 2`).
 - `SimpleSolvers.with_config(ls, config)` returns a `Linesearch` with the problem and method of
   `ls` but different `Options`.
-- `NonlinearSolverStatus`, `isconverged`, `isstalled` and `status(solver, state)` are exported.
-  `solve!` returns `x`, not a status, so `status(solver, state)` is how a caller inspects the
-  outcome — in particular whether a solve *converged* or merely *stagnated* at the residual
-  floor. (`status` was removed from the exports in 0.9.0 as undefined; this implements it.)
+- `NonlinearSolverStatus` is exported; `SimpleSolvers.isconverged`, `isstalled` and
+  `status(solver, state)` are not, `status` least of all — a downstream package that does
+  `using SimpleSolvers` and defines its own `status` would get a method-definition error rather
+  than a shadowing warning. `solve!` returns `x`, not a status, so
+  `SimpleSolvers.status(solver, state)` is how a caller inspects the outcome — in particular
+  whether a solve *converged* or merely *stagnated* at the residual floor.
 - `SimpleSolvers.residual_small`, `iterate_settled`, `stalled_step`, `record_stall!`,
-  `flag_stall!` and `stall_number`.
+  `flag_stall!`, `stall_number` and `needs_refresh`.
 
 ### Changed (behavioural)
 
@@ -113,11 +125,27 @@ better the initial guess is.
   and convergence are mutually exclusive by construction. This is diagnosed from the step
   actually taken, so it also covers a `Static` step along an underflowed direction, a collapsed
   `DogLeg` trust-region radius and a locally expanding `Picard` map; a line search that reports
-  `LINESEARCH_FLOOR` additionally flags it one iteration earlier. A counter (rather than a
-  one-shot stop) is used because `maybe_refactorize!` and `DogLegSolver` both deliberately
-  recover on the step *after* a frozen one. `max_stalls = typemax(Int)` restores the old
-  behaviour. The two misleading warnings are replaced by one message naming the achieved
-  residual, the requested tolerance and both remedies.
+  `LINESEARCH_FLOOR` or `LINESEARCH_NO_DESCENT` additionally flags it one iteration earlier.
+  A counter (rather than a one-shot stop) is used because the step *after* a stalled one is
+  deliberately attempted under better conditions — see the next entry. `max_stalls = typemax(Int)`
+  restores the old behaviour. The two misleading warnings are replaced by one message naming the
+  achieved residual, the requested tolerance and both remedies, rate-limited with `maxlog` so
+  that a caller looping `solve!` per time step does not see it once per step.
+- **A stalled step forces a fresh Jacobian on the next step.** `maybe_refactorize!` gained a
+  `stalled` keyword, supplied by `solver_step!` from the new `SimpleSolvers.needs_refresh(state)`.
+  Without it, a quasi-Newton solver with `refactorize = r` would rebuild the same direction from
+  the same stale Jacobian for up to `r - 1` further steps and reproduce the same negligible step,
+  so `max_stalls = 2` could give up at the second of those for a reason a fresh Jacobian would
+  have fixed. Now the second consecutive stall is one a freshly evaluated Jacobian did *not* fix,
+  which makes `max_stalls = 2` conclusive for every `refactorize` rather than only for
+  `refactorize = 1`. `DogLegSolver` folds the same signal into its existing `force_refresh`.
+- **`LINESEARCH_NO_DESCENT` is acted on rather than only reported.** An ascent anchor is a
+  stale-Jacobian symptom whose remedy is to refresh the Jacobian, so `solver_step!` now leaves the
+  iterate where it is — moving along a direction the line search has rejected outright would only
+  make the retry start from a worse point — and records a stall, which triggers exactly that
+  refresh. Previously the full step was taken along the ascent direction, the iterate moved (so
+  nothing counted it as a stall), and the solve ran to `max_iterations`. The line search itself
+  still returns `α > 0` as its contract requires; whether to use it is the caller's decision.
 - **`solve!` tests the stopping criteria before the first step.** An initial guess that already
   satisfies them is no longer perturbed by a full solver step (Jacobian, factorization, and a
   line search asked to improve an already-exact residual). Only the absolute branch is
@@ -129,6 +157,17 @@ better the initial guess is.
   the residual the solver has already computed as `params.φ₀`, saving one `F` evaluation per
   solver step. A caller driving `solver_step!` by hand from a state whose `value` is stale must
   not supply it.
+- `StrongWolfe` no longer evaluates the merit twice per trial step. Both its expansion loop and
+  its zoom phase called the one-argument `sdc(α)` immediately after computing `φ(α)`, and the
+  status construction re-evaluated `φ` at the accepted step; all three now reuse the value in
+  scope (`_wolfe_zoom` returns `(α, φ, n)`). For a `NonlinearSolver` each of those was a full
+  residual evaluation.
+- `LinesearchStatus.trials` is now the true merit-evaluation count for every method.
+  `Bisection`, `Quadratic` and `BierlaireQuadratic` reported a hardcoded `0`, so the
+  round-off-floor message read "in 0 trial step(s)", and `StrongWolfe` counted only its expansion
+  loop. `LinesearchStatus.αmin` remains a shrinking-ladder quantity and is documented as
+  `zero` — "not applicable" — for the bracketing and minimising searches, which no longer print
+  it.
 - `Base.show(::Backtracking)` includes `τ_ulps`; `Base.show(::NonlinearSolverStatus)` appends a
   `stalls` line only when it is nonzero, so the printout of a fresh status is unchanged.
 - Passing `linesearch = …` to `PicardSolver`/`DogLegSolver` is still an error, but now raises a
@@ -218,11 +257,29 @@ private helpers, so `solve`/`solve_with_status` is unambiguously the public entr
 
 ### Changed (breaking)
 
-- `Quadratic` and `Bisection` no longer return negative steps; an ascending anchor is reported as
-  `LINESEARCH_NO_DESCENT` instead. The test that pinned the old behaviour asserted
-  `solve(ls, 0.0) ≈ -1.0`.
-- `triple_point_finder`, `bracket_minimum` and `bracket_minimum_with_fixed_point` return
-  `Union{Nothing,…}`. `bracket_minimum` is exported; the other two are not.
+- `Quadratic` and `Bisection` no longer return negative steps. The test that pinned the old
+  behaviour asserted `solve(ls, 0.0) ≈ -1.0`. A result that is still non-positive after the
+  retry from the `α = 0` anchor is reported as `LINESEARCH_FLOOR` (not `LINESEARCH_NO_DESCENT`,
+  which would contradict the anchor check that already passed).
+- `bracket_minimum` and `bracket_minimum_with_fixed_point` return `Union{Nothing,…}` instead of
+  throwing, and `triple_point_finder` returns `Union{Symbol,…}`. **`bracket_minimum` is
+  exported**, so `a, b = bracket_minimum(f, x)` on an unbracketable `f` now raises
+  `MethodError: iterate(::Nothing)` where it used to raise a descriptive error, and code that
+  relied on the throw to detect failure now proceeds silently. The other two are not exported.
+  `triple_point_finder` distinguishes its two failures — `:flat` (the merit does not resolve a
+  decrease, mapped to `LINESEARCH_FLOOR`) from `:unbracketable` (there *is* a decrease that
+  could not be bracketed, mapped to `LINESEARCH_EXHAUSTED`) — because conflating them makes the
+  outer iteration count a *descending* merit as stagnation.
+- Removed the unexported `max_number_of_quadratic_linesearch_iterations` and the constants
+  `MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH` and its `_SINGLE_PRECISION` sibling; both
+  quadratic searches now use `Options.linesearch_max_iterations`.
+- Removed the `solve(::Linesearch{<:Bisection}, α₀, α₁, params)` overload and the
+  `BierlaireQuadratic` `solve(ls, α₀, params, iteration_number)` overloads, which made the
+  public `solve` name ambiguous; `solve`/`solve_with_status` with a single `α` is the entry
+  point. The private `_bisect_on`, `_bierlaire_fit` and `_quadratic_search` replace them.
+- `DEFAULT_ARMIJO_τ_ULPS` and `armijo_tolerance` moved from `linesearch/backtracking.jl` to
+  `base/options.jl` so that `bracketing/` can use them, and `armijo_tolerance`'s second argument
+  widened from `::T` to `::Real`. Both are unexported.
 - `assess_convergence` returns a **4-tuple** `(x_converged, f_converged, f_increased, stalled)`.
   Existing `a, b, _ = assess_convergence(…)` destructurings keep working unchanged.
 - `NonlinearSolverStatus` gained the fields `stalls::Int` and `stalled::Bool`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,9 +93,23 @@ better the initial guess is.
   nonlinear iteration; the `Backtracking` ladder, the `StrongWolfe` bracketing and zoom phases
   and `bisection` are bounded by `linesearch_max_iterations`. The default therefore drops from
   1000 to 60 for `Float64` — unobservable, since all of these loops terminate on their own
-  floor long before either bound. (`Quadratic`/`BierlaireQuadratic` keep their own
-  `max_number_of_quadratic_linesearch_iterations`: those are quadratic-*fit* counts, not shrink
-  ladders.)
+  floor long before either bound. `Quadratic` and `BierlaireQuadratic` are bounded by the same
+  field: the (unexported) `max_number_of_quadratic_linesearch_iterations` and the constants
+  `MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH[_SINGLE_PRECISION]` are removed, so their
+  budget is now settable by the user like every other line search's.
+
+  This is the one place where the split *is* observable, and it is an improvement. Their budget
+  rises from 20 to 60 (`Float64`) and from 5 to 31/18 (`Float32`/`Float16`), which lets them
+  resolve the one-dimensional subproblem further. Measured over 300 random starting points on
+  the `exp(x)(x³ − 5x² + 2x) + 2` root-finding fixture, with `BierlaireQuadratic` as the
+  `NewtonSolver` line search, the 95th-percentile distance from the root drops from 1.9e6 to
+  9.7e3 `eps` with a fresh Jacobian and from 6.0e6 to 8.5e4 `eps` with `refactorize = 5`
+  (median 8599 → 1.0 `eps`), and three starting points that used to throw in
+  `triple_point_finder` no longer do. `Quadratic` improves too (95th percentile 9 → 2 and
+  55 → 17 `eps`). The improvement is distributional rather than uniform: a minority of starting
+  points end up slightly further from the root because the outer iteration now meets its
+  convergence test one step earlier, which is why the `BierlaireQuadratic` rows of
+  `test/nonlinear_solver_tests.jl` carry a looser fixture tolerance.
 - **A stagnating solve now stops after `max_stalls` steps instead of running to
   `max_iterations`.** A step is *stalled* when it did not move the iterate while the residual is
   not small — the exact logical complement of the existing `x_converged` gate, so stagnation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,151 @@
 
 All notable changes to SimpleSolvers.jl are documented here.
 
+## [0.9.3]
+
+Robustness release for the `Backtracking` line search. Downstream packages
+(GeometricIntegrators, GeometricProblems, ChargedParticleDynamics) were flooded by
+
+```
+Backtracking line search did not satisfy the sufficient decrease condition within 1000
+iterations. Returning the last trial step α = 2.220446049250313e-16.
+```
+
+— thousands of messages per test run — and could not silence it through the public API.
+
+### The defect
+
+`2.220446049250313e-16 == eps(1.0) == 1.0·0.5^52`, so the ladder always exited via its
+`α ≤ eps` guard after ~53 trials; the "within 1000 iterations" in the message was never
+true, and neither was the implied diagnosis. The sufficient decrease condition
+`φ(α) ≤ φ(0) + c₁·α·φ'(0)` demands a decrease *proportional to* `α` with no round-off
+allowance, so once `c₁·α·|φ'(0)|` falls below one ulp of `φ(0)` — at
+`α* = eps/(4c₁) ≈ 5.55e-13` for the `‖F‖²` merit of a Newton step — the right-hand side
+rounds back up to `φ(0)` and the accept/reject decision is made by *rounding alone*. Two
+failure modes followed:
+
+- when the trial point stopped moving above `α*`, the condition "succeeded" at `α ≈ 2.3e-13`
+  purely because the frozen merit tied a rounded right-hand side. The returned step did not
+  move `x` at all, and **nothing was reported**;
+- otherwise the ladder ran to `α = eps` and emitted the warning above.
+
+Either way the outer iterate froze, the solve spun to `max_iterations`, and a second
+misleading warning (`"Solver took 1000 iterations."`) followed. The underlying user-visible
+cause is an `f_abstol` below the residual's own round-off floor — unsatisfiable, and *not*
+rescued by `f_reltol`, which is anchored at `‖F(x₀)‖` and therefore becomes *tighter* the
+better the initial guess is.
+
+### Added
+
+- `LinesearchStatus`, `LinesearchOutcome` (`LINESEARCH_DECREASED`, `LINESEARCH_FLOOR`,
+  `LINESEARCH_EXHAUSTED`, `LINESEARCH_NO_DESCENT`, `LINESEARCH_STATIONARY`,
+  `LINESEARCH_UNKNOWN`), `solve_with_status`, `issufficient` and `isfloor`. `solve_with_status`
+  returns the step length *plus* why the search stopped, which the step length alone cannot
+  express — a tiny `α` may be the right answer or all that is left after the merit turned out
+  to be irreducible. Only `Backtracking` reports a genuine outcome; a generic fallback returns
+  `LINESEARCH_UNKNOWN` for the other five methods, so the entry point is uniform.
+  `SimpleSolvers.linesearch_warnings` is now the single place a line search emits messages.
+- `Backtracking` gained a `τ_ulps` keyword (default 4): the round-off allowance
+  `τ = τ_ulps·ulp(φ(0))` added to the sufficient decrease condition, from which the smallest
+  *informative* step `αmin = τ/(c₁|φ'(0)|) = 2·τ_ulps·α*` is derived. Because `αmin` is a
+  factor `2·τ_ulps` above `α*`, the search provably never enters the region where the test is
+  decided by rounding. `τ_ulps = 0` recovers the exact condition. New (unexported)
+  `armijo_tolerance`, `backtracking_αmin`, `backtracking_interpolation`, and the constants
+  `DEFAULT_ARMIJO_τ_ULPS` and `BACKTRACKING_SHRINK_MIN`.
+- `SufficientDecreaseCondition` gained a keyword-only `τ` field (default `zero(T)`, i.e. the
+  exact former condition) and a two-argument call form `sdc(α, fα)` taking a merit value the
+  caller already computed, so a backtracking loop no longer evaluates the merit twice per
+  trial. `StrongWolfe` keeps `τ = 0`.
+- `Options` gained `linesearch_max_iterations` (default `linesearch_iterations(T)`: 60 for
+  `Float64`, 31 for `Float32`, 18 for `Float16`) and `max_stalls` (default `MAX_STALLS = 2`).
+- `SimpleSolvers.with_config(ls, config)` returns a `Linesearch` with the problem and method of
+  `ls` but different `Options`.
+- `NonlinearSolverStatus`, `isconverged`, `isstalled` and `status(solver, state)` are exported.
+  `solve!` returns `x`, not a status, so `status(solver, state)` is how a caller inspects the
+  outcome — in particular whether a solve *converged* or merely *stagnated* at the residual
+  floor. (`status` was removed from the exports in 0.9.0 as undefined; this implements it.)
+- `SimpleSolvers.residual_small`, `iterate_settled`, `stalled_step`, `record_stall!`,
+  `flag_stall!` and `stall_number`.
+
+### Changed (behavioural)
+
+- **`Backtracking` no longer decides the sufficient decrease condition by rounding.** It now
+  checks the anchor up front (a non-descent or non-finite `φ'(0)` returns the caller's `α`
+  immediately instead of shrinking 53 times to find out, consistent with `StrongWolfe`; a
+  stationary `φ'(0) = 0` is benign and reported only at `verbosity ≥ 2`), stops at `αmin`
+  rather than `eps`, detects a bit-frozen merit, and shrinks by safeguarded quadratic/cubic
+  interpolation confined to `[0.1α, p·α]` instead of a fixed factor `p`. `Backtracking.p` is
+  therefore now an *upper bound* on the shrink factor, so the trial sequence is pointwise never
+  longer than before. Warnings report the true trial count and the true reason. The
+  round-off-floor and stationary-anchor outcomes are reported only at `verbosity ≥ 2` — both are
+  the *expected* final state of a converged solve, so warning about them at the default
+  verbosity would mean warning about success (measured on GeometricProblems, gating them at
+  `verbosity ≥ 1` newly surfaced one message each on three previously-silent solves). The
+  remaining outcomes are rate-limited with `maxlog`.
+- **A line search now shares its solver's `Options`.** Every solver used to build its
+  `Linesearch` with an `Options` constructed from nothing but defaults, so
+  `NewtonSolver(…; verbosity = 0)` did *not* silence the line search (downstream packages had
+  to swallow the messages with a `NullLogger`) and a user-supplied iteration budget never
+  reached the inner ladder. `config(linesearch(s)) === config(s)` now holds for `NewtonSolver`,
+  `PicardSolver` and `DogLegSolver`, in every constructor arity.
+- **`max_iterations` no longer doubles as the line-search budget.** It bounds only the outer
+  nonlinear iteration; the `Backtracking` ladder, the `StrongWolfe` bracketing and zoom phases
+  and `bisection` are bounded by `linesearch_max_iterations`. The default therefore drops from
+  1000 to 60 for `Float64` — unobservable, since all of these loops terminate on their own
+  floor long before either bound. (`Quadratic`/`BierlaireQuadratic` keep their own
+  `max_number_of_quadratic_linesearch_iterations`: those are quadratic-*fit* counts, not shrink
+  ladders.)
+- **A stagnating solve now stops after `max_stalls` steps instead of running to
+  `max_iterations`.** A step is *stalled* when it did not move the iterate while the residual is
+  not small — the exact logical complement of the existing `x_converged` gate, so stagnation
+  and convergence are mutually exclusive by construction. This is diagnosed from the step
+  actually taken, so it also covers a `Static` step along an underflowed direction, a collapsed
+  `DogLeg` trust-region radius and a locally expanding `Picard` map; a line search that reports
+  `LINESEARCH_FLOOR` additionally flags it one iteration earlier. A counter (rather than a
+  one-shot stop) is used because `maybe_refactorize!` and `DogLegSolver` both deliberately
+  recover on the step *after* a frozen one. `max_stalls = typemax(Int)` restores the old
+  behaviour. The two misleading warnings are replaced by one message naming the achieved
+  residual, the requested tolerance and both remedies.
+- **`solve!` tests the stopping criteria before the first step.** An initial guess that already
+  satisfies them is no longer perturbed by a full solver step (Jacobian, factorization, and a
+  line search asked to improve an already-exact residual). Only the absolute branch is
+  reachable at iteration 0, so this fires exactly when `‖F(x₀)‖ ≤ f_abstol`; with the default
+  `f_abstol = 0` that means an exact root. Two consequences: with `min_iterations = 0` and
+  `f_abstol > 0` an already-satisfying guess now takes **zero** steps instead of one, and
+  `f_abstol_break` can now fire before any step. `min_iterations ≥ 1` is unaffected.
+- The line search no longer re-evaluates the merit at the `α = 0` anchor: `solver_step!` passes
+  the residual the solver has already computed as `params.φ₀`, saving one `F` evaluation per
+  solver step. A caller driving `solver_step!` by hand from a state whose `value` is stale must
+  not supply it.
+- `Base.show(::Backtracking)` includes `τ_ulps`; `Base.show(::NonlinearSolverStatus)` appends a
+  `stalls` line only when it is nonzero, so the printout of a fresh status is unchanged.
+- Passing `linesearch = …` to `PicardSolver`/`DogLegSolver` is still an error, but now raises a
+  `MethodError` rather than an `Options` error.
+
+### Changed (breaking)
+
+- `assess_convergence` returns a **4-tuple** `(x_converged, f_converged, f_increased, stalled)`.
+  Existing `a, b, _ = assess_convergence(…)` destructurings keep working unchanged.
+- `NonlinearSolverStatus` gained the fields `stalls::Int` and `stalled::Bool`;
+  `NonlinearSolverState` gained `stalls::Int` and `stallflag::Bool`. Positional construction of
+  either changes accordingly.
+- `Backtracking` gained a fifth field `τ_ulps::T`. The positional inner constructor defaults
+  it, so `Backtracking{T}(α₀, c₁, c₂, p)` still works.
+
+## [0.9.2]
+
+### Fixed
+
+- `Quadratic`: a `Float16` fix in the quadratic line search.
+
+## [0.9.1]
+
+### Changed (breaking)
+
+- The default line search of `NewtonSolver(x, F, y; …)` is `Backtracking` again, reverting the
+  change to `StrongWolfe` made in 0.9.0. Pass `linesearch=StrongWolfe(T)` to opt in to the
+  strong Wolfe conditions.
+
 ## [0.9.0]
 
 Pre-1.0 breaking release from the 2026-07 code-review remediation. The bulk is bug
@@ -58,6 +203,7 @@ signature are not enumerated here.)
   condition). Pass `linesearch=Backtracking(T)` to restore the previous behavior.
   (`DogLegSolver` is a trust-region method and does not run the stored line search, so
   its default is unaffected; `PicardSolver` takes no line search.)
+  **Reverted in 0.9.1** — the default is `Backtracking` again; see below.
 - `CurvatureCondition`'s `mode` is now a positional `Val{:Standard}()`/`Val{:Strong}()`
   argument (was a runtime `mode::Symbol` keyword) — inference-stable.
 - `DogLegSolver` now uses a carried, ρ-based trust-region radius (N&W Alg. 4.1; new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ better the initial guess is.
   `LINESEARCH_UNKNOWN`), `solve_with_status`, `issufficient` and `isfloor`. `solve_with_status`
   returns the step length *plus* why the search stopped, which the step length alone cannot
   express — a tiny `α` may be the right answer or all that is left after the merit turned out
-  to be irreducible. Only `Backtracking` reports a genuine outcome; a generic fallback returns
-  `LINESEARCH_UNKNOWN` for the other five methods, so the entry point is uniform.
+  to be irreducible. All six built-in methods report a genuine outcome (see the contract section
+  below); the generic `LINESEARCH_UNKNOWN` fallback remains for user-defined methods.
   `SimpleSolvers.linesearch_warnings` is now the single place a line search emits messages.
 - `Backtracking` gained a `τ_ulps` keyword (default 4): the round-off allowance
   `τ = τ_ulps·ulp(φ(0))` added to the sufficient decrease condition, from which the smallest
@@ -101,15 +101,12 @@ better the initial guess is.
   This is the one place where the split *is* observable, and it is an improvement. Their budget
   rises from 20 to 60 (`Float64`) and from 5 to 31/18 (`Float32`/`Float16`), which lets them
   resolve the one-dimensional subproblem further. Measured over 300 random starting points on
-  the `exp(x)(x³ − 5x² + 2x) + 2` root-finding fixture, with `BierlaireQuadratic` as the
-  `NewtonSolver` line search, the 95th-percentile distance from the root drops from 1.9e6 to
-  9.7e3 `eps` with a fresh Jacobian and from 6.0e6 to 8.5e4 `eps` with `refactorize = 5`
-  (median 8599 → 1.0 `eps`), and three starting points that used to throw in
-  `triple_point_finder` no longer do. `Quadratic` improves too (95th percentile 9 → 2 and
-  55 → 17 `eps`). The improvement is distributional rather than uniform: a minority of starting
-  points end up slightly further from the root because the outer iteration now meets its
-  convergence test one step earlier, which is why the `BierlaireQuadratic` rows of
-  `test/nonlinear_solver_tests.jl` carry a looser fixture tolerance.
+  the `exp(x)(x³ − 5x² + 2x) + 2` root-finding fixture with `BierlaireQuadratic` as the
+  `NewtonSolver` line search, the `Float64` 95th-percentile distance from the root drops from
+  1.9e6 to 0.5 `eps` with a fresh Jacobian and from 6.0e6 to 1.6 `eps` with `refactorize = 5`
+  (median 8599 → 0.50). Note that most of that gain comes from fixing the single-point stall
+  described below, not from the budget itself: the intermediate figures (9.7e3 and 8.5e4 `eps`)
+  were solves hitting the raised cap through the stall.
 - **A stagnating solve now stops after `max_stalls` steps instead of running to
   `max_iterations`.** A step is *stalled* when it did not move the iterate while the residual is
   not small — the exact logical complement of the existing `x_converged` gate, so stagnation
@@ -137,8 +134,95 @@ better the initial guess is.
 - Passing `linesearch = …` to `PicardSolver`/`DogLegSolver` is still an error, but now raises a
   `MethodError` rather than an `Options` error.
 
+### The line-search contract (standardised across all six methods)
+
+Investigating a crash in `BierlaireQuadratic` (below) showed the six line searches differing
+along eight independent axes — only some of them principled. Every method reached through
+`solve`/`solve_with_status` now guarantees:
+
+1. **It never throws.** A situation it cannot handle is *reported*, never raised: a line search
+   must not abort the enclosing solve. `triple_point_finder`, `bracket_minimum` and
+   `bracket_minimum_with_fixed_point` return `nothing` instead of calling `error(...)` (four
+   sites), and each method maps that onto a `LinesearchOutcome`.
+2. **It returns `α > 0`.** Never the `α = 0` anchor (which freezes the outer iterate) and never a
+   negative step. `Quadratic` and `Bisection` used to return negative steps — measured at up to
+   `α = -3` for `Bisection`, in 49 of ~3750 calls with `refactorize = 5` — because both inherit a
+   direction flip from `bracket_minimum`. That was emergent rather than designed: `α` scales a
+   direction that has already been chosen, an ascending anchor arises *only* from a stale Jacobian
+   (zero occurrences with `refactorize = 1` over 3727 calls), and the correct response to
+   staleness is to refresh the Jacobian, which `maybe_refactorize!` already does. The flip stays
+   in `bracket_minimum` itself, which is a general-purpose minimum bracketer; only the line-search
+   layer restricts it. Verified: 0 negative steps in ~45 000 calls, down from 49.
+3. **All six implement `solve_with_status`; `solve` is a thin wrapper.** Previously only
+   `Backtracking` did, which meant `solver_step!`'s `isfloor(lsstatus) && flag_stall!(state)` was
+   dead code for five of six methods — stall detection now works whatever line search is chosen.
+   This also collapses six inline warning sites into `linesearch_warnings`, giving one message
+   site and one verbosity policy (`Bisection` warned at `≥ 1` where `BierlaireQuadratic` warned at
+   `≥ 2` for the same class of event).
+4. **A non-finite or ascending anchor is reported, not assumed away** — the new (unexported)
+   `check_anchor` is the single definition of that policy, used by every method. This closes an
+   `AssertionError` in `StrongWolfe`: a `NaN` derivative is not `≥ zero(T)`, so it slipped past
+   the descent check into `SufficientDecreaseCondition`'s `@assert !isnan(d₀)` and aborted the
+   solve. `StrongWolfe` could also return `α = 0` from its zoom phase, despite a comment claiming
+   otherwise.
+5. **Cost is bounded independently of the merit's scale.**
+
+Deliberately *not* standardised: the meaning of the input `α` and what each method guarantees
+about the step, because there are two families — condition-satisfying and `α`-relative
+(`Backtracking`, `StrongWolfe`, `Static`) versus minimising and `α`-independent (`Bisection`,
+`Quadratic`, `BierlaireQuadratic`, which check no Wolfe condition). Documented on
+`LinesearchMethod`.
+
+`LINESEARCH_DECREASED` is documented as "the merit decreased by more than `τ`" rather than
+"satisfies the `SufficientDecreaseCondition`", since the minimising searches never test one.
+
+### Fixed: `BierlaireQuadratic` could abort a solve, or stall until its budget ran out
+
+**The crash.** `triple_point_finder` raised
+`The function f must be decreasing at 0.0` — 3 of 300 random starts — aborting the whole solve.
+Two distinct causes, both measured: an **ascent anchor** (`φ′(0) = +2.06e-15` for `Float64`,
+`+1.10e-02` for `Float32`, both with `refactorize = 5`), because the entry point never checked
+`φ′(0)` while claiming in a comment that the `α = 0` anchor was "guaranteed decreasing"; and a
+**merit flat to round-off** (`φ(δ) − φ(0) = 0` exactly, `Float32`, `refactorize = 1`). The
+response was wrong for both: halving `δ` five times and then erroring. Halving answers an
+*overshoot*; for an ascent direction nothing helps, and for a round-off-limited probe a smaller
+`δ` is strictly less informative. `triple_point_finder` now halves only when the rise exceeds
+`4 eps(f(x₀))`, so a flat merit costs 2 evaluations instead of 12 followed by a throw.
+
+**The stall.** `φ(α) = c·(α−1)²` cost 15 / **70** / 14 merit evaluations at `c` = 1 / 1e-6 /
+1e-12 — a 5× swing from a pure rescaling, with the middle case exhausting its budget. It was
+stuck on a single point, evaluating `α = 0.99999999999999911` thirty-plus times in a row: when
+`χ` lands on `b`, both branch tests are false, so the triple becomes `c ← b` with `b` unchanged,
+the next fit is degenerate, and the `(a+c)/2` fallback plus the anti-stalling shift map back onto
+`b` while `c − a` never shrinks. `shift_χ_to_avoid_stalling` exists to prevent exactly this and
+does not. The fit now bisects the wider sub-interval whenever `χ` coincides with a bracket point,
+making `c − a` contract strictly every iteration. Cost is now 15/16/16/15/15 across merit scales
+`1e-12 … 1e12`, and no `α` is evaluated more than twice.
+
+This was also the cause of the poor accuracy that the previous entry attributed to the raised
+iteration budget: those solves were hitting the cap, not converging poorly. Over 300 random
+starts the `Float64` 95th-percentile distance to the root improves from **9.7e3 to 0.5 `eps`**
+with a fresh Jacobian and from **8.5e4 to 1.6 `eps`** with `refactorize = 5` (median 8599 → 0.50),
+so the `tolfac` on the two `BierlaireQuadratic` fixture rows is back to the 2 `eps` every other
+method meets.
+
+The merit-space comparisons in the `BierlaireQuadratic` termination test now use the shared
+round-off allowance `τ = armijo_tolerance(φ₀, τ_ulps)` instead of `ε`. One absolute constant used
+to govern three incommensurable quantities — a bracket width in `α` and two merit differences.
+This is correctness-neutral (the returned `α` was already scale-invariant, and the `α`-space width
+term is the binding one); it removes a latent hazard rather than fixing observed behaviour.
+
+Internal `solve` overloads that were algorithm steps rather than entry points
+(`solve(ls, a, b, c, params, n)`, `solve(ls, α₀, params, n)`, `solve(ls, α₀, α₁, params)`) are now
+private helpers, so `solve`/`solve_with_status` is unambiguously the public entry point.
+
 ### Changed (breaking)
 
+- `Quadratic` and `Bisection` no longer return negative steps; an ascending anchor is reported as
+  `LINESEARCH_NO_DESCENT` instead. The test that pinned the old behaviour asserted
+  `solve(ls, 0.0) ≈ -1.0`.
+- `triple_point_finder`, `bracket_minimum` and `bracket_minimum_with_fixed_point` return
+  `Union{Nothing,…}`. `bracket_minimum` is exported; the other two are not.
 - `assess_convergence` returns a **4-tuple** `(x_converged, f_converged, f_increased, stalled)`.
   Existing `a, b, _ = assess_convergence(…)` destructurings keep working unchanged.
 - `NonlinearSolverStatus` gained the fields `stalls::Int` and `stalled::Bool`;

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleSolvers"
 uuid = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Michael Kraus"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleSolvers"
 uuid = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Michael Kraus"]
 
 [deps]

--- a/docs/src/SimpleSolvers.bib
+++ b/docs/src/SimpleSolvers.bib
@@ -7,6 +7,15 @@
   note={Second Edition}
 }
 
+@book{dennis1996numerical,
+  title={Numerical methods for unconstrained optimization and nonlinear equations},
+  author={Dennis, John E and Schnabel, Robert B},
+  year={1996},
+  publisher={Society for Industrial and Applied Mathematics},
+  address={Philadelphia, PA},
+  series={Classics in Applied Mathematics}
+}
+
 @book{fletcher1987practical,
   title={Practical methods of optimization},
   author={Fletcher, Roger},

--- a/docs/src/linesearch/backtracking.md
+++ b/docs/src/linesearch/backtracking.md
@@ -113,3 +113,55 @@ c₂ = .9
 cc = CurvatureCondition(c₂, problem.D(0., params), alpha -> problem.D(alpha, params))
 cc(αₜ)
 ```
+
+## Stagnation at the round-off floor
+
+The sufficient decrease condition demands a decrease *proportional to* ``\alpha``:
+
+```math
+\varphi(\alpha) \leq \varphi(0) + c_1\alpha\varphi'(0),
+```
+
+so once ``c_1\alpha|\varphi'(0)|`` drops below one unit in the last place of ``\varphi(0)``,
+the right-hand side rounds back up to ``\varphi(0)`` exactly and the test degenerates to
+``\varphi(\alpha) \leq \varphi(0)``. A merit that has reached its own round-off floor — think
+of ``\|F\|^2`` for a residual that is already pure rounding noise, which is the normal state
+of affairs at the end of a converged solve — then passes or fails that test essentially at
+random. Shrinking ``\alpha`` cannot recover from this: below the round-off scale of ``x`` the
+trial point stops differing from the base point altogether, and ``\varphi(\alpha)`` is
+*bit-identical* to ``\varphi(0)``.
+
+`Backtracking` therefore slackens the condition by an explicit allowance
+``\tau = `` `τ_ulps` ``\cdot\,\mathrm{ulp}(\varphi(0))`` (see
+[`SimpleSolvers.armijo_tolerance`](@ref)) and stops at the smallest step that ``\tau`` can
+still resolve, ``\alpha_\mathrm{min} = \tau/(c_1|\varphi'(0)|)`` (see
+[`SimpleSolvers.backtracking_αmin`](@ref)). Because ``\alpha_\mathrm{min}`` is a factor
+``2\cdot`` `τ_ulps` above the step at which the rounding degeneracy sets in, the search never
+enters that region at all.
+
+The situation is reported rather than hidden. [`solve_with_status`](@ref) returns a
+[`LinesearchStatus`](@ref) whose [`LinesearchOutcome`](@ref) distinguishes a step that
+genuinely decreased the merit (`LINESEARCH_DECREASED`) from one accepted only because nothing
+*can* decrease it (`LINESEARCH_FLOOR`):
+
+```@example floor
+using SimpleSolvers
+using SimpleSolvers: outcome, trials, steplength
+
+# a merit that is pure round-off noise: every α > 0 lands one ulp above φ(0)
+noise = LinesearchProblem{Float64}((α, _) -> α > 0 ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
+ls = Linesearch(noise, Backtracking(); verbosity = 0)
+st = solve_with_status(ls, 1.0)
+(outcome(st), trials(st), steplength(st), st.αmin)
+```
+
+```@example floor
+isfloor(st), issufficient(st)
+```
+
+A `LINESEARCH_FLOOR` outcome is *not* an error: it says that no line search can make progress
+at this point, which is normally a statement about the problem rather than about the search.
+A [`NonlinearSolver`](@ref) treats it as a stalled step (see
+[`SimpleSolvers.stalled_step`](@ref)) and stops after `max_stalls` of them, reporting the
+residual it did achieve against the tolerance that was requested — the usual cause being an
+`f_abstol` below the residual's own round-off floor. See [`Options`](@ref).

--- a/docs/src/linesearch/backtracking.md
+++ b/docs/src/linesearch/backtracking.md
@@ -151,10 +151,17 @@ still searched at all).
 The ``\min`` against ``\varphi(0)`` is what makes those trial steps harmless. Where the
 right-hand side has degenerated, the condition reduces to plain monotonicity
 ``\varphi(\alpha) \leq \varphi(0)``: it can accept a non-increase but never an increase, and such
-an accept is classified `LINESEARCH_FLOOR` rather than reported as a decrease. Without the
-``\min`` the allowance would license a step whose merit is up to ``\tau`` *above* ``\varphi(0)``
-— irrelevant at ``10^{-16}`` relative in double precision, but ``3.9\cdot10^{-3}`` in `Float16`,
-twenty times the ``2c_1`` the condition demands at ``\alpha = 1``.
+an accept is classified `LINESEARCH_FLOOR` rather than reported as a decrease.
+
+`τ_ulps` itself is precision-aware, because ``\tau`` has to be at least an ulp or so of
+``\varphi(0)`` to recognise the floor *and* far below the ``2c_1\varphi(0)`` the condition demands
+at ``\alpha = 1`` to leave that condition meaningful. Those are compatible only while
+``\mathrm{eps}(T) \ll 2c_1``, which is true by ten orders of magnitude in double precision and
+false in `Float16`; [`SimpleSolvers.armijo_ulps`](@ref) caps the nominal 4 ulps accordingly, a
+no-op in `Float64` and `Float32`. Without the cap a `Float16` merit that genuinely decreased by
+two ulps — the smallest that precision can express — was reported as `LINESEARCH_FLOOR`, which a
+[`NonlinearSolver`](@ref) counts towards `max_stalls`, so a converging solve could be reported as
+stagnated.
 
 The situation is reported rather than hidden. [`solve_with_status`](@ref) returns a
 [`LinesearchStatus`](@ref) whose [`LinesearchOutcome`](@ref) distinguishes a step that

--- a/docs/src/linesearch/backtracking.md
+++ b/docs/src/linesearch/backtracking.md
@@ -131,13 +131,30 @@ random. Shrinking ``\alpha`` cannot recover from this: below the round-off scale
 trial point stops differing from the base point altogether, and ``\varphi(\alpha)`` is
 *bit-identical* to ``\varphi(0)``.
 
-`Backtracking` therefore slackens the condition by an explicit allowance
+`Backtracking` therefore takes the round-off resolution of the merit,
 ``\tau = `` `τ_ulps` ``\cdot\,\mathrm{ulp}(\varphi(0))`` (see
-[`SimpleSolvers.armijo_tolerance`](@ref)) and stops at the smallest step that ``\tau`` can
-still resolve, ``\alpha_\mathrm{min} = \tau/(c_1|\varphi'(0)|)`` (see
+[`SimpleSolvers.armijo_tolerance`](@ref)), slackens the condition to
+
+```math
+\varphi(\alpha) \leq \min\{\varphi(0),\ \varphi(0) + c_1\alpha\varphi'(0) + \tau\},
+```
+
+and stops at the smallest step that ``\tau`` can still resolve,
+``\alpha_\mathrm{min} = \tau/(c_1|\varphi'(0)|)`` (see
 [`SimpleSolvers.backtracking_αmin`](@ref)). Because ``\alpha_\mathrm{min}`` is a factor
-``2\cdot`` `τ_ulps` above the step at which the rounding degeneracy sets in, the search never
-enters that region at all.
+``2\cdot`` `τ_ulps` above the step at which the rounding degeneracy sets in, the search stays
+clear of that region — *unless* ``\alpha_\mathrm{min}``'s upper clamp at
+``\sqrt{\mathrm{eps}(T)}`` binds, which it does for a very flat merit in double precision and for
+essentially any merit in `Float16` (the clamp is there so that a nearly flat but genuine merit is
+still searched at all).
+
+The ``\min`` against ``\varphi(0)`` is what makes those trial steps harmless. Where the
+right-hand side has degenerated, the condition reduces to plain monotonicity
+``\varphi(\alpha) \leq \varphi(0)``: it can accept a non-increase but never an increase, and such
+an accept is classified `LINESEARCH_FLOOR` rather than reported as a decrease. Without the
+``\min`` the allowance would license a step whose merit is up to ``\tau`` *above* ``\varphi(0)``
+— irrelevant at ``10^{-16}`` relative in double precision, but ``3.9\cdot10^{-3}`` in `Float16`,
+twenty times the ``2c_1`` the condition demands at ``\alpha = 1``.
 
 The situation is reported rather than hidden. [`solve_with_status`](@ref) returns a
 [`LinesearchStatus`](@ref) whose [`LinesearchOutcome`](@ref) distinguishes a step that
@@ -146,7 +163,7 @@ genuinely decreased the merit (`LINESEARCH_DECREASED`) from one accepted only be
 
 ```@example floor
 using SimpleSolvers
-using SimpleSolvers: outcome, trials, steplength
+using SimpleSolvers: outcome, trials, steplength, issufficient, isfloor
 
 # a merit that is pure round-off noise: every α > 0 lands one ulp above φ(0)
 noise = LinesearchProblem{Float64}((α, _) -> α > 0 ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)

--- a/docs/src/linesearch/quadratic.md
+++ b/docs/src/linesearch/quadratic.md
@@ -106,7 +106,7 @@ p₁ = ∂fˡˢ∂α(0.)
 
 ### Finding ``p_2``
 
-We call [`bracket_minimum_with_fixed_point`](@ref) to find ``\alpha_0.`` For this point we should have ``f^\mathrm{ls}(\alpha_0) > f^\mathrm{ls}(0).``
+We call [`bracket_minimum_with_fixed_point`](@ref) to find ``\alpha_0.`` That routine grows the right end outward until the merit stops decreasing — the *turning point* — rather than until it climbs back above the fixed left anchor, so ``f^\mathrm{ls}(\alpha_0) > f^\mathrm{ls}(0)`` is *not* required (a merit that dips and then only asymptotes back up would never satisfy it). It returns `nothing` if no minimum can be bracketed at all.
 
 ```@example quadratic
 using SimpleSolvers: bracket_minimum_with_fixed_point

--- a/docs/src/linesearch/quadratic_bierlaire.md
+++ b/docs/src/linesearch/quadratic_bierlaire.md
@@ -27,6 +27,16 @@ fˡˢ(alpha) = ls_obj.F(alpha, params)
 nothing # hide
 ```
 
+!!! warning "Requires a decreasing anchor"
+    The three points are produced by [`SimpleSolvers.triple_point_finder`](@ref), which searches
+    *rightward only* and therefore needs the merit to be decreasing at its start. Unlike
+    [`bracket_minimum`](@ref) — used by [`Quadratic`](@ref) and [`Bisection`](@ref) — it cannot
+    recover by flipping direction. `BierlaireQuadratic` therefore validates the ``\alpha = 0``
+    anchor up front with [`SimpleSolvers.check_anchor`](@ref): an ascending or non-finite anchor
+    is *reported* (as `LINESEARCH_NO_DESCENT`) and the caller's step returned, rather than handed
+    to a bracketer that cannot succeed. An ascending anchor is not exotic — it is what a stale
+    Jacobian produces under `refactorize > 1`. See the contract on [`LinesearchMethod`](@ref).
+
 For the Bierlaire quadratic line search we need three points: ``a``, ``b`` and ``c``:
 
 ```@example bierlaire
@@ -61,7 +71,7 @@ nothing # hide
 
 In the figure above we already plotted three points ``a``, ``b`` and ``c`` on whose basis a second-order polynomial will be built that should approximate ``f^\mathrm{ls}``.[^1] The polynomial is built with the ansatz:
 
-[^1]: These points further need to satisfy ``f^\mathrm{ls}(a) > f^\mathrm{ls}(b) < f^\mathrm{ls}(c)``.
+[^1]: These points further need to satisfy ``f^\mathrm{ls}(a) \geq f^\mathrm{ls}(b) < f^\mathrm{ls}(c)``. Note that the left inequality is *non-strict*: while descending, consecutive samples may tie on a plateau, and for a flat-bottomed merit a strict ``f^\mathrm{ls}(a) > f^\mathrm{ls}(b)`` is unattainable. This matches the guarantee documented by [`SimpleSolvers.triple_point_finder`](@ref), which produces the points.
 
 ```math
 p(\alpha) = \beta_1(\alpha - a)(x - b) + \beta_2(\alpha - a) + \beta_3(\alpha - b),
@@ -217,3 +227,13 @@ save("f_ls_bierlaire6_dark.png", fig)
 
 !!! info
     After having computed ``\chi`` we further either shift it to the left or right depending on whether ``(c - b)`` or ``(b - a)`` is bigger respectively. The shift is made by either adding or subtracting the constant ``\varepsilon``.
+
+!!! info "Guaranteed contraction"
+    That shift alone does not guarantee progress. If ``\chi`` coincides with a bracket point the
+    triple update cannot narrow ``[a, c]``: for ``\chi = b`` both branch tests are false (it is
+    the same point, so the merit values are identical), the bracket collapses to ``c = b``, the
+    next fit is degenerate, and the bisection fallback plus the shift map straight back onto
+    ``b`` — an iteration that never contracts and so never satisfies the termination test. The
+    implementation therefore bisects the wider sub-interval whenever ``\chi`` lands on ``a``,
+    ``b`` or ``c``, which makes ``c - a`` decrease strictly every iteration and bounds the search
+    at ``O(\log_2((c-a)/\varepsilon))`` steps regardless of the merit's magnitude.

--- a/src/SimpleSolvers.jl
+++ b/src/SimpleSolvers.jl
@@ -89,7 +89,11 @@ export Backtracking,
     Static,
     StrongWolfe
 
-export LinesearchStatus, LinesearchOutcome, solve_with_status, issufficient, isfloor
+# Types and enum values are exported; the predicates and accessors that go with them
+# (`steplength`, `outcome`, `trials`, `issufficient`, `isfloor`) are not, because they are
+# generic names that a package doing `using SimpleSolvers` may well want for itself. Reach them
+# as `SimpleSolvers.steplength` and friends.
+export LinesearchStatus, LinesearchOutcome, solve_with_status
 export LINESEARCH_DECREASED,
     LINESEARCH_FLOOR,
     LINESEARCH_EXHAUSTED,
@@ -112,7 +116,10 @@ include("linesearch/wolfe.jl")
 export NonlinearProblem, NonlinearSolver, NonlinearSolverException, NonlinearSolverState,
     NewtonSolver, assess_convergence
 
-export NonlinearSolverStatus, isconverged, isstalled, status
+# As above: the type is exported, `isconverged`/`isstalled`/`status` are not. `status` in
+# particular would be hostile to export — a downstream package that does `using SimpleSolvers`
+# and defines its own `status` gets a method-definition error, not a shadowing warning.
+export NonlinearSolverStatus
 
 export PicardSolver
 

--- a/src/SimpleSolvers.jl
+++ b/src/SimpleSolvers.jl
@@ -89,7 +89,16 @@ export Backtracking,
     Static,
     StrongWolfe
 
+export LinesearchStatus, LinesearchOutcome, solve_with_status, issufficient, isfloor
+export LINESEARCH_DECREASED,
+    LINESEARCH_FLOOR,
+    LINESEARCH_EXHAUSTED,
+    LINESEARCH_NO_DESCENT,
+    LINESEARCH_STATIONARY,
+    LINESEARCH_UNKNOWN
+
 include("linesearch/linesearch.jl")
+include("linesearch/linesearch_status.jl")
 include("linesearch/backtracking_condition.jl")
 include("linesearch/curvature_condition.jl")
 include("linesearch/sufficient_decrease_condition.jl")
@@ -102,6 +111,8 @@ include("linesearch/wolfe.jl")
 
 export NonlinearProblem, NonlinearSolver, NonlinearSolverException, NonlinearSolverState,
     NewtonSolver, assess_convergence
+
+export NonlinearSolverStatus, isconverged, isstalled, status
 
 export PicardSolver
 

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -75,19 +75,20 @@ end
 @doc raw"""
     const DEFAULT_ARMIJO_τ_ULPS
 
-The number of units in the last place (ulps) of ``\varphi(0)`` taken as the round-off
+The *nominal* number of units in the last place (ulps) of ``\varphi(0)`` taken as the round-off
 resolution ``\tau`` of a merit function, i.e.
 ``\tau = \mathrm{DEFAULT\_ARMIJO\_τ\_ULPS}\cdot\mathrm{ulp}(\varphi(0))``
 (see [`armijo_tolerance`](@ref)). Its value is """ * """$(DEFAULT_ARMIJO_τ_ULPS)""" * raw""".
+
+Use [`armijo_ulps`](@ref) rather than this constant: it caps the nominal value at what the
+element type can actually support, which matters in `Float16`.
 
 ``\tau`` is used for three things, and it is worth keeping them apart:
 
 1. it slackens the [`SufficientDecreaseCondition`](@ref) inside [`Backtracking`](@ref) to
    ``\varphi(\alpha) \leq \min\{\varphi(0),\ \varphi(0) + c_1\alpha\varphi'(0) + \tau\}``.
    The ``\min`` is what keeps the allowance honest: it may reduce the decrease *demanded*, but
-   it can never license a step whose merit *exceeds* ``\varphi(0)``. Without it the condition
-   would accept an increase of up to ``\tau``, which is negligible in double precision but
-   larger than the demanded ``2c_1\varphi(0)`` in `Float16`;
+   it can never license a step whose merit *exceeds* ``\varphi(0)``;
 2. it fixes the smallest *informative* trial step ``\alpha_\mathrm{min}`` below which the
    condition could only be decided by rounding (see [`backtracking_αmin`](@ref));
 3. every [`LinesearchMethod`](@ref) uses it to decide whether an accepted step's decrease was
@@ -99,11 +100,77 @@ Set `τ_ulps = 0` in [`Backtracking`](@ref) to recover the exact condition for (
 const DEFAULT_ARMIJO_τ_ULPS = 4
 
 @doc raw"""
+    const ARMIJO_τ_DEMAND_FRACTION
+
+The largest fraction of the *demanded* decrease that the round-off resolution ``\tau`` is
+allowed to amount to, used by [`armijo_ulps`](@ref) to cap ``\tau`` in low precision. Its value
+is """ * """$(ARMIJO_τ_DEMAND_FRACTION)""" * raw""", i.e. ``\tau`` may distort the
+[`SufficientDecreaseCondition`](@ref) by at most one percent.
+"""
+const ARMIJO_τ_DEMAND_FRACTION = 0.01
+
+@doc raw"""
+    armijo_ulps(T, c₁)
+    armijo_ulps(T)
+
+The number of ulps of ``\varphi(0)`` to use as the round-off resolution ``\tau`` for element
+type `T`: the nominal [`DEFAULT_ARMIJO_τ_ULPS`](@ref), capped at what `T` can support. The
+one-argument form uses [`DEFAULT_WOLFE_c₁`](@ref).
+
+``\tau`` has to satisfy two requirements that pull in opposite directions. To recognise a merit
+sitting at its round-off floor it must be *at least* an ulp or so of ``\varphi(0)``. To leave the
+[`SufficientDecreaseCondition`](@ref) meaningful it must be *far below* the decrease that
+condition demands, which for the canonical ``\|F\|^2`` merit of a Newton step
+(``\varphi'(0) = -2\varphi(0)``) is ``2c_1\varphi(0)`` at ``\alpha = 1``. Hence the cap
+
+```math
+n \leq \frac{\mathtt{ARMIJO\_τ\_DEMAND\_FRACTION}\cdot 2c_1}{\mathrm{eps}(T)} .
+```
+
+The two requirements are compatible only while ``\mathrm{eps}(T) \ll 2c_1``. They are, by a wide
+margin, in double precision (the cap is ``\sim10^{10}``) and comfortably in single (``\sim17``),
+so the nominal 4 stands in both. They are *not* in `Float16`, where ``\mathrm{eps}(T) = 9.8
+\cdot 10^{-4}`` already exceeds ``2c_1 = 2\cdot10^{-4}``: no value of `τ_ulps` above zero can
+satisfy both, so the cap resolves the conflict in favour of a meaningful condition and drops
+``\tau`` to about ``2\cdot10^{-3}`` ulps — in effect the exact condition.
+
+Nothing is lost by that. The floor is still detected, by two mechanisms that do not depend on
+``\tau``: at a trial step small enough that ``\mathrm{fl}(\varphi(0) + c_1\alpha\varphi'(0))``
+rounds back to ``\varphi(0)`` the condition *is* ``\varphi(\alpha) \leq \varphi(0)``, and
+[`Backtracking`](@ref) additionally stops on two consecutive bit-identical merits. What is gained
+is that a genuine decrease of one or two ulps — the smallest a `Float16` merit can express — is
+reported as `LINESEARCH_DECREASED` instead of as `LINESEARCH_FLOOR`, which the outer iteration
+would otherwise count towards `max_stalls`.
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers: armijo_ulps)
+julia> armijo_ulps(Float64), armijo_ulps(Float32)
+(4.0, 4.0f0)
+```
+
+```jldoctest; setup = :(using SimpleSolvers: armijo_ulps)
+julia> armijo_ulps(Float16)
+Float16(0.002075)
+```
+"""
+function armijo_ulps(::Type{T}, c₁) where {T<:AbstractFloat}
+    # the decrease demanded at α = 1, relative to φ(0), for φ'(0) = -2φ(0)
+    demanded = 2 * T(c₁)
+    min(T(DEFAULT_ARMIJO_τ_ULPS), T(ARMIJO_τ_DEMAND_FRACTION) * demanded / eps(T))
+end
+
+# `DEFAULT_WOLFE_c₁` is defined with the other Wolfe constants in `linesearch/backtracking.jl`,
+# which is included after this file; the reference is resolved at call time, not here.
+armijo_ulps(::Type{T}) where {T<:AbstractFloat} = armijo_ulps(T, T(DEFAULT_WOLFE_c₁))
+
+@doc raw"""
     armijo_tolerance(φ₀, n)
 
 The absolute round-off resolution ``\tau = n\cdot\mathrm{ulp}(\varphi_0)`` of a merit function,
-where `n` is a number of units in the last place. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref) for what
-it is used for and [`backtracking_αmin`](@ref) for the step length derived from it.
+where `n` is a number of units in the last place — [`armijo_ulps`](@ref) for the default.
+See [`DEFAULT_ARMIJO_τ_ULPS`](@ref) for what it is used for and [`backtracking_αmin`](@ref) for
+the step length derived from it.
 
 This lives here rather than next to [`Backtracking`](@ref) because
 [`triple_point_finder`](@ref) needs it too, and `bracketing/` is included before

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -87,9 +87,10 @@ double precision, 24 in single), and a [`bisection`](@ref) needs the same count 
 mantissa. We take that count plus a small margin; everything beyond it can only produce
 denormals.
 
-Note that [`Quadratic`](@ref) and [`BierlaireQuadratic`](@ref) are *not* bounded by this: they
-fit a quadratic rather than shrink a step, and keep their own
-`max_number_of_quadratic_linesearch_iterations`.
+[`Quadratic`](@ref) and [`BierlaireQuadratic`](@ref) are bounded by the same field even though
+they fit a quadratic rather than shrink a step: they converge on their own `ε` tolerance long
+before the budget, which serves only as a backstop, so there is no reason for them to carry a
+separate knob.
 
 Compare this to [`default_tolerance`](@ref) and [`absolute_tolerance`](@ref).
 
@@ -201,8 +202,9 @@ linesearch_max_iterations = 60
     `max_iterations` bounds the **outer** nonlinear iteration (see
     [`meets_stopping_criteria`](@ref)); `linesearch_max_iterations` bounds the **inner**,
     one-dimensional line search taken within a single solver step — the
-    [`Backtracking`](@ref) ladder, the [`StrongWolfe`](@ref) bracketing and zoom phases, and
-    [`bisection`](@ref). These used to be the same field, which meant that capping the solver
+    [`Backtracking`](@ref) ladder, the [`StrongWolfe`](@ref) bracketing and zoom phases,
+    [`bisection`](@ref), and the [`Quadratic`](@ref)/[`BierlaireQuadratic`](@ref) fits. These
+    used to be the same field, which meant that capping the solver
     at `max_iterations = 50` silently also capped the ladder, and that the default of 1000 was
     applied to a ladder which can never need more than ``\\lceil-\\log_2\\varepsilon\\rceil``
     trials. See [`linesearch_iterations`](@ref).

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -73,6 +73,45 @@ function minimum_decrease_threshold(::Type{T}) where {T<:AbstractFloat}
 end
 
 @doc raw"""
+    const DEFAULT_ARMIJO_τ_ULPS
+
+The number of units in the last place (ulps) of ``\varphi(0)`` taken as the round-off
+resolution ``\tau`` of a merit function, i.e.
+``\tau = \mathrm{DEFAULT\_ARMIJO\_τ\_ULPS}\cdot\mathrm{ulp}(\varphi(0))``
+(see [`armijo_tolerance`](@ref)). Its value is """ * """$(DEFAULT_ARMIJO_τ_ULPS)""" * raw""".
+
+``\tau`` is used for three things, and it is worth keeping them apart:
+
+1. it slackens the [`SufficientDecreaseCondition`](@ref) inside [`Backtracking`](@ref) to
+   ``\varphi(\alpha) \leq \min\{\varphi(0),\ \varphi(0) + c_1\alpha\varphi'(0) + \tau\}``.
+   The ``\min`` is what keeps the allowance honest: it may reduce the decrease *demanded*, but
+   it can never license a step whose merit *exceeds* ``\varphi(0)``. Without it the condition
+   would accept an increase of up to ``\tau``, which is negligible in double precision but
+   larger than the demanded ``2c_1\varphi(0)`` in `Float16`;
+2. it fixes the smallest *informative* trial step ``\alpha_\mathrm{min}`` below which the
+   condition could only be decided by rounding (see [`backtracking_αmin`](@ref));
+3. every [`LinesearchMethod`](@ref) uses it to decide whether an accepted step's decrease was
+   genuine (`LINESEARCH_DECREASED`) or within the noise (`LINESEARCH_FLOOR`, see
+   [`LinesearchOutcome`](@ref)).
+
+Set `τ_ulps = 0` in [`Backtracking`](@ref) to recover the exact condition for (1) and (2).
+"""
+const DEFAULT_ARMIJO_τ_ULPS = 4
+
+@doc raw"""
+    armijo_tolerance(φ₀, n)
+
+The absolute round-off resolution ``\tau = n\cdot\mathrm{ulp}(\varphi_0)`` of a merit function,
+where `n` is a number of units in the last place. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref) for what
+it is used for and [`backtracking_αmin`](@ref) for the step length derived from it.
+
+This lives here rather than next to [`Backtracking`](@ref) because
+[`triple_point_finder`](@ref) needs it too, and `bracketing/` is included before
+`linesearch/`.
+"""
+armijo_tolerance(φ₀::T, n::Real) where {T} = T(n) * eps(φ₀)
+
+@doc raw"""
     linesearch_iterations(T)
 
 Determine the default number of trial steps a line search may take, i.e. the default of the
@@ -86,6 +125,12 @@ reaches the negligible-step floor after ``\lceil-\log_2\varepsilon\rceil`` halvi
 double precision, 24 in single), and a [`bisection`](@ref) needs the same count to exhaust the
 mantissa. We take that count plus a small margin; everything beyond it can only produce
 denormals.
+
+The count is derived for the default shrink factor ``p = 0.5``. A [`Backtracking`](@ref) built
+with a `p` close to 1 needs more trials in principle, though in the case that matters — a merit
+frozen at its round-off floor — the safeguarded interpolation shrinks by about a half per trial
+regardless of `p`, because the quadratic model through a frozen value has its minimiser at
+``\alpha/2``.
 
 [`Quadratic`](@ref) and [`BierlaireQuadratic`](@ref) are bounded by the same field even though
 they fit a quadratic rather than shrink a step: they converge on their own `ε` tolerance long
@@ -133,10 +178,13 @@ gives up; the default of the `max_stalls` field of [`Options`](@ref). Its value 
 
 A step is stalled when it does not move the iterate while the residual is not small (see
 [`stalled_step`](@ref)), i.e. when the merit ``\|F\|^2`` cannot be reduced along the current
-direction. One stalled step is not conclusive: a quasi-Newton solver refreshes its
-[`Jacobian`](@ref) on a later step (see [`maybe_refactorize!`](@ref)) and the
-[`DogLegSolver`](@ref) resets a collapsed trust-region radius on the step *after* a rejected
-one, so both can still make progress after a frozen step. Two in a row are conclusive.
+direction. One stalled step is not conclusive, because the *next* step is guaranteed to be
+attempted under better conditions: a stall forces a fresh [`Jacobian`](@ref) immediately (see
+[`maybe_refactorize!`](@ref) and [`needs_refresh`](@ref)) rather than waiting for the next
+`refactorize` multiple, and the [`DogLegSolver`](@ref) additionally resets a collapsed
+trust-region radius. A second consecutive stall is therefore one that a freshly evaluated
+Jacobian did *not* fix, which is conclusive — and it is conclusive for every `refactorize`,
+not just `refactorize = 1`.
 
 Set `max_stalls = typemax(Int)` to restore the previous behaviour of running all the way to
 `max_iterations`.

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -72,6 +72,43 @@ function minimum_decrease_threshold(::Type{T}) where {T<:AbstractFloat}
     T(10)^-4
 end
 
+@doc raw"""
+    linesearch_iterations(T)
+
+Determine the default number of trial steps a line search may take, i.e. the default of the
+`linesearch_max_iterations` field of [`Options`](@ref).
+
+This is deliberately *not* the same quantity as `max_iterations`, which bounds the outer
+nonlinear iteration (see [`meets_stopping_criteria`](@ref)). A one-dimensional search *inside
+a single solver step* needs a budget on the order of the mantissa width, not thousands of
+trials: a [`Backtracking`](@ref) ladder ``\alpha \gets p\alpha`` starting at ``\alpha_0 = 1``
+reaches the negligible-step floor after ``\lceil-\log_2\varepsilon\rceil`` halvings (52 in
+double precision, 24 in single), and a [`bisection`](@ref) needs the same count to exhaust the
+mantissa. We take that count plus a small margin; everything beyond it can only produce
+denormals.
+
+Note that [`Quadratic`](@ref) and [`BierlaireQuadratic`](@ref) are *not* bounded by this: they
+fit a quadratic rather than shrink a step, and keep their own
+`max_number_of_quadratic_linesearch_iterations`.
+
+Compare this to [`default_tolerance`](@ref) and [`absolute_tolerance`](@ref).
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers: linesearch_iterations)
+julia> linesearch_iterations(Float64)
+60
+```
+
+```jldoctest; setup = :(using SimpleSolvers: linesearch_iterations)
+julia> linesearch_iterations(Float32)
+31
+```
+"""
+function linesearch_iterations(::Type{T}) where {T<:AbstractFloat}
+    ceil(Int, -log2(eps(T))) + 8
+end
+
 const ALLOW_F_INCREASES::Bool = true
 const MIN_ITERATIONS::Int = 0
 const MAX_ITERATIONS::Int = 1_000
@@ -85,6 +122,25 @@ const VERBOSITY::Int = 1
 const NAN_MAX_ITERATIONS = 10
 const NAN_FACTOR = 0.5
 const REGULARIZATION_FACTOR = 0
+
+@doc raw"""
+    const MAX_STALLS
+
+The default number of *consecutive* stalled steps after which a [`NonlinearSolver`](@ref)
+gives up; the default of the `max_stalls` field of [`Options`](@ref). Its value is """ *
+                     """$(MAX_STALLS)""" * raw""".
+
+A step is stalled when it does not move the iterate while the residual is not small (see
+[`stalled_step`](@ref)), i.e. when the merit ``\|F\|^2`` cannot be reduced along the current
+direction. One stalled step is not conclusive: a quasi-Newton solver refreshes its
+[`Jacobian`](@ref) on a later step (see [`maybe_refactorize!`](@ref)) and the
+[`DogLegSolver`](@ref) resets a collapsed trust-region radius on the step *after* a rejected
+one, so both can still make progress after a frozen step. Two in a row are conclusive.
+
+Set `max_stalls = typemax(Int)` to restore the previous behaviour of running all the way to
+`max_iterations`.
+"""
+const MAX_STALLS::Int = 2
 
 """
     Options
@@ -108,6 +164,8 @@ Options()
           min_iterations = 0
           max_iterations = 1000
          warn_iterations = 1000
+linesearch_max_iterations = 60
+              max_stalls = 2
               show_trace = false
              store_trace = false
           extended_trace = false
@@ -139,6 +197,33 @@ Options()
     [`DOGLEG_Δ_INITIAL`](@ref), [`DOGLEG_Δ_SHRINK`](@ref), [`DOGLEG_Δ_EXPAND`](@ref) and
     [`DOGLEG_Δ_MAX`](@ref), and are ignored by the other solvers.
 
+!!! info "`max_iterations` versus `linesearch_max_iterations`"
+    `max_iterations` bounds the **outer** nonlinear iteration (see
+    [`meets_stopping_criteria`](@ref)); `linesearch_max_iterations` bounds the **inner**,
+    one-dimensional line search taken within a single solver step — the
+    [`Backtracking`](@ref) ladder, the [`StrongWolfe`](@ref) bracketing and zoom phases, and
+    [`bisection`](@ref). These used to be the same field, which meant that capping the solver
+    at `max_iterations = 50` silently also capped the ladder, and that the default of 1000 was
+    applied to a ladder which can never need more than ``\\lceil-\\log_2\\varepsilon\\rceil``
+    trials. See [`linesearch_iterations`](@ref).
+
+!!! warning "Choosing `f_abstol`"
+    `f_abstol` is an *absolute* target for ``\\|F(x)\\|``, and the default `0` (see
+    [`absolute_tolerance`](@ref)) is never met by a nonzero residual: the absolute branch of
+    [`assess_convergence`](@ref) is switched *off* by default and convergence is decided
+    entirely by the relative (`f_reltol`) and successive (`x_suctol`, `f_suctol`) branches.
+
+    Conversely, an `f_abstol` **below the round-off floor of your own residual** — the
+    cancellation level of the terms `F` sums internally, which the solver cannot see — is
+    *unsatisfiable*. The iteration then reaches that floor, stops making progress, and is
+    reported as stagnated (see `max_stalls`, [`stalled_step`](@ref) and
+    [`nonlinear_solver_warnings`](@ref)) rather than converged.
+
+    Note that `f_reltol` does **not** rescue this case: the relative gate is anchored at the
+    *initial* residual ``\\|F(x_0)\\|``, so an excellent initial guess makes it *tighter*, not
+    looser. If the stagnation warning reports an achieved `rfₐ` near your `f_abstol`, raise
+    `f_abstol` above it — an order of magnitude of headroom is usual.
+
 !!! info
     Also see [`meets_stopping_criteria`](@ref).
 """
@@ -155,6 +240,8 @@ struct Options{T}
     min_iterations::Int
     max_iterations::Int
     warn_iterations::Int
+    linesearch_max_iterations::Int
+    max_stalls::Int
     show_trace::Bool
     store_trace::Bool
     extended_trace::Bool
@@ -182,6 +269,8 @@ function Options(T=Float64;
     min_iterations::Integer=MIN_ITERATIONS,
     max_iterations::Integer=MAX_ITERATIONS,
     warn_iterations::Integer=WARN_ITERATIONS,
+    linesearch_max_iterations::Integer=linesearch_iterations(T),
+    max_stalls::Integer=MAX_STALLS,
     show_trace::Bool=SHOW_TRACE,
     store_trace::Bool=STORE_TRACE,
     extended_trace::Bool=EXTENDED_TRACE,
@@ -210,6 +299,8 @@ function Options(T=Float64;
         min_iterations,
         max_iterations,
         warn_iterations,
+        linesearch_max_iterations,
+        max_stalls,
         show_trace,
         store_trace,
         extended_trace,
@@ -245,3 +336,20 @@ f_suctol(o::Options) = o.f_suctol
 f_mindec(o::Options) = o.f_mindec
 
 verbosity(o::Options) = o.verbosity
+
+"""
+    linesearch_max_iterations(o::Options)
+
+The maximum number of trial steps a line search may take within a single solver step. See
+[`linesearch_iterations`](@ref); *not* to be confused with `max_iterations`, which bounds the
+outer nonlinear iteration.
+"""
+linesearch_max_iterations(o::Options) = o.linesearch_max_iterations
+
+"""
+    max_stalls(o::Options)
+
+The number of consecutive stalled steps after which a [`NonlinearSolver`](@ref) gives up. See
+[`MAX_STALLS`](@ref) and [`stalled_step`](@ref).
+"""
+max_stalls(o::Options) = o.max_stalls

--- a/src/bracketing/bracket_minimum.jl
+++ b/src/bracketing/bracket_minimum.jl
@@ -86,6 +86,10 @@ just to the *left* of `a` (at `a - s`). This early exit is only valid for the
 [`BracketRootCriterion`](@ref), where it corresponds to a sign change in
 `(a - s, b)`. For the [`BracketMinimumCriterion`](@ref) it would instead bracket a
 maximum rather than a minimum, so it is deliberately skipped.
+
+Returns `nothing` when no bracket is found within `nmax` steps. A line search must be able to
+report an unbracketable merit rather than abort the enclosing solve, so this is a `nothing`
+rather than an error; see [`bracket_minimum`](@ref).
 """
 function bracket(f::Callable, x::T, bc::BracketingCriterion, s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
     a = x
@@ -109,7 +113,7 @@ function bracket(f::Callable, x::T, bc::BracketingCriterion, s::T=T(DEFAULT_BRAC
         yb = yc
         s *= k
     end
-    error("Unable to bracket f starting at x = $x.")
+    nothing
 end
 
 @doc raw"""
@@ -158,8 +162,13 @@ b \gets & c, \\
 s \gets & sk,
 \end{aligned}
 ```
-and the algorithm is continued. If we have not found a sign change after ``n_\mathrm{max}`` iterations (see [`DEFAULT_BRACKETING_nmax`](@ref)) the algorithm is terminated and returns an error.
+and the algorithm is continued. If we have not found a bracket after ``n_\mathrm{max}`` iterations (see [`DEFAULT_BRACKETING_nmax`](@ref)) the algorithm terminates and returns `nothing`.
 The interval that is returned by `bracket_minimum` is then typically used as a starting point for [`bisection`](@ref).
+
+!!! warning "Returns `nothing` on failure"
+    A line search must be able to *report* a merit it cannot bracket rather than abort the
+    enclosing solve, so an unbracketable `f` yields `nothing` rather than an error. Callers must
+    handle it — see [`solve_with_status`](@ref) and [`LinesearchOutcome`](@ref).
 
 !!! info
     The function [`bracket_root`](@ref) is equivalent to `bracket_minimum` with the only difference that the criterion we check for is:
@@ -221,6 +230,9 @@ Returns the bracket *together with the function values at its endpoints*,
 `(a, b, f(a), f(b))` with `a < b`.  The values are already computed during
 bracketing, so the caller (the [`Quadratic`](@ref) line search) does not have
 to re-evaluate `f` at the endpoints.
+
+Returns `nothing` if no bracket is found within `nmax` steps — a line search must be able to
+report an unbracketable merit rather than abort the enclosing solve.
 """
 function bracket_minimum_with_fixed_point(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
     a = x
@@ -257,7 +269,7 @@ function bracket_minimum_with_fixed_point(f::Callable, x::T, s::T, k::T=T(DEFAUL
         s *= k
     end
 
-    error("Unable to bracket f starting at x = $x.")
+    nothing
 end
 
 function bracket_minimum_with_fixed_point(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}

--- a/src/bracketing/triple_point_finder.jl
+++ b/src/bracketing/triple_point_finder.jl
@@ -3,7 +3,7 @@ const MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS = 5
 """
     triple_point_finder(f, x)
 
-Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)` and `f(c) > f(b)`, so that a minimum is bracketed in `(a, c)`. This is used for performing a quadratic line search (see [`BierlaireQuadratic`](@ref)). Returns `nothing` when no such triple exists — see the warning below.
+Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)` and `f(c) > f(b)`, so that a minimum is bracketed in `(a, c)`. This is used for performing a quadratic line search (see [`BierlaireQuadratic`](@ref)). Returns a `Symbol` instead of a triple when no such triple exists — see the warning below.
 
 !!! note
     The left inequality is *non-strict* (`f(a) ≥ f(b)`): while descending, consecutive
@@ -12,17 +12,24 @@ Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)
     guards a degenerate (collinear) fit by falling back to a bisection step, so the
     non-strict left bound is sufficient to bracket the minimum.
 
-!!! warning "Searches rightward only, and returns `nothing` on failure"
+!!! warning "Searches rightward only, and reports failure as a `Symbol`"
     Unlike [`bracket_minimum`](@ref), which *flips* direction when `f` increases to the right,
     `triple_point_finder` only ever searches in the direction of increasing `x` and therefore
     requires `f` to be decreasing at `x₀`. A caller that cannot guarantee that — a line search
     whose direction came from a stale or regularized [`Jacobian`](@ref), say — must check the
     anchor itself (see [`check_anchor`](@ref)).
 
-    When no triple can be found the function returns `nothing` rather than raising: a line
+    When no triple can be found the function returns a `Symbol` rather than raising: a line
     search must be able to *report* an unbracketable merit rather than abort the enclosing
-    solve. Two situations produce it — `f` is not decreasing at `x₀` even after `δ` has been
-    reduced, or `nmax` doublings did not reach a turning point.
+    solve. The two failures mean opposite things and are therefore distinguished, because a
+    caller that conflates them reports a *descending* merit as stagnation:
+
+    - `:flat` — the rise at the first probe is within the round-off resolution of `f(x₀)`
+      ([`armijo_tolerance`](@ref)), so `f` does not resolve a decrease here at all. No line
+      search can improve on this point (`LINESEARCH_FLOOR`).
+    - `:unbracketable` — there *is* a decrease, but it cannot be bracketed: either `nmax`
+      doublings never reached a turning point, or `f` rose at every probe down to the smallest
+      `δ` tried. This is a genuine failure to report (`LINESEARCH_EXHAUSTED`), not a floor.
 
 # Implementation
 
@@ -58,13 +65,9 @@ function triple_point_finder(f::Callable, x₀::T, δ::T, nmax::Integer=DEFAULT_
         # stepped past a nearby minimum, so a shorter probe lands on the descending side. It is
         # the wrong answer when the rise is within round-off of `f(x₀)`: the merit then simply
         # does not resolve a decrease here, and a *smaller* δ is strictly less informative, so
-        # the remaining halvings are wasted evaluations that end in the same failure. The
-        # allowance matches `armijo_tolerance(fx₀, DEFAULT_ARMIJO_τ_ULPS)`, which is defined in
-        # `src/linesearch/backtracking.jl` and so cannot be called from here without inverting
-        # the `bracketing` → `linesearch` include order.
-        τ = 4 * eps(fx₀)
-        fx₁ ≤ fx₀ + τ && return nothing
-        adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return nothing
+        # the remaining halvings are wasted evaluations that end in the same failure.
+        fx₁ ≤ fx₀ + armijo_tolerance(fx₀, DEFAULT_ARMIJO_τ_ULPS) && return :flat
+        adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return :unbracketable
         return triple_point_finder(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1)
     end
 
@@ -87,7 +90,10 @@ function triple_point_finder(f::Callable, x₀::T, δ::T, nmax::Integer=DEFAULT_
         end
     end
 
-    nothing
+    # `nmax` doublings without a turning point: the merit is still descending at
+    # `x₀ + δ(2^(nmax+1) - 1)`. That is the opposite of `:flat` — there is a decrease here, it
+    # just cannot be bracketed — so the caller must not report it as a round-off floor.
+    :unbracketable
 end
 
 function triple_point_finder(f::Callable, x₀::T; δ::T=T(DEFAULT_BRACKETING_s), nmax::Integer=DEFAULT_BRACKETING_nmax, adjust_constant_iteration::Integer=1) where {T}

--- a/src/bracketing/triple_point_finder.jl
+++ b/src/bracketing/triple_point_finder.jl
@@ -3,7 +3,7 @@ const MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS = 5
 """
     triple_point_finder(f, x)
 
-Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)` and `f(c) > f(b)`, so that a minimum is bracketed in `(a, c)`. This is used for performing a quadratic line search (see [`BierlaireQuadratic`](@ref)).
+Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)` and `f(c) > f(b)`, so that a minimum is bracketed in `(a, c)`. This is used for performing a quadratic line search (see [`BierlaireQuadratic`](@ref)). Returns `nothing` when no such triple exists — see the warning below.
 
 !!! note
     The left inequality is *non-strict* (`f(a) ≥ f(b)`): while descending, consecutive
@@ -11,6 +11,18 @@ Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)
     is unattainable. `f(b)` is still strictly below `f(c)`, and `BierlaireQuadratic`
     guards a degenerate (collinear) fit by falling back to a bisection step, so the
     non-strict left bound is sufficient to bracket the minimum.
+
+!!! warning "Searches rightward only, and returns `nothing` on failure"
+    Unlike [`bracket_minimum`](@ref), which *flips* direction when `f` increases to the right,
+    `triple_point_finder` only ever searches in the direction of increasing `x` and therefore
+    requires `f` to be decreasing at `x₀`. A caller that cannot guarantee that — a line search
+    whose direction came from a stale or regularized [`Jacobian`](@ref), say — must check the
+    anchor itself (see [`check_anchor`](@ref)).
+
+    When no triple can be found the function returns `nothing` rather than raising: a line
+    search must be able to *report* an unbracketable merit rather than abort the enclosing
+    solve. Two situations produce it — `f` is not decreasing at `x₀` even after `δ` has been
+    reduced, or `nmax` doublings did not reach a turning point.
 
 # Implementation
 
@@ -42,9 +54,17 @@ function triple_point_finder(f::Callable, x₀::T, δ::T, nmax::Integer=DEFAULT_
     fx₁ = f(x₁)
 
     if fx₁ ≥ fx₀
-        if adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS
-            error("The function `f` must be decreasing at `$(x₀)`; `f($(x₁)) = $(fx₁)` must be smaller than `f($(x₀)) = $(fx₀)`.")
-        end
+        # Halving δ is the right answer to an *overshoot* — the merit rose because the probe
+        # stepped past a nearby minimum, so a shorter probe lands on the descending side. It is
+        # the wrong answer when the rise is within round-off of `f(x₀)`: the merit then simply
+        # does not resolve a decrease here, and a *smaller* δ is strictly less informative, so
+        # the remaining halvings are wasted evaluations that end in the same failure. The
+        # allowance matches `armijo_tolerance(fx₀, DEFAULT_ARMIJO_τ_ULPS)`, which is defined in
+        # `src/linesearch/backtracking.jl` and so cannot be called from here without inverting
+        # the `bracketing` → `linesearch` include order.
+        τ = 4 * eps(fx₀)
+        fx₁ ≤ fx₀ + τ && return nothing
+        adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return nothing
         return triple_point_finder(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1)
     end
 
@@ -67,7 +87,7 @@ function triple_point_finder(f::Callable, x₀::T, δ::T, nmax::Integer=DEFAULT_
         end
     end
 
-    error("Unable to find a triple point for quadratic line search starting at x = $x₀.")
+    nothing
 end
 
 function triple_point_finder(f::Callable, x₀::T; δ::T=T(DEFAULT_BRACKETING_s), nmax::Integer=DEFAULT_BRACKETING_nmax, adjust_constant_iteration::Integer=1) where {T}

--- a/src/bracketing/triple_point_finder.jl
+++ b/src/bracketing/triple_point_finder.jl
@@ -66,7 +66,7 @@ function triple_point_finder(f::Callable, x₀::T, δ::T, nmax::Integer=DEFAULT_
         # the wrong answer when the rise is within round-off of `f(x₀)`: the merit then simply
         # does not resolve a decrease here, and a *smaller* δ is strictly less informative, so
         # the remaining halvings are wasted evaluations that end in the same failure.
-        fx₁ ≤ fx₀ + armijo_tolerance(fx₀, DEFAULT_ARMIJO_τ_ULPS) && return :flat
+        fx₁ ≤ fx₀ + armijo_tolerance(fx₀, armijo_ulps(typeof(fx₀))) && return :flat
         adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return :unbracketable
         return triple_point_finder(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1)
     end

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -262,17 +262,10 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
     φ₀ = f(zero(T))
     d₀ = d(zero(T))
 
-    # No α can satisfy the SufficientDecreaseCondition unless the merit is finite and
-    # actually decreasing at the anchor, so report that instead of shrinking α fifty times to
-    # find out. Like `StrongWolfe`, hand the caller's trial step back rather than a step that
-    # was never accepted (and never the α = 0 anchor, which would freeze the outer iterate).
-    if !isfinite(φ₀) || !isfinite(d₀) || d₀ > zero(T)
-        return LinesearchStatus{T}(α, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, zero(T), zero(T))
-    elseif iszero(d₀)
-        # A stationary anchor. For the ‖F‖² merit of a nonlinear solver this is the exact
-        # root (F = 0 ⇒ φ'(0) = 0 and the direction vanishes), so every α is equivalent.
-        return LinesearchStatus{T}(α, LINESEARCH_STATIONARY, 0, φ₀, d₀, φ₀, zero(T), zero(T))
-    end
+    # No α can satisfy the SufficientDecreaseCondition unless the merit is finite and actually
+    # decreasing at the anchor, so report that instead of shrinking α fifty times to find out.
+    anchor = check_anchor(φ₀, d₀, α)
+    isnothing(anchor) || return anchor
 
     τ = armijo_tolerance(φ₀, m.τ_ulps)
     αmin = backtracking_αmin(m.c₁, d₀, τ)

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -44,27 +44,6 @@ We use ``c_2 = 0.9`` as default.
 const DEFAULT_WOLFE_c₂ = 0.9
 
 @doc raw"""
-    const DEFAULT_ARMIJO_τ_ULPS
-
-The number of units in the last place (ulps) of ``\varphi(0)`` by which the
-[`SufficientDecreaseCondition`](@ref) is slackened inside [`Backtracking`](@ref), i.e.
-``\tau = \mathrm{DEFAULT\_ARMIJO\_τ\_ULPS}\cdot\mathrm{ulp}(\varphi(0))`` in
-
-```math
-\varphi(\alpha) \leq \varphi(0) + c_1\alpha\varphi'(0) + \tau .
-```
-
-Its value is """ * """$(DEFAULT_ARMIJO_τ_ULPS)""" * raw""". Since the decrease demanded at
-``\alpha \approx 1`` is ``2c_1\varphi(0)``, i.e. some ``10^{-4}`` relative, ``\tau`` is
-irrelevant except in the region where the condition was previously decided by rounding
-rather than by the merit. Set `τ_ulps = 0` in [`Backtracking`](@ref) to recover the exact
-condition.
-
-See [`armijo_tolerance`](@ref) and [`backtracking_αmin`](@ref).
-"""
-const DEFAULT_ARMIJO_τ_ULPS = 4
-
-@doc raw"""
     const BACKTRACKING_SHRINK_MIN
 
 Lower bound on the factor by which a rejected step is shrunk by the interpolation in
@@ -85,7 +64,7 @@ The keys are:
 - `c₁`=""" * string(DEFAULT_WOLFE_c₁) * raw""": the constant ``c_1`` in the [`SufficientDecreaseCondition`](@ref) (Armijo condition). Also see [`DEFAULT_WOLFE_c₁`](@ref).
 - `c₂`=""" * string(DEFAULT_WOLFE_c₂) * raw""": the constant on whose basis the [`CurvatureCondition`](@ref) is tested. We should have ``c_2\in(c_1, 1).`` The closer this constant is to 1, the easier it is to satisfy the [`CurvatureCondition`](@ref).
 - `p`=""" * string(DEFAULT_ARMIJO_p) * raw""": an *upper bound* on the factor by which ``\alpha`` is decreased in every step until the stopping criterion is satisfied. The actual factor is chosen by interpolation and confined to ``[`` [`BACKTRACKING_SHRINK_MIN`](@ref) ``\cdot\alpha, p\alpha]``, so the trial sequence is never longer than the plain ``\alpha \gets p\alpha`` ladder.
-- `τ_ulps`=""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""": the round-off allowance of the [`SufficientDecreaseCondition`](@ref), in units in the last place of ``\varphi(0)``. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
+- `τ_ulps`=""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""": the round-off resolution of the merit, in units in the last place of ``\varphi(0)``. It slackens the [`SufficientDecreaseCondition`](@ref) (never past ``\varphi(0)``), fixes ``\alpha_\mathrm{min}``, and separates a genuine decrease from one within the noise. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
 
 # Implementation
 
@@ -101,7 +80,7 @@ finite with ``d_0 < 0`` the search is abandoned at once — no ``\alpha`` can sa
 [`SufficientDecreaseCondition`](@ref) along a direction that is not decreasing, so shrinking
 ``\alpha`` would only waste merit evaluations to find that out.
 
-Otherwise it sets the round-off allowance ``\tau`` ([`armijo_tolerance`](@ref)) and the
+Otherwise it sets the round-off resolution ``\tau`` ([`armijo_tolerance`](@ref)) and the
 smallest informative step ``\alpha_\mathrm{min}`` ([`backtracking_αmin`](@ref)), and shrinks
 the trial step by [`backtracking_interpolation`](@ref) until one of the following happens:
 1. the [`SufficientDecreaseCondition`](@ref) is satisfied — the step is accepted, and reported
@@ -122,7 +101,16 @@ honoured by shrinking alone — it is only checked afterwards to emit a warning 
 
 # Extended help
 
-[Sometimes](https://en.wikipedia.org/wiki/Backtracking_line_search) the parameters ``p`` and ``c_1`` have different names such as ``\tau`` and ``c``. Note that our ``\tau`` is something else entirely (the round-off allowance above).
+[Sometimes](https://en.wikipedia.org/wiki/Backtracking_line_search) the parameters ``p`` and ``c_1`` have different names such as ``\tau`` and ``c``. Note that our ``\tau`` is something else entirely (the round-off resolution above).
+
+``\alpha_\mathrm{min}`` is a factor ``2\,`` `τ_ulps` above the step ``\alpha^*`` at which the
+condition degenerates into a test decided by rounding — *provided*
+[`backtracking_αmin`](@ref)'s upper clamp at ``\sqrt{\mathrm{eps}(T)}`` is inactive, which it is
+for a merit of ordinary steepness in double precision. Where the clamp binds (a very flat merit,
+or any merit in `Float16`) the search does trial steps below ``\alpha^*``. That is deliberate and
+harmless: the ``\min`` in the [`SufficientDecreaseCondition`](@ref) means the test there reduces
+to ``\varphi(\alpha) \leq \varphi_0``, i.e. plain monotonicity, and such an accept is reported as
+`LINESEARCH_FLOOR` rather than as a decrease.
 """
 struct Backtracking{T} <: LinesearchMethod{T}
     α₀::T
@@ -153,15 +141,6 @@ Backtracking(::Type{T}, ::SolverMethod) where {T} = Backtracking(T)
 
 
 @doc raw"""
-    armijo_tolerance(φ₀, n)
-
-The absolute round-off allowance ``\tau = n\cdot\mathrm{ulp}(\varphi_0)`` of the
-[`SufficientDecreaseCondition`](@ref), where `n` is a number of units in the last place.
-See [`DEFAULT_ARMIJO_τ_ULPS`](@ref) and [`backtracking_αmin`](@ref).
-"""
-armijo_tolerance(φ₀::T, n::T) where {T} = n * eps(φ₀)
-
-@doc raw"""
     backtracking_αmin(c₁, d₀, τ)
 
 The smallest step length for which the [`SufficientDecreaseCondition`](@ref) can still be
@@ -172,7 +151,7 @@ decided by the merit rather than by rounding:
 ```
 
 Below ``\alpha_\mathrm{min}`` the demanded decrease ``c_1\alpha|\varphi'(0)|`` is smaller than
-the round-off allowance ``\tau``, so a trial step carries no information. Writing
+the round-off resolution ``\tau``, so a trial step carries no information. Writing
 ``\tau = n\cdot\mathrm{ulp}(\varphi(0))`` (see [`armijo_tolerance`](@ref)) gives
 
 ```math
@@ -182,13 +161,24 @@ the round-off allowance ``\tau``, so a trial step carries no information. Writin
 
 where ``\alpha^*`` is the step below which ``\mathrm{fl}(\varphi(0) + c_1\alpha\varphi'(0))``
 rounds back up to ``\varphi(0)`` and the condition degenerates to
-``\varphi(\alpha) \leq \varphi(0)`` — a test that a merit sitting at its round-off floor
-passes or fails at random. Since ``n \geq 1`` the search therefore stops a factor ``2n``
-*before* entering that region, rather than being decided by it.
+``\varphi(\alpha) \leq \varphi(0)``.
 
 The result is clamped to ``[\mathrm{eps}(T), \sqrt{\mathrm{eps}(T)}]``: the lower bound is the
 historical negligible-step floor, and the upper bound makes sure that a nearly flat but
-genuine merit (very small ``|\varphi'(0)|``) is still searched.
+genuine merit (very small ``|\varphi'(0)|``) is still searched — an unclamped
+``\alpha_\mathrm{min}`` grows without bound as ``|\varphi'(0)| \to 0`` and would stop the search
+before it began.
+
+!!! note "The factor ``2n`` holds only while the upper clamp is inactive"
+    ``\alpha_\mathrm{min} = 2n\,\alpha^*`` puts the search a factor ``2n`` clear of the region
+    where the condition is decided by rounding, but the ``\sqrt{\mathrm{eps}(T)}`` clamp can pull
+    it *below* ``\alpha^*``: that happens for
+    ``|\varphi'(0)| < \mathrm{ulp}(\varphi(0)) / (2c_1\sqrt{\mathrm{eps}(T)})``, i.e. below
+    ``7\cdot10^{-5}`` for `Float64` with ``\varphi(0) = 1``, below ``1.7`` for `Float32`, and
+    essentially always for `Float16`. Trial steps below ``\alpha^*`` are then taken, and that is
+    safe rather than merely tolerated: the ``\min`` in the [`SufficientDecreaseCondition`](@ref)
+    reduces the test there to ``\varphi(\alpha) \leq \varphi(0)``, so it can accept a
+    non-increase but never an increase, and such an accept is classified `LINESEARCH_FLOOR`.
 """
 function backtracking_αmin(c₁::T, d₀::T, τ::T) where {T}
     αmin = τ / (c₁ * abs(d₀))
@@ -277,6 +267,7 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
     φp = T(NaN)
     frozen = 0   # consecutive trials whose merit is bit-identical to φ(0)
     n = 0        # trial steps at which the merit was evaluated
+    reachedαmin = false  # the ladder ran down to the αmin floor rather than out of budget
 
     for _ in 1:config(ls).linesearch_max_iterations
         αₐ = α
@@ -285,10 +276,12 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
 
         # Accept as soon as the (round-off tolerant) sufficient decrease condition holds.
         # Whether that is a *genuine* decrease or merely a tie at the merit's round-off floor
-        # is decided by φₐ: only a decrease exceeding the allowance τ counts. The returned
+        # is decided by φₐ: only a decrease exceeding the resolution τ counts. The returned
         # step is the same either way, the reported outcome is not — which is precisely what
         # the former exact test could not express, since its accepts in the region below
         # α* = ulp(φ₀)/(2c₁|d₀|) were ties produced by rounding yet reported as successes.
+        # The condition itself can never accept an increase (see `SufficientDecreaseCondition`),
+        # so a `LINESEARCH_FLOOR` accept here is always a non-increasing step.
         if sdc(α, φₐ)
             oc = φₐ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR
             return LinesearchStatus{T}(α, oc, n, φ₀, d₀, φₐ, τ, αmin)
@@ -302,7 +295,10 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
         φₐ == φ₀ ? (frozen += 1) : (frozen = 0)
         frozen ≥ 2 && return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ₀, d₀, φₐ, τ, αmin)
 
-        α ≤ αmin && break
+        if α ≤ αmin
+            reachedαmin = true
+            break
+        end
 
         αₙ = backtracking_interpolation(φ₀, d₀, α, φₐ, αp, φp, m.p)
         αp, φp = α, φₐ
@@ -310,13 +306,16 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
     end
 
     # Nothing satisfied the sufficient decrease condition. Distinguish the two very different
-    # reasons: if the merit at the smallest informative step differs from φ(0) by no more than
-    # the round-off allowance, the merit has reached its round-off floor and *no* step can
-    # decrease it — the outer iteration is stuck no matter what the line search returns.
-    # Otherwise the merit genuinely fails to decrease even at the smallest informative step,
-    # which contradicts φ'(0) < 0.
-    capped = α > αmin  # the loop ended on the iteration budget, not on the αmin floor
-    oc = (!capped && abs(φₐ - φ₀) ≤ τ) ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
+    # reasons: if the ladder got all the way down to the smallest informative step and the merit
+    # there differs from φ(0) by no more than the round-off resolution, the merit has reached its
+    # round-off floor and *no* step can decrease it — the outer iteration is stuck no matter what
+    # the line search returns. Otherwise the merit genuinely fails to decrease even at the
+    # smallest informative step, which contradicts φ'(0) < 0.
+    #
+    # `reachedαmin` is tracked explicitly rather than inferred from `α > αmin`, which
+    # misclassifies the one case where the budget runs out on the very iteration that sets
+    # `α = αmin`: the ladder was then cut short, but the comparison says otherwise.
+    oc = (reachedαmin && abs(φₐ - φ₀) ≤ τ) ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
     LinesearchStatus{T}(αₐ, oc, n, φ₀, d₀, φₐ, τ, αmin)
 end
 

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -44,6 +44,38 @@ We use ``c_2 = 0.9`` as default.
 const DEFAULT_WOLFE_c₂ = 0.9
 
 @doc raw"""
+    const DEFAULT_ARMIJO_τ_ULPS
+
+The number of units in the last place (ulps) of ``\varphi(0)`` by which the
+[`SufficientDecreaseCondition`](@ref) is slackened inside [`Backtracking`](@ref), i.e.
+``\tau = \mathrm{DEFAULT\_ARMIJO\_τ\_ULPS}\cdot\mathrm{ulp}(\varphi(0))`` in
+
+```math
+\varphi(\alpha) \leq \varphi(0) + c_1\alpha\varphi'(0) + \tau .
+```
+
+Its value is """ * """$(DEFAULT_ARMIJO_τ_ULPS)""" * raw""". Since the decrease demanded at
+``\alpha \approx 1`` is ``2c_1\varphi(0)``, i.e. some ``10^{-4}`` relative, ``\tau`` is
+irrelevant except in the region where the condition was previously decided by rounding
+rather than by the merit. Set `τ_ulps = 0` in [`Backtracking`](@ref) to recover the exact
+condition.
+
+See [`armijo_tolerance`](@ref) and [`backtracking_αmin`](@ref).
+"""
+const DEFAULT_ARMIJO_τ_ULPS = 4
+
+@doc raw"""
+    const BACKTRACKING_SHRINK_MIN
+
+Lower bound on the factor by which a rejected step is shrunk by the interpolation in
+[`Backtracking`](@ref): the new trial step is confined to
+``[\mathrm{BACKTRACKING\_SHRINK\_MIN}\cdot\alpha, p\alpha]`` (see
+[nocedal2006numerical; §3.5](@cite), [dennis1996numerical; Alg. A6.3.1](@cite)).
+Its value is """ * """$(BACKTRACKING_SHRINK_MIN).
+"""
+const BACKTRACKING_SHRINK_MIN = 0.1
+
+@doc raw"""
     Backtracking <: LinesearchMethod
 
 # Keys
@@ -52,35 +84,58 @@ The keys are:
 - `α₀`=""" * string(DEFAULT_ARMIJO_α₀) * raw""": the initial step size ``\alpha``. This is decreased iteratively by a factor ``p`` until the [`SufficientDecreaseCondition`](@ref) is satisfied.
 - `c₁`=""" * string(DEFAULT_WOLFE_c₁) * raw""": the constant ``c_1`` in the [`SufficientDecreaseCondition`](@ref) (Armijo condition). Also see [`DEFAULT_WOLFE_c₁`](@ref).
 - `c₂`=""" * string(DEFAULT_WOLFE_c₂) * raw""": the constant on whose basis the [`CurvatureCondition`](@ref) is tested. We should have ``c_2\in(c_1, 1).`` The closer this constant is to 1, the easier it is to satisfy the [`CurvatureCondition`](@ref).
-- `p`=""" * string(DEFAULT_ARMIJO_p) * raw""": a parameter with which ``\alpha`` is decreased in every step until the stopping criterion is satisfied.
+- `p`=""" * string(DEFAULT_ARMIJO_p) * raw""": an *upper bound* on the factor by which ``\alpha`` is decreased in every step until the stopping criterion is satisfied. The actual factor is chosen by interpolation and confined to ``[`` [`BACKTRACKING_SHRINK_MIN`](@ref) ``\cdot\alpha, p\alpha]``, so the trial sequence is never longer than the plain ``\alpha \gets p\alpha`` ladder.
+- `τ_ulps`=""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""": the round-off allowance of the [`SufficientDecreaseCondition`](@ref), in units in the last place of ``\varphi(0)``. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
 
 # Implementation
 
-The algorithm starts by setting:
+The algorithm starts by setting
 ```math
 \begin{aligned}
-x_0 &\gets 0,\\
-y_0 &\gets f(x_0),\\
-d_0 &\gets f'(x_0),\\
-\alpha &\gets \alpha_0,
+\varphi_0 &\gets \varphi(0),\\
+d_0 &\gets \varphi'(0),
 \end{aligned}
 ```
-where ``f`` is of type [`LinesearchProblem`](@ref) and ``\alpha_0`` is stored in `ls`. It then repeatedly does ``\alpha \gets \alpha\cdot{}p`` until either (i) the maximum number of iterations is reached (the `max_iterations` keyword in [`Options`](@ref)) or (ii) the [`SufficientDecreaseCondition`](@ref) is satisfied. The [`CurvatureCondition`](@ref) is not used to terminate the iteration; it is only checked afterwards to emit a warning.
+where ``\varphi`` is of type [`LinesearchProblem`](@ref). Unless ``\varphi_0`` and ``d_0`` are
+finite with ``d_0 < 0`` the search is abandoned at once — no ``\alpha`` can satisfy the
+[`SufficientDecreaseCondition`](@ref) along a direction that is not decreasing, so shrinking
+``\alpha`` would only waste merit evaluations to find that out.
+
+Otherwise it sets the round-off allowance ``\tau`` ([`armijo_tolerance`](@ref)) and the
+smallest informative step ``\alpha_\mathrm{min}`` ([`backtracking_αmin`](@ref)), and shrinks
+the trial step by [`backtracking_interpolation`](@ref) until one of the following happens:
+1. the [`SufficientDecreaseCondition`](@ref) is satisfied — the step is accepted, and reported
+   as a genuine decrease only if ``\varphi(\alpha) \leq \varphi_0 - \tau``;
+2. two consecutive trials return ``\varphi(\alpha) = \varphi_0`` bit-exactly — the trial point
+   no longer differs from the base point in floating point, so no smaller step can either;
+3. ``\alpha \leq \alpha_\mathrm{min}`` — a smaller step could only be judged by rounding;
+4. the `linesearch_max_iterations` budget of [`Options`](@ref) is spent.
+
+Cases 2–4 are distinguished in the returned [`LinesearchStatus`](@ref): a merit that does not
+vary by more than ``\tau`` has reached its round-off floor (`LINESEARCH_FLOOR`, benign and not
+improvable by any line search), whereas one that does vary contradicts ``d_0 < 0``
+(`LINESEARCH_EXHAUSTED`, a genuine inconsistency). See [`LinesearchOutcome`](@ref).
+
+The [`CurvatureCondition`](@ref) is not used to terminate the iteration — it cannot be
+honoured by shrinking alone — it is only checked afterwards to emit a warning (see
+[`curvature_diagnostic`](@ref)).
 
 # Extended help
 
-[Sometimes](https://en.wikipedia.org/wiki/Backtracking_line_search) the parameters ``p`` and ``c_1`` have different names such as ``\tau`` and ``c``.
+[Sometimes](https://en.wikipedia.org/wiki/Backtracking_line_search) the parameters ``p`` and ``c_1`` have different names such as ``\tau`` and ``c``. Note that our ``\tau`` is something else entirely (the round-off allowance above).
 """
 struct Backtracking{T} <: LinesearchMethod{T}
     α₀::T
     c₁::T
     c₂::T
     p::T
+    τ_ulps::T
 
-    function Backtracking{T}(α₀::T, c₁::T, c₂::T, p::T) where {T}
+    function Backtracking{T}(α₀::T, c₁::T, c₂::T, p::T, τ_ulps::T=T(DEFAULT_ARMIJO_τ_ULPS)) where {T}
         @assert 0 < p < 1 "The shrinking parameter needs to satisfy 0 < p < 1, it is $(p)."
         @assert 0 < c₁ < c₂ < 1 "The Wolfe constants need to satisfy 0 < c₁ < c₂ < 1, they are c₁ = $(c₁), c₂ = $(c₂)."
-        new{T}(α₀, c₁, c₂, p)
+        @assert τ_ulps ≥ 0 "The round-off allowance needs to be nonnegative, it is $(τ_ulps) ulps."
+        new{T}(α₀, c₁, c₂, p, τ_ulps)
     end
 end
 
@@ -88,59 +143,208 @@ function Backtracking(::Type{T}=Float64;
     α₀=T(DEFAULT_ARMIJO_α₀),
     c₁=T(DEFAULT_WOLFE_c₁),
     c₂=T(DEFAULT_WOLFE_c₂),
-    p=T(DEFAULT_ARMIJO_p)
+    p=T(DEFAULT_ARMIJO_p),
+    τ_ulps=T(DEFAULT_ARMIJO_τ_ULPS)
 ) where {T}
-    Backtracking{T}(α₀, c₁, c₂, p)
+    Backtracking{T}(α₀, c₁, c₂, p, τ_ulps)
 end
 
 Backtracking(::Type{T}, ::SolverMethod) where {T} = Backtracking(T)
 
 
-# function solve(ls::Linesearch{T,<:Backtracking}, α::T=method(ls).α₀) where {T,LST}
-function solve(ls::Linesearch{T,<:Backtracking}, α::T, params=NullParameters()) where {T}
-    f(α) = value(problem(ls), α, params)
-    d(α) = derivative(problem(ls), α, params)
+@doc raw"""
+    armijo_tolerance(φ₀, n)
 
-    α₀ = zero(α)
-    y₀ = f(α₀)
-    d₀ = d(α₀)
+The absolute round-off allowance ``\tau = n\cdot\mathrm{ulp}(\varphi_0)`` of the
+[`SufficientDecreaseCondition`](@ref), where `n` is a number of units in the last place.
+See [`DEFAULT_ARMIJO_τ_ULPS`](@ref) and [`backtracking_αmin`](@ref).
+"""
+armijo_tolerance(φ₀::T, n::T) where {T} = n * eps(φ₀)
 
-    # note that we set pₖ ← 0 here as this is the descent direction for the linesearch problem.
-    sdc = SufficientDecreaseCondition(method(ls).c₁, y₀, d₀, f)
+@doc raw"""
+    backtracking_αmin(c₁, d₀, τ)
 
-    αₐ = α  # last trial step that was actually evaluated
-    satisfied = false
-    for i in 1:config(ls).max_iterations
-        αₐ = α
-        if sdc(α)
-            satisfied = true
-            break
-        end
-        # Stop shrinking once the step is negligible: further iterations would only
-        # drive α down to a denormal without changing the outcome, and returning the
-        # α₀ = 0 anchor here would freeze the outer iterate (x .+= 0 .* d).
-        α ≤ eps(one(α)) && break
-        α *= method(ls).p
-    end
+The smallest step length for which the [`SufficientDecreaseCondition`](@ref) can still be
+decided by the merit rather than by rounding:
 
-    if !satisfied
-        config(ls).verbosity ≥ 1 && @warn "Backtracking line search did not satisfy the sufficient decrease condition within $(config(ls).max_iterations) iterations. Returning the last trial step α = $(αₐ)."
-        return αₐ
-    end
+```math
+\alpha_\mathrm{min} = \frac{\tau}{c_1|\varphi'(0)|} .
+```
 
-    cc = CurvatureCondition(method(ls).c₂, d₀, d, Val(:Standard))
-    (config(ls).verbosity ≥ 2 && !cc(α)) && @warn "Backtracking line search: accepted step α = $(α) satisfies the sufficient decrease but not the curvature condition."
+Below ``\alpha_\mathrm{min}`` the demanded decrease ``c_1\alpha|\varphi'(0)|`` is smaller than
+the round-off allowance ``\tau``, so a trial step carries no information. Writing
+``\tau = n\cdot\mathrm{ulp}(\varphi(0))`` (see [`armijo_tolerance`](@ref)) gives
 
-    α
+```math
+\alpha_\mathrm{min} = 2n\,\alpha^*, \qquad
+\alpha^* = \frac{\mathrm{ulp}(\varphi(0))}{2c_1|\varphi'(0)|},
+```
+
+where ``\alpha^*`` is the step below which ``\mathrm{fl}(\varphi(0) + c_1\alpha\varphi'(0))``
+rounds back up to ``\varphi(0)`` and the condition degenerates to
+``\varphi(\alpha) \leq \varphi(0)`` — a test that a merit sitting at its round-off floor
+passes or fails at random. Since ``n \geq 1`` the search therefore stops a factor ``2n``
+*before* entering that region, rather than being decided by it.
+
+The result is clamped to ``[\mathrm{eps}(T), \sqrt{\mathrm{eps}(T)}]``: the lower bound is the
+historical negligible-step floor, and the upper bound makes sure that a nearly flat but
+genuine merit (very small ``|\varphi'(0)|``) is still searched.
+"""
+function backtracking_αmin(c₁::T, d₀::T, τ::T) where {T}
+    αmin = τ / (c₁ * abs(d₀))
+    isfinite(αmin) || (αmin = sqrt(eps(T)))
+    clamp(αmin, eps(T), sqrt(eps(T)))
 end
 
-Base.show(io::IO, ls::Backtracking) = print(io, "Backtracking with α₀ = $(ls.α₀) c₁ = $(ls.c₁), c₂ = $(ls.c₂) and p = $(ls.p).")
+@doc raw"""
+    backtracking_interpolation(φ₀, d₀, α, φα, αp, φp, p)
+
+The next trial step of the safeguarded polynomial backtracking used by [`Backtracking`](@ref)
+(see [nocedal2006numerical; §3.5](@cite), [dennis1996numerical; Alg. A6.3.1](@cite)).
+
+`α`/`φα` is the trial step that was just rejected and `αp`/`φp` the one rejected before it
+(`αp` is `NaN` on the first backtrack). The model interpolates ``\varphi(0)``,
+``\varphi'(0)`` and the rejected value(s) — a quadratic on the first backtrack, a cubic
+afterwards — and its minimiser is clamped to
+``[`` [`BACKTRACKING_SHRINK_MIN`](@ref) ``\cdot\alpha, p\alpha]``.
+
+The clamp is what makes this safe: an unclamped interpolant can return ``\alpha`` itself (no
+progress at all), collapse to numerically zero, or be meaningless because the merit values it
+is built from are rounding noise. Because the upper bound is ``p``, the trial sequence is
+pointwise never longer than the plain ``\alpha \gets p\alpha`` ladder.
+"""
+function backtracking_interpolation(φ₀::T, d₀::T, α::T, φα::T, αp::T, φp::T, p::T) where {T}
+    αₙ = T(NaN)
+    if isfinite(φα)
+        if isnan(αp)
+            # quadratic model through (0, φ₀), φ'(0) = d₀ and (α, φα)
+            den = 2 * (φα - φ₀ - d₀ * α)
+            den > zero(T) && (αₙ = -d₀ * α^2 / den)
+        elseif isfinite(φp) && α ≠ αp
+            # cubic model through (0, φ₀), φ'(0) = d₀, (αp, φp) and (α, φα)
+            r₁ = φα - φ₀ - d₀ * α
+            r₂ = φp - φ₀ - d₀ * αp
+            den = α^2 * αp^2 * (α - αp)
+            a = (αp^2 * r₁ - α^2 * r₂) / den
+            b = (-αp^3 * r₁ + α^3 * r₂) / den
+            disc = b^2 - 3 * a * d₀
+            if disc ≥ zero(T)
+                αₙ = iszero(a) ? -d₀ / (2 * b) : (-b + sqrt(disc)) / (3 * a)
+            end
+        end
+    end
+    (isfinite(αₙ) && αₙ > zero(T)) || (αₙ = p * α)
+    clamp(αₙ, T(BACKTRACKING_SHRINK_MIN) * α, p * α)
+end
+
+"""
+    solve(ls::Linesearch{T,<:Backtracking}, α, params)
+
+Run the backtracking line search from the trial step `α`, report the outcome through
+[`linesearch_warnings`](@ref) and return the accepted step length.
+
+Use [`solve_with_status`](@ref) to obtain the [`LinesearchStatus`](@ref) instead: a caller
+that has to tell "I found a decreasing step" from "the merit is at its round-off floor and
+nothing can decrease it" cannot do so from the step length alone.
+"""
+function solve(ls::Linesearch{T,<:Backtracking}, α::T, params=NullParameters()) where {T}
+    status = solve_with_status(ls, α, params)
+    linesearch_warnings(status, ls, params)
+    steplength(status)
+end
+
+function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullParameters()) where {T}
+    m = method(ls)
+    f(a) = value(problem(ls), a, params)
+    d(a) = derivative(problem(ls), a, params)
+
+    # note that we anchor at α = 0 here as this is the base point of the linesearch problem.
+    φ₀ = f(zero(T))
+    d₀ = d(zero(T))
+
+    # No α can satisfy the SufficientDecreaseCondition unless the merit is finite and
+    # actually decreasing at the anchor, so report that instead of shrinking α fifty times to
+    # find out. Like `StrongWolfe`, hand the caller's trial step back rather than a step that
+    # was never accepted (and never the α = 0 anchor, which would freeze the outer iterate).
+    if !isfinite(φ₀) || !isfinite(d₀) || d₀ > zero(T)
+        return LinesearchStatus{T}(α, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, zero(T), zero(T))
+    elseif iszero(d₀)
+        # A stationary anchor. For the ‖F‖² merit of a nonlinear solver this is the exact
+        # root (F = 0 ⇒ φ'(0) = 0 and the direction vanishes), so every α is equivalent.
+        return LinesearchStatus{T}(α, LINESEARCH_STATIONARY, 0, φ₀, d₀, φ₀, zero(T), zero(T))
+    end
+
+    τ = armijo_tolerance(φ₀, m.τ_ulps)
+    αmin = backtracking_αmin(m.c₁, d₀, τ)
+    sdc = SufficientDecreaseCondition(m.c₁, φ₀, d₀, f; τ=τ)
+
+    αₐ = α       # last trial step that was actually evaluated
+    φₐ = φ₀      # the merit there
+    αp = T(NaN)  # previous trial step and merit, for the cubic model
+    φp = T(NaN)
+    frozen = 0   # consecutive trials whose merit is bit-identical to φ(0)
+    n = 0        # trial steps at which the merit was evaluated
+
+    for _ in 1:config(ls).linesearch_max_iterations
+        αₐ = α
+        φₐ = f(α)
+        n += 1
+
+        # Accept as soon as the (round-off tolerant) sufficient decrease condition holds.
+        # Whether that is a *genuine* decrease or merely a tie at the merit's round-off floor
+        # is decided by φₐ: only a decrease exceeding the allowance τ counts. The returned
+        # step is the same either way, the reported outcome is not — which is precisely what
+        # the former exact test could not express, since its accepts in the region below
+        # α* = ulp(φ₀)/(2c₁|d₀|) were ties produced by rounding yet reported as successes.
+        if sdc(α, φₐ)
+            oc = φₐ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR
+            return LinesearchStatus{T}(α, oc, n, φ₀, d₀, φₐ, τ, αmin)
+        end
+
+        # A merit that is bit-identical to φ(0) means the trial point no longer differs from
+        # the base point in floating point (α below the x-scale eps‖x‖/‖δx‖), or that the
+        # merit is flat to the last bit: every smaller α is frozen too, so shrinking cannot
+        # help. Two consecutive frozen trials guard against an accidental tie. This is the
+        # scalar surrogate for the x-scale minimum step — a line search only ever sees φ.
+        φₐ == φ₀ ? (frozen += 1) : (frozen = 0)
+        frozen ≥ 2 && return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ₀, d₀, φₐ, τ, αmin)
+
+        α ≤ αmin && break
+
+        αₙ = backtracking_interpolation(φ₀, d₀, α, φₐ, αp, φp, m.p)
+        αp, φp = α, φₐ
+        α = max(αₙ, αmin)  # a trial exactly at αmin is always taken before giving up
+    end
+
+    # Nothing satisfied the sufficient decrease condition. Distinguish the two very different
+    # reasons: if the merit at the smallest informative step differs from φ(0) by no more than
+    # the round-off allowance, the merit has reached its round-off floor and *no* step can
+    # decrease it — the outer iteration is stuck no matter what the line search returns.
+    # Otherwise the merit genuinely fails to decrease even at the smallest informative step,
+    # which contradicts φ'(0) < 0.
+    capped = α > αmin  # the loop ended on the iteration budget, not on the αmin floor
+    oc = (!capped && abs(φₐ - φ₀) ≤ τ) ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
+    LinesearchStatus{T}(αₐ, oc, n, φ₀, d₀, φₐ, τ, αmin)
+end
+
+# The curvature condition cannot be enforced by shrinking alone, so `Backtracking` only
+# reports it — and only for a step that was genuinely accepted, because `derivative` costs a
+# full Jacobian for the line search problem of a nonlinear solver.
+function curvature_diagnostic(status::LinesearchStatus{T}, ls::Linesearch{T,<:Backtracking}, params) where {T}
+    issufficient(status) || return nothing
+    d(a) = derivative(problem(ls), a, params)
+    cc = CurvatureCondition(method(ls).c₂, status.d₀, d, Val(:Standard))
+    cc(steplength(status)) || @warn "Backtracking line search: accepted step α = $(steplength(status)) satisfies the sufficient decrease but not the curvature condition."
+    nothing
+end
+
+Base.show(io::IO, ls::Backtracking) = print(io, "Backtracking with α₀ = $(ls.α₀) c₁ = $(ls.c₁), c₂ = $(ls.c₂), p = $(ls.p) and τ_ulps = $(ls.τ_ulps).")
 
 function change_precision(::Type{T}, method::Backtracking) where {T}
     T ≠ eltype(method) || return method
-    Backtracking{T}(T(method.α₀), T(method.c₁), T(method.c₂), T(method.p))
+    Backtracking{T}(T(method.α₀), T(method.c₁), T(method.c₂), T(method.p), T(method.τ_ulps))
 end
 
 function Base.isapprox(bt₁::Backtracking{T}, bt₂::Backtracking{T}; kwargs...) where {T}
-    isapprox(bt₁.α₀, bt₂.α₀; kwargs...) && isapprox(bt₁.c₁, bt₂.c₁; kwargs...) && isapprox(bt₁.c₂, bt₂.c₂; kwargs...) && isapprox(bt₁.p, bt₂.p; kwargs...)
+    isapprox(bt₁.α₀, bt₂.α₀; kwargs...) && isapprox(bt₁.c₁, bt₂.c₁; kwargs...) && isapprox(bt₁.c₂, bt₂.c₂; kwargs...) && isapprox(bt₁.p, bt₂.p; kwargs...) && isapprox(bt₁.τ_ulps, bt₂.τ_ulps; kwargs...)
 end

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -64,7 +64,7 @@ The keys are:
 - `c₁`=""" * string(DEFAULT_WOLFE_c₁) * raw""": the constant ``c_1`` in the [`SufficientDecreaseCondition`](@ref) (Armijo condition). Also see [`DEFAULT_WOLFE_c₁`](@ref).
 - `c₂`=""" * string(DEFAULT_WOLFE_c₂) * raw""": the constant on whose basis the [`CurvatureCondition`](@ref) is tested. We should have ``c_2\in(c_1, 1).`` The closer this constant is to 1, the easier it is to satisfy the [`CurvatureCondition`](@ref).
 - `p`=""" * string(DEFAULT_ARMIJO_p) * raw""": an *upper bound* on the factor by which ``\alpha`` is decreased in every step until the stopping criterion is satisfied. The actual factor is chosen by interpolation and confined to ``[`` [`BACKTRACKING_SHRINK_MIN`](@ref) ``\cdot\alpha, p\alpha]``, so the trial sequence is never longer than the plain ``\alpha \gets p\alpha`` ladder.
-- `τ_ulps`=""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""": the round-off resolution of the merit, in units in the last place of ``\varphi(0)``. It slackens the [`SufficientDecreaseCondition`](@ref) (never past ``\varphi(0)``), fixes ``\alpha_\mathrm{min}``, and separates a genuine decrease from one within the noise. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
+- `τ_ulps`=[`armijo_ulps`](@ref)`(T, c₁)` (""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""" in `Float64` and `Float32`, less in `Float16`): the round-off resolution of the merit, in units in the last place of ``\varphi(0)``. It slackens the [`SufficientDecreaseCondition`](@ref) (never past ``\varphi(0)``), fixes ``\alpha_\mathrm{min}``, and separates a genuine decrease from one within the noise. A value larger than [`armijo_ulps`](@ref)`(T, c₁)` is capped to it, since above that ``\tau`` would swamp the decrease the condition demands. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
 
 # Implementation
 
@@ -119,11 +119,14 @@ struct Backtracking{T} <: LinesearchMethod{T}
     p::T
     τ_ulps::T
 
-    function Backtracking{T}(α₀::T, c₁::T, c₂::T, p::T, τ_ulps::T=T(DEFAULT_ARMIJO_τ_ULPS)) where {T}
+    function Backtracking{T}(α₀::T, c₁::T, c₂::T, p::T, τ_ulps::T=armijo_ulps(T, c₁)) where {T}
         @assert 0 < p < 1 "The shrinking parameter needs to satisfy 0 < p < 1, it is $(p)."
         @assert 0 < c₁ < c₂ < 1 "The Wolfe constants need to satisfy 0 < c₁ < c₂ < 1, they are c₁ = $(c₁), c₂ = $(c₂)."
-        @assert τ_ulps ≥ 0 "The round-off allowance needs to be nonnegative, it is $(τ_ulps) ulps."
-        new{T}(α₀, c₁, c₂, p, τ_ulps)
+        @assert τ_ulps ≥ 0 "The round-off resolution needs to be nonnegative, it is $(τ_ulps) ulps."
+        # Capped here rather than only in the keyword constructor, so that *every* path into a
+        # `Backtracking{T}` — including `change_precision`, which converts a method built for a
+        # different `T` — gets a resolution the element type can support. See `armijo_ulps`.
+        new{T}(α₀, c₁, c₂, p, min(τ_ulps, armijo_ulps(T, c₁)))
     end
 end
 
@@ -132,7 +135,7 @@ function Backtracking(::Type{T}=Float64;
     c₁=T(DEFAULT_WOLFE_c₁),
     c₂=T(DEFAULT_WOLFE_c₂),
     p=T(DEFAULT_ARMIJO_p),
-    τ_ulps=T(DEFAULT_ARMIJO_τ_ULPS)
+    τ_ulps=armijo_ulps(T, c₁)
 ) where {T}
     Backtracking{T}(α₀, c₁, c₂, p, τ_ulps)
 end

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -175,7 +175,7 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     anchor = check_anchor(φ₀, d₀, α)
     isnothing(anchor) || return anchor
 
-    τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
+    τ = armijo_tolerance(φ₀, armijo_ulps(T))
 
     # Lower-anchor the bracket at α = 0, where a genuine descent direction has a decreasing
     # merit (φ′(0) < 0, now guaranteed by `check_anchor`). Probe the caller's trial step α (one

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -47,6 +47,17 @@ So the algorithm checks in each step where the sign change occurred and moves th
     only at high verbosity.
 """
 function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
+    α, converged = _bisection_core(f, αmin, αmax, params, config)
+    converged || (config.verbosity ≥ 1 && @warn "Bisection did not converge within $(config.linesearch_max_iterations) iterations; returning best estimate α = $(α).")
+    α
+end
+
+# The bisection loop, returning `(α, converged)` so a caller can report non-convergence itself
+# instead of having this function log it. The `Bisection` *line search* needs that: it reports
+# through `linesearch_warnings` like every other line search, so a message emitted from here
+# would duplicate it and bypass the shared verbosity policy. The public `bisection` above keeps
+# warning, since it is also used standalone as a root finder.
+function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Options) where {T<:Number}
     R = float(T)
     α₀ = R(αmin)
     α₁ = R(αmax)
@@ -63,7 +74,7 @@ function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), con
 
     if y₀ * y₁ > zero(y₀)
         config.verbosity ≥ 2 && @warn "Bisection bracket [$(α₀), $(α₁)] shows no sign change (f = $(y₀), $(y₁)); returning the endpoint with the smallest |f|."
-        return abs(y₀) ≤ abs(y₁) ? α₀ : α₁
+        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), true
     end
 
     converged = false
@@ -91,9 +102,7 @@ function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), con
         end
     end
 
-    converged || (config.verbosity ≥ 1 && @warn "Bisection did not converge within $(config.linesearch_max_iterations) iterations; returning best estimate α = $(α).")
-
-    α
+    α, converged
 end
 
 function bisection(f::Callable, α::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
@@ -136,25 +145,67 @@ Bisection(::Type{T}=Float64) where {T} = Bisection{T}()
 Bisection(::Type{T}, ::SolverMethod) where {T} = Bisection(T)
 
 
-function solve(ls::Linesearch{T,<:Bisection}, α₀::T, α₁::T, params=NullParameters()) where {T}
-    bisection(problem(ls).D, α₀, α₁, params, config(ls))
+# Bisect the derivative on a known bracket. Private: `solve`/`solve_with_status` is the public
+# entry point (this used to be a `solve` overload, which made the public name ambiguous).
+_bisect_on(ls::Linesearch{T,<:Bisection}, α₀::T, α₁::T, params) where {T} =
+    _bisection_core(problem(ls).D, α₀, α₁, params, config(ls))
+
+"""
+    solve(ls::Linesearch{T,<:Bisection}, α, params)
+
+Bisect the derivative of the merit to approximate the line minimiser, report the outcome
+through [`linesearch_warnings`](@ref) and return the step length. See [`Bisection`](@ref) and
+[`solve_with_status`](@ref).
+"""
+function solve(ls::Linesearch{T,<:Bisection}, α::T, params=NullParameters()) where {T}
+    status = solve_with_status(ls, α, params)
+    linesearch_warnings(status, ls, params)
+    steplength(status)
 end
 
-function solve(ls::Linesearch{T,<:Bisection}, α::T, params=NullParameters()) where {T}
+function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullParameters()) where {T}
     prob = problem(ls)
+    φ₀ = value(prob, zero(T), params)
+    d₀ = derivative(prob, zero(T), params)
 
-    # Lower-anchor the bracket at α = 0, where a genuine descent direction has a
-    # decreasing merit (φ′(0) < 0). Probe the caller's trial step α (one extra
-    # derivative evaluation) to decide how to fold it in; see the docstring and #164.
-    if α > zero(T) && derivative(prob, zero(T), params) < zero(T) && derivative(prob, α, params) ≥ zero(T)
+    anchor = check_anchor(φ₀, d₀, α)
+    isnothing(anchor) || return anchor
+
+    τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
+
+    # Lower-anchor the bracket at α = 0, where a genuine descent direction has a decreasing
+    # merit (φ′(0) < 0, now guaranteed by `check_anchor`). Probe the caller's trial step α (one
+    # extra derivative evaluation) to decide how to fold it in; see the docstring and #164.
+    αres, converged = if α > zero(T) && derivative(prob, α, params) ≥ zero(T)
         # α overshot the minimum: [0, α] already brackets the stationary point.
-        return solve(ls, zero(T), α, params)
+        _bisect_on(ls, zero(T), α, params)
+    else
+        # α is on the descent side: grow the bracket from 0, seeding the step scale from |α|
+        # (clamped) instead of the fixed default.
+        s = clamp(abs(α), T(DEFAULT_BRACKETING_s), one(T))
+        bracket = bracket_minimum(prob, params, zero(T), s)
+        # `bracket_minimum` returns `nothing` when it cannot bracket a minimum; there is then no
+        # interval to bisect and no resolvable improvement to be had.
+        isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_FLOOR, 0, φ₀, d₀, φ₀, τ, zero(T))
+        _bisect_on(ls, bracket..., params)
     end
+    # Non-convergence of the bisection is reported through the status rather than logged here,
+    # so that `linesearch_warnings` remains the only place a line search emits messages.
+    converged || return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
 
-    # α is on the descent side (or not a descent step / α ≤ 0): grow the bracket from
-    # 0, seeding the step scale from |α| (clamped) instead of the fixed default.
-    s = clamp(abs(α), T(DEFAULT_BRACKETING_s), one(T))
-    solve(ls, bracket_minimum(prob, params, zero(T), s)..., params)
+    # `bracket_minimum` flips direction when the merit rises to the right of its start, so the
+    # bracket — and hence the bisected result — can lie left of zero. A negative step is not a
+    # meaningful step length along a direction (see the α > 0 contract), so retry once from the
+    # α = 0 anchor, which `check_anchor` has established is decreasing.
+    if αres ≤ zero(T)
+        bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s))
+        isnothing(bracket) || (αres, _ = _bisect_on(ls, bracket..., params))
+    end
+    αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, τ, zero(T))
+
+    φres = value(prob, αres, params)
+    LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
+        0, φ₀, d₀, φres, τ, zero(T))
 end
 
 Base.show(io::IO, ::Bisection) = print(io, "Bisection")

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -47,17 +47,19 @@ So the algorithm checks in each step where the sign change occurred and moves th
     only at high verbosity.
 """
 function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
-    α, converged = _bisection_core(f, αmin, αmax, params, config)
+    α, converged, _ = _bisection_core(f, αmin, αmax, params, config)
     converged || (config.verbosity ≥ 1 && @warn "Bisection did not converge within $(config.linesearch_max_iterations) iterations; returning best estimate α = $(α).")
     α
 end
 
-# The bisection loop, returning `(α, converged)` so a caller can report non-convergence itself
-# instead of having this function log it. The `Bisection` *line search* needs that: it reports
-# through `linesearch_warnings` like every other line search, so a message emitted from here
-# would duplicate it and bypass the shared verbosity policy. The public `bisection` above keeps
+# The bisection loop, returning `(α, converged, n)` so a caller can report non-convergence
+# itself instead of having this function log it, and report the evaluation count `n` as the
+# `trials` of a `LinesearchStatus`. The `Bisection` *line search* needs both: it reports through
+# `linesearch_warnings` like every other line search, so a message emitted from here would
+# duplicate it and bypass the shared verbosity policy. The public `bisection` above keeps
 # warning, since it is also used standalone as a root finder.
 function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Options) where {T<:Number}
+    n = 0
     R = float(T)
     α₀ = R(αmin)
     α₁ = R(αmax)
@@ -70,17 +72,19 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
 
     y₀ = f(α₀, params)
     y₁ = f(α₁, params)
+    n += 2
     y = zero(y₀)
 
     if y₀ * y₁ > zero(y₀)
         config.verbosity ≥ 2 && @warn "Bisection bracket [$(α₀), $(α₁)] shows no sign change (f = $(y₀), $(y₁)); returning the endpoint with the smallest |f|."
-        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), true
+        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), true, n
     end
 
     converged = false
     for _ in 1:config.linesearch_max_iterations
         α = (α₀ + α₁) / 2
         y = f(α, params)
+        n += 1
 
         # break if y is close to zero.
         if ≈(y, zero(y); atol=config.f_abstol)
@@ -102,7 +106,7 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
         end
     end
 
-    α, converged
+    α, converged, n
 end
 
 function bisection(f::Callable, α::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
@@ -176,7 +180,7 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # Lower-anchor the bracket at α = 0, where a genuine descent direction has a decreasing
     # merit (φ′(0) < 0, now guaranteed by `check_anchor`). Probe the caller's trial step α (one
     # extra derivative evaluation) to decide how to fold it in; see the docstring and #164.
-    αres, converged = if α > zero(T) && derivative(prob, α, params) ≥ zero(T)
+    αres, converged, n = if α > zero(T) && derivative(prob, α, params) ≥ zero(T)
         # α overshot the minimum: [0, α] already brackets the stationary point.
         _bisect_on(ls, zero(T), α, params)
     else
@@ -184,14 +188,16 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # (clamped) instead of the fixed default.
         s = clamp(abs(α), T(DEFAULT_BRACKETING_s), one(T))
         bracket = bracket_minimum(prob, params, zero(T), s)
-        # `bracket_minimum` returns `nothing` when it cannot bracket a minimum; there is then no
-        # interval to bisect and no resolvable improvement to be had.
-        isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_FLOOR, 0, φ₀, d₀, φ₀, τ, zero(T))
+        # `bracket_minimum` returns `nothing` only when `nmax` steps found no bracket in either
+        # direction, i.e. for a merit that keeps decreasing. There is then no interval to bisect —
+        # but that is a failure to *report*, not a round-off floor: calling it a floor would make
+        # the outer iteration count a descending merit as stagnation.
+        isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, φ₀, τ, zero(T))
         _bisect_on(ls, bracket..., params)
     end
     # Non-convergence of the bisection is reported through the status rather than logged here,
     # so that `linesearch_warnings` remains the only place a line search emits messages.
-    converged || return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
+    converged || return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, n, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
 
     # `bracket_minimum` flips direction when the merit rises to the right of its start, so the
     # bracket — and hence the bisected result — can lie left of zero. A negative step is not a
@@ -199,13 +205,19 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # α = 0 anchor, which `check_anchor` has established is decreasing.
     if αres ≤ zero(T)
         bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s))
-        isnothing(bracket) || (αres, _ = _bisect_on(ls, bracket..., params))
+        if !isnothing(bracket)
+            αres, _, nretry = _bisect_on(ls, bracket..., params)
+            n += nretry
+        end
     end
-    αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, τ, zero(T))
+    # Still non-positive: no positive step improves the merit as far as this search can tell.
+    # That is the floor, not a non-descent anchor — `check_anchor` established above that the
+    # anchor *does* descend.
+    αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ₀, d₀, φ₀, τ, zero(T))
 
     φres = value(prob, αres, params)
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
-        0, φ₀, d₀, φres, τ, zero(T))
+        n, φ₀, d₀, φres, τ, zero(T))
 end
 
 Base.show(io::IO, ::Bisection) = print(io, "Bisection")

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -33,7 +33,7 @@ and then repeat:
 & \text{end}
 \end{aligned}
 ```
-So the algorithm checks in each step where the sign change occurred and moves the ``\alpha_0`` or ``\alpha_1`` accordingly. The loop is terminated if `config.max_iterations` is reached (by default """ * """$(MAX_ITERATIONS) in [`Options`](@ref) struct); in that case a warning is emitted (at `verbosity ≥ 1`) and the best estimate found so far is returned.
+So the algorithm checks in each step where the sign change occurred and moves the ``\alpha_0`` or ``\alpha_1`` accordingly. The loop is terminated if `config.linesearch_max_iterations` is reached (by default """ * """$(linesearch_iterations(Float64)) for `Float64` in the [`Options`](@ref) struct, see [`linesearch_iterations`](@ref)); in that case a warning is emitted (at `verbosity ≥ 1`) and the best estimate found so far is returned.
 
 !!! warning
     The obvious danger with using bisections is that the supplied interval can have multiple roots (or no roots). One should be careful to avoid this when fixing the interval.
@@ -67,7 +67,7 @@ function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), con
     end
 
     converged = false
-    for _ in 1:config.max_iterations
+    for _ in 1:config.linesearch_max_iterations
         α = (α₀ + α₁) / 2
         y = f(α, params)
 
@@ -91,7 +91,7 @@ function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), con
         end
     end
 
-    converged || (config.verbosity ≥ 1 && @warn "Bisection did not converge within $(config.max_iterations) iterations; returning best estimate α = $(α).")
+    converged || (config.verbosity ≥ 1 && @warn "Bisection did not converge within $(config.linesearch_max_iterations) iterations; returning best estimate α = $(α).")
 
     α
 end

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -67,6 +67,27 @@ Linesearch(problem::LinesearchProblem{T}, method::LinesearchMethod=Static(); opt
 Linesearch(problem::LinesearchProblem{T}, method::LinesearchMethod, config::Options{T}) where {T} =
     Linesearch{T}(problem, change_precision(T, method), config)
 
+@doc raw"""
+    with_config(ls, config)
+
+Return a [`Linesearch`](@ref) with the [`LinesearchProblem`](@ref) and the
+[`LinesearchMethod`](@ref) of `ls`, but with the [`Options`](@ref) `config`.
+
+This is how a [`NonlinearSolver`](@ref) makes its line search share *its* options. A
+`Linesearch` built by `Linesearch(problem, method)` carries an `Options` of its own,
+constructed from nothing but defaults — so `verbosity` and `linesearch_max_iterations` would
+be configured twice, and `verbosity = 0` on the solver would not silence the line search.
+
+`Linesearch` is an immutable three-field wrapper, so rebuilding it is cheap: the problem (and
+hence its closures and scratch buffers) and the method are shared, not copied.
+
+The `Options` element type is pinned to the `Linesearch` element type, so a mismatched
+`config` raises a `MethodError` rather than silently producing a broken object — the same
+guarantee the three-argument [`Linesearch`](@ref) constructor gives.
+"""
+with_config(ls::Linesearch{T}, config::Options{T}) where {T} =
+    Linesearch(problem(ls), method(ls), config)
+
 function solve(prob::LinesearchProblem{T}, method::LinesearchMethod, α, params=NullParameters(), config::Options{T}=Options(T)) where {T}
     solve(Linesearch(prob, method, config), T(α), params)
 end

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -12,6 +12,38 @@ It is a subtype of `SolverMethod` (imported from `GeometricBase`) — line searc
 are one-dimensional subproblems used *inside* nonlinear solvers and
 optimizers, so (unlike a [`NonlinearSolverMethod`](@ref)) a `LinesearchMethod` is
 not itself a nonlinear-solver method.
+
+# The line search contract
+
+Every method reached through [`solve`](@ref) or [`solve_with_status`](@ref) guarantees:
+
+1. **It never throws.** A situation it cannot handle is *reported*, never raised — a line
+   search must not abort the enclosing solve. Bracketing helpers signal failure with `nothing`
+   (see [`bracket_minimum`](@ref), [`triple_point_finder`](@ref)) and the method maps that onto
+   a [`LinesearchOutcome`](@ref).
+2. **It returns ``\\alpha > 0``.** Never the ``\\alpha = 0`` anchor, which would freeze the
+   outer iterate (`x .+= 0 .* d`), and never a negative step: ``\\alpha`` scales a direction
+   that has already been chosen, so its sign is not the line search's to decide.
+3. **It reports through [`linesearch_warnings`](@ref) only** — one message site and one
+   verbosity policy for all methods (genuine failure at `verbosity ≥ 1`, rate limited; the
+   benign round-off-floor and stationary outcomes at `≥ 2`).
+4. **A non-finite or ascending anchor is reported, not assumed away** — see
+   [`check_anchor`](@ref).
+5. **It terminates in a bounded number of merit evaluations, independently of the merit's
+   scale.** Multiplying ``\\varphi`` by a constant must not change the cost.
+
+# The two families
+
+What is *not* standardised is the meaning of the input ``\\alpha`` and what each method
+guarantees about the step, because there are two distinct kinds:
+
+- **Condition-satisfying, ``\\alpha``-relative** — [`Backtracking`](@ref),
+  [`StrongWolfe`](@ref) and trivially [`Static`](@ref): "given the trial step ``\\alpha``,
+  return a step satisfying a decrease condition". The result depends on the input ``\\alpha``.
+- **Minimising, ``\\alpha``-independent** — [`Bisection`](@ref), [`Quadratic`](@ref) and
+  [`BierlaireQuadratic`](@ref): "approximate the minimiser of ``\\varphi`` along the
+  direction". The input ``\\alpha`` only seeds the bracketing (see issue #164), and no Wolfe
+  condition is checked.
 """
 abstract type LinesearchMethod{T} <: SolverMethod end
 

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -51,13 +51,22 @@ answer, or it may be all that is left after the merit turned out to be irreducib
 
 - `α`: the returned step length (the value [`solve`](@ref) returns),
 - `outcome::`[`LinesearchOutcome`](@ref),
-- `trials`: the number of trial steps ``\alpha > 0`` at which the merit was actually
-  evaluated — *not* the `linesearch_max_iterations` budget,
+- `trials`: the number of trial steps ``\alpha > 0`` at which the method actually evaluated the
+  problem in its own iteration — *not* the `linesearch_max_iterations` budget. That is the merit
+  for every method except [`Bisection`](@ref), which drives on the derivative it bisects.
+  Evaluations spent inside a bracketing helper ([`bracket_minimum`](@ref),
+  [`triple_point_finder`](@ref)) are not included, so for the bracketing searches this is a
+  lower bound on the total cost; for [`Backtracking`](@ref) and [`StrongWolfe`](@ref) it is
+  exact, and every merit evaluation is either the ``\alpha = 0`` anchor or a counted trial,
 - `φ₀`, `d₀`: the merit and its derivative at the anchor ``\alpha = 0``,
 - `φ`: the merit at the returned step,
-- `τ`: the round-off allowance used in the [`SufficientDecreaseCondition`](@ref),
+- `τ`: the round-off resolution of the merit (see [`armijo_tolerance`](@ref)), against which
+  every method decides whether the decrease it achieved was genuine,
 - `αmin`: the smallest step length that could still be decided by the merit rather than by
-  rounding (see [`backtracking_αmin`](@ref)).
+  rounding (see [`backtracking_αmin`](@ref)). This is a *shrinking-ladder* quantity and is
+  therefore `zero` — meaning "not applicable" — for the minimising searches
+  ([`Bisection`](@ref), [`Quadratic`](@ref), [`BierlaireQuadratic`](@ref)) and for
+  [`StrongWolfe`](@ref), which bracket rather than shrink.
 """
 struct LinesearchStatus{T}
     α::T
@@ -148,8 +157,15 @@ This is the one definition of the anchor policy shared by every [`LinesearchMeth
 An ascent anchor arises in practice when the direction did not come from an exact, freshly
 factorized Newton solve — a stale [`Jacobian`](@ref) under `refactorize > 1`, a nonzero
 `regularization_factor`, or an inexact linear solve. The correct response is to refresh the
-Jacobian (see [`maybe_refactorize!`](@ref)), which is why the line search reports the situation
-instead of trying to salvage a step from it.
+Jacobian, which is why the line search reports the situation instead of trying to salvage a step
+from it, and [`solver_step!`](@ref) acts on the report: on `LINESEARCH_NO_DESCENT` it leaves the
+iterate where it is (moving along a direction that cannot decrease the merit would only make the
+retry start from a worse point) and records a stall, which forces a fresh Jacobian on the next
+step (see [`needs_refresh`](@ref) and [`maybe_refactorize!`](@ref)) and gives up after
+`max_stalls` if that does not help.
+
+The step handed back is therefore still positive, as the contract requires — whether to *use*
+it is the caller's decision, not the line search's.
 """
 function check_anchor(φ₀::T, d₀::T, α::T) where {T}
     # A non-positive trial step is not a step the caller can be handed back, so substitute the
@@ -202,6 +218,15 @@ allows. And the remaining outcomes are rate limited with `maxlog`, because a sol
 make progress asks the line search for an impossible decrease at every one of its iterations,
 which an unconditional warning turns into thousands of identical messages.
 
+!!! warning "`maxlog` is per session, not per solve"
+    Julia keys `maxlog` on the *source location* of the `@warn`, so the caps below are
+    process-global and are **not** reset between `solve!` calls. Once a message has appeared its
+    quota is spent for the lifetime of the session, including for later solves of entirely
+    different problems. That is deliberate — a time-stepping loop calling `solve!` once per step
+    is precisely the case these caps exist for — but it does mean a genuinely new line-search
+    failure late in a long run can go unreported. Raise `verbosity` to 2 and re-run when
+    diagnosing one.
+
 Whether an irreducible merit actually *matters* is the outer iteration's call, and
 [`nonlinear_solver_warnings`](@ref) makes it: it reports stagnation once, naming the residual
 that was achieved and the tolerance that was requested.
@@ -218,11 +243,17 @@ function linesearch_warnings(status::LinesearchStatus, ls::Linesearch, params=Nu
         # iteration's call, and it makes it: `record_stall!` counts a floor only while the
         # residual is *not* small, and `nonlinear_solver_warnings` then reports it once, with
         # the achieved residual and the requested tolerance.
-        verbose ≥ 2 && @warn "$(name) line search: no trial step changed the merit by more than the round-off allowance τ = $(status.τ) in $(trials(status)) trial step(s). φ(0) = $(status.φ₀) has reached its round-off floor, so no step can decrease it (the smallest informative step is αmin = $(status.αmin)). Returning α = $(steplength(status)). Check whether the requested residual tolerance is attainable in this precision." maxlog = 1
+        # `αmin` is a `Backtracking` quantity (zero means "not applicable", see `LinesearchStatus`),
+        # so the clause naming it is only included when there is a value to name.
+        αminclause = iszero(status.αmin) ? "" : " (the smallest informative step is αmin = $(status.αmin))"
+        verbose ≥ 2 && @warn "$(name) line search: no trial step changed the merit by more than the round-off resolution τ = $(status.τ) in $(trials(status)) trial step(s). φ(0) = $(status.φ₀) has reached its round-off floor, so no step can decrease it$(αminclause). Returning α = $(steplength(status)). Check whether the requested residual tolerance is attainable in this precision." maxlog = 1
     elseif outcome(status) === LINESEARCH_EXHAUSTED
+        # With `αmin = 0` — every method other than `Backtracking` — this selects the budget
+        # wording, which is correct: those searches only ever exhaust by running out of budget or
+        # by failing to bracket, never by reaching an `αmin` floor.
         reason = steplength(status) > status.αmin ?
-                 "the budget linesearch_max_iterations = $(config(ls).linesearch_max_iterations) was spent" :
-                 "the merit changed by $(status.φ - status.φ₀) at the smallest informative step αmin = $(status.αmin), which exceeds the round-off allowance τ = $(status.τ), so φ'(0) = $(status.d₀) is inconsistent with the merit (a stale or regularized Jacobian, an inexact linear solve, or a non-smooth problem)"
+                 "the budget linesearch_max_iterations = $(config(ls).linesearch_max_iterations) was spent, or the merit could not be bracketed" :
+                 "the merit changed by $(status.φ - status.φ₀) at the smallest informative step αmin = $(status.αmin), which exceeds the round-off resolution τ = $(status.τ), so φ'(0) = $(status.d₀) is inconsistent with the merit (a stale or regularized Jacobian, an inexact linear solve, or a non-smooth problem)"
         verbose ≥ 1 && @warn "$(name) line search: no step satisfied the sufficient decrease condition in $(trials(status)) trial step(s) — $(reason). Returning α = $(steplength(status))." maxlog = 3
     elseif outcome(status) === LINESEARCH_NO_DESCENT
         verbose ≥ 1 && @warn "$(name) line search: φ'(0) = $(status.d₀) (with φ(0) = $(status.φ₀)) is not a descent direction, so no α can satisfy the sufficient decrease condition. Returning α = $(steplength(status))." maxlog = 3

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -1,0 +1,197 @@
+@doc raw"""
+    LinesearchOutcome
+
+Why a [`LinesearchMethod`](@ref) stopped. Stored in a [`LinesearchStatus`](@ref), which is
+returned by [`solve_with_status`](@ref).
+
+- `LINESEARCH_DECREASED`: a step satisfying the [`SufficientDecreaseCondition`](@ref) with a
+  *genuine* decrease (more than the round-off allowance ``\tau``) was found. This is the only
+  outcome that reports progress.
+- `LINESEARCH_FLOOR`: the merit has reached its round-off floor — no trial step changes it by
+  more than ``\tau``, so *no* line search can make progress here. The returned step is the
+  smallest informative one. This is not an error and is only reported at `verbosity ≥ 2`: it is
+  the *expected* final state of a converged solve, and when it is *not* — when the residual is
+  still large — the outer iteration reports it as stagnation instead (see
+  [`stalled_step`](@ref) and [`Options`](@ref)).
+- `LINESEARCH_EXHAUSTED`: no acceptable step although the merit *does* vary by more than
+  ``\tau``. Either ``\varphi'(0)`` is inconsistent with ``\varphi`` (a stale or regularized
+  [`Jacobian`](@ref), an inexact linear solve, a non-smooth merit), or the
+  `linesearch_max_iterations` budget of [`Options`](@ref) was spent.
+- `LINESEARCH_NO_DESCENT`: ``\varphi'(0) > 0``, or ``\varphi(0)``/``\varphi'(0)`` is not
+  finite. No ``\alpha`` can satisfy the sufficient decrease condition.
+- `LINESEARCH_STATIONARY`: ``\varphi'(0) = 0``, e.g. a vanishing direction at an exact root.
+  Benign — there is nothing to search for.
+- `LINESEARCH_UNKNOWN`: the method does not report an outcome (the generic fallback of
+  [`solve_with_status`](@ref)).
+"""
+@enum LinesearchOutcome::Int8 begin
+    LINESEARCH_DECREASED
+    LINESEARCH_FLOOR
+    LINESEARCH_EXHAUSTED
+    LINESEARCH_NO_DESCENT
+    LINESEARCH_STATIONARY
+    LINESEARCH_UNKNOWN
+end
+
+@doc raw"""
+    LinesearchStatus{T}
+
+The step length returned by a line search together with the diagnostics needed to tell
+*progress* from *stagnation*. Obtained from [`solve_with_status`](@ref); compare this to
+[`NonlinearSolverStatus`](@ref), which plays the same role for the outer iteration.
+
+The step length alone cannot express the difference: a tiny ``\alpha`` may be the correct
+answer, or it may be all that is left after the merit turned out to be irreducible. See
+[`LinesearchOutcome`](@ref).
+
+# Keys
+
+- `α`: the returned step length (the value [`solve`](@ref) returns),
+- `outcome::`[`LinesearchOutcome`](@ref),
+- `trials`: the number of trial steps ``\alpha > 0`` at which the merit was actually
+  evaluated — *not* the `linesearch_max_iterations` budget,
+- `φ₀`, `d₀`: the merit and its derivative at the anchor ``\alpha = 0``,
+- `φ`: the merit at the returned step,
+- `τ`: the round-off allowance used in the [`SufficientDecreaseCondition`](@ref),
+- `αmin`: the smallest step length that could still be decided by the merit rather than by
+  rounding (see [`backtracking_αmin`](@ref)).
+"""
+struct LinesearchStatus{T}
+    α::T
+    outcome::LinesearchOutcome
+    trials::Int
+
+    φ₀::T
+    d₀::T
+    φ::T
+    τ::T
+    αmin::T
+end
+
+"""
+    LinesearchStatus(α, outcome=LINESEARCH_UNKNOWN)
+
+Construct a [`LinesearchStatus`](@ref) that carries only the step length and the
+[`LinesearchOutcome`](@ref); the remaining diagnostics are filled with `NaN`/zero. Used by
+the generic fallback of [`solve_with_status`](@ref) for methods that do not report them.
+"""
+LinesearchStatus(α::T, outcome::LinesearchOutcome=LINESEARCH_UNKNOWN) where {T} =
+    LinesearchStatus{T}(α, outcome, 0, T(NaN), T(NaN), T(NaN), zero(T), zero(T))
+
+"""
+    steplength(status)
+
+The step length stored in `status::`[`LinesearchStatus`](@ref), i.e. what [`solve`](@ref)
+returns.
+"""
+steplength(status::LinesearchStatus) = status.α
+
+"""
+    outcome(status)
+
+The [`LinesearchOutcome`](@ref) stored in `status::`[`LinesearchStatus`](@ref).
+"""
+outcome(status::LinesearchStatus) = status.outcome
+
+"""
+    trials(status)
+
+The number of trial steps at which the merit was evaluated, stored in
+`status::`[`LinesearchStatus`](@ref).
+"""
+trials(status::LinesearchStatus) = status.trials
+
+"""
+    issufficient(status)
+
+`true` if the line search found a step with a *genuine* sufficient decrease, i.e. one that
+decreased the merit by more than the round-off allowance `τ` of `status`. Compare
+[`isfloor`](@ref).
+"""
+issufficient(status::LinesearchStatus) = outcome(status) === LINESEARCH_DECREASED
+
+"""
+    isfloor(status)
+
+`true` if the line search could not find *any* step that changes the merit by more than the
+round-off allowance `τ`, i.e. the merit has reached its round-off floor. The outer iteration
+cannot make progress in this state no matter how the step is chosen — which is why a
+[`NonlinearSolver`](@ref) counts it as a stalled step (see [`record_stall!`](@ref)).
+"""
+isfloor(status::LinesearchStatus) = outcome(status) === LINESEARCH_FLOOR
+
+Base.show(io::IO, s::LinesearchStatus) = print(io,
+    "LinesearchStatus: α = $(s.α), $(s.outcome) after $(s.trials) trial step(s) ",
+    "(φ(0) = $(s.φ₀), φ(α) = $(s.φ), φ'(0) = $(s.d₀), τ = $(s.τ), αmin = $(s.αmin)).")
+
+"""
+    solve_with_status(ls, α, params=NullParameters())
+
+Like [`solve`](@ref), but return a [`LinesearchStatus`](@ref) — the step length *plus* the
+reason the search stopped — and emit no log messages. Use [`linesearch_warnings`](@ref) to
+report the status.
+
+Only [`Backtracking`](@ref) reports a genuine [`LinesearchOutcome`](@ref); the generic
+fallback calls [`solve`](@ref) and reports `LINESEARCH_UNKNOWN`, so a caller may use
+`solve_with_status` uniformly for every [`LinesearchMethod`](@ref).
+"""
+solve_with_status(ls::Linesearch{T}, α::T, params=NullParameters()) where {T} =
+    LinesearchStatus(solve(ls, α, params))
+
+"""
+    curvature_diagnostic(status, ls, params)
+
+Method-specific extra diagnostic emitted by [`linesearch_warnings`](@ref) at
+`verbosity ≥ 2`. The fallback does nothing; [`Backtracking`](@ref) checks the
+[`CurvatureCondition`](@ref), which costs a derivative evaluation — a full
+[`Jacobian`](@ref) for the line search problem of a [`NonlinearSolver`](@ref), hence the
+verbosity gate.
+"""
+curvature_diagnostic(::LinesearchStatus, ::Linesearch, params) = nothing
+
+"""
+    linesearch_warnings(status, ls, params=NullParameters())
+
+Report a [`LinesearchStatus`](@ref) obtained from [`solve_with_status`](@ref). Compare this
+to [`nonlinear_solver_warnings`](@ref). This is the *only* place where a line search emits
+log messages, so [`solve`](@ref) and [`solver_step!`](@ref) report identically.
+
+Two things keep this quiet in normal use. `LINESEARCH_FLOOR` and `LINESEARCH_STATIONARY` are
+reported only at `verbosity ≥ 2`, because both are the *expected* final state of a converged
+solve — a residual that cannot be improved because it is already as small as the arithmetic
+allows. And the remaining outcomes are rate limited with `maxlog`, because a solve that cannot
+make progress asks the line search for an impossible decrease at every one of its iterations,
+which an unconditional warning turns into thousands of identical messages.
+
+Whether an irreducible merit actually *matters* is the outer iteration's call, and
+[`nonlinear_solver_warnings`](@ref) makes it: it reports stagnation once, naming the residual
+that was achieved and the tolerance that was requested.
+"""
+function linesearch_warnings(status::LinesearchStatus, ls::Linesearch, params=NullParameters())
+    verbose = config(ls).verbosity
+    name = nameof(typeof(method(ls)))
+
+    if outcome(status) === LINESEARCH_FLOOR
+        # Gated at `verbosity ≥ 2`, not 1: reaching the merit's round-off floor is the *normal*
+        # final state of a converged solve (the residual cannot be improved because it is
+        # already as small as the arithmetic allows), so warning about it at the default
+        # verbosity means warning about success. Whether the floor matters is the outer
+        # iteration's call, and it makes it: `record_stall!` counts a floor only while the
+        # residual is *not* small, and `nonlinear_solver_warnings` then reports it once, with
+        # the achieved residual and the requested tolerance.
+        verbose ≥ 2 && @warn "$(name) line search: no trial step changed the merit by more than the round-off allowance τ = $(status.τ) in $(trials(status)) trial step(s). φ(0) = $(status.φ₀) has reached its round-off floor, so no step can decrease it (the smallest informative step is αmin = $(status.αmin)). Returning α = $(steplength(status)). Check whether the requested residual tolerance is attainable in this precision." maxlog = 1
+    elseif outcome(status) === LINESEARCH_EXHAUSTED
+        reason = steplength(status) > status.αmin ?
+                 "the budget linesearch_max_iterations = $(config(ls).linesearch_max_iterations) was spent" :
+                 "the merit changed by $(status.φ - status.φ₀) at the smallest informative step αmin = $(status.αmin), which exceeds the round-off allowance τ = $(status.τ), so φ'(0) = $(status.d₀) is inconsistent with the merit (a stale or regularized Jacobian, an inexact linear solve, or a non-smooth problem)"
+        verbose ≥ 1 && @warn "$(name) line search: no step satisfied the sufficient decrease condition in $(trials(status)) trial step(s) — $(reason). Returning α = $(steplength(status))." maxlog = 3
+    elseif outcome(status) === LINESEARCH_NO_DESCENT
+        verbose ≥ 1 && @warn "$(name) line search: φ'(0) = $(status.d₀) (with φ(0) = $(status.φ₀)) is not a descent direction, so no α can satisfy the sufficient decrease condition. Returning α = $(steplength(status))." maxlog = 3
+    elseif outcome(status) === LINESEARCH_STATIONARY
+        verbose ≥ 2 && @warn "$(name) line search: φ'(0) = 0, the merit is stationary at α = 0. Returning α = $(steplength(status))."
+    end
+
+    verbose ≥ 2 && curvature_diagnostic(status, ls, params)
+
+    nothing
+end

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -4,9 +4,12 @@
 Why a [`LinesearchMethod`](@ref) stopped. Stored in a [`LinesearchStatus`](@ref), which is
 returned by [`solve_with_status`](@ref).
 
-- `LINESEARCH_DECREASED`: a step satisfying the [`SufficientDecreaseCondition`](@ref) with a
-  *genuine* decrease (more than the round-off allowance ``\tau``) was found. This is the only
-  outcome that reports progress.
+- `LINESEARCH_DECREASED`: a step was found that decreased the merit by more than the round-off
+  allowance ``\tau``. This is the only outcome that reports progress. Note what it does *not*
+  claim: [`Backtracking`](@ref) and [`StrongWolfe`](@ref) additionally verify their Wolfe
+  condition before returning, whereas the minimising searches ([`Bisection`](@ref),
+  [`Quadratic`](@ref), [`BierlaireQuadratic`](@ref)) approximate the line minimiser and never
+  test one. The common guarantee across all of them is the ``\tau``-exceeding decrease.
 - `LINESEARCH_FLOOR`: the merit has reached its round-off floor — no trial step changes it by
   more than ``\tau``, so *no* line search can make progress here. The returned step is the
   smallest informative one. This is not an error and is only reported at `verbosity ≥ 2`: it is
@@ -123,6 +126,42 @@ isfloor(status::LinesearchStatus) = outcome(status) === LINESEARCH_FLOOR
 Base.show(io::IO, s::LinesearchStatus) = print(io,
     "LinesearchStatus: α = $(s.α), $(s.outcome) after $(s.trials) trial step(s) ",
     "(φ(0) = $(s.φ₀), φ(α) = $(s.φ), φ'(0) = $(s.d₀), τ = $(s.τ), αmin = $(s.αmin)).")
+
+@doc raw"""
+    check_anchor(φ₀, d₀, α)
+
+Validate the ``\alpha = 0`` anchor of a line search problem. Return a
+[`LinesearchStatus`](@ref) that the caller should return *immediately*, or `nothing` if the
+anchor is usable and the search may proceed.
+
+This is the one definition of the anchor policy shared by every [`LinesearchMethod`](@ref):
+
+- ``\varphi(0)`` or ``\varphi'(0)`` not finite, or ``\varphi'(0) > 0``, gives
+  `LINESEARCH_NO_DESCENT`: no ``\alpha`` can decrease the merit along this direction, so
+  shrinking or bracketing would only spend merit evaluations to discover that. The caller's
+  trial step `α` is handed back — never the ``\alpha = 0`` anchor, which would freeze the outer
+  iterate (`x .+= 0 .* d`).
+- ``\varphi'(0) = 0`` gives `LINESEARCH_STATIONARY`. For the ``\|F\|^2`` merit of a
+  [`NonlinearSolver`](@ref) this *is* the exact root (``F = 0 \Rightarrow \varphi'(0) = 0`` and
+  the direction vanishes), so it is benign and every ``\alpha`` is equivalent.
+
+An ascent anchor arises in practice when the direction did not come from an exact, freshly
+factorized Newton solve — a stale [`Jacobian`](@ref) under `refactorize > 1`, a nonzero
+`regularization_factor`, or an inexact linear solve. The correct response is to refresh the
+Jacobian (see [`maybe_refactorize!`](@ref)), which is why the line search reports the situation
+instead of trying to salvage a step from it.
+"""
+function check_anchor(φ₀::T, d₀::T, α::T) where {T}
+    # A non-positive trial step is not a step the caller can be handed back, so substitute the
+    # unit step — the same convention `StrongWolfe` uses for its initial trial. This is what
+    # makes the α > 0 guarantee hold even when the caller passes α ≤ 0.
+    αout = α > zero(T) ? α : one(T)
+    if !isfinite(φ₀) || !isfinite(d₀) || d₀ > zero(T)
+        LinesearchStatus{T}(αout, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, zero(T), zero(T))
+    elseif iszero(d₀)
+        LinesearchStatus{T}(αout, LINESEARCH_STATIONARY, 0, φ₀, d₀, φ₀, zero(T), zero(T))
+    end
+end
 
 """
     solve_with_status(ls, α, params=NullParameters())

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -1,18 +1,4 @@
 """
-This constant is used for [`Quadratic`](@ref) and [`BierlaireQuadratic`](@ref) in double precision.
-
-In single precision we use [`MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH_SINGLE_PRECISION`](@ref).
-"""
-const MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH = 20
-
-"See [`MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH`](@ref)."
-const MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH_SINGLE_PRECISION = 5
-
-max_number_of_quadratic_linesearch_iterations(::Type{Float16}) = MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH_SINGLE_PRECISION
-max_number_of_quadratic_linesearch_iterations(::Type{Float32}) = MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH_SINGLE_PRECISION
-max_number_of_quadratic_linesearch_iterations(::Type{Float64}) = MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH
-
-"""
 A factor by which `s` is reduced in each bracketing iteration (see [`bracket_minimum_with_fixed_point`](@ref)).
 """
 const DEFAULT_s_REDUCTION = 0.5
@@ -26,7 +12,8 @@ p(α) = p_0 + p_1(\alpha - \alpha_0) + p_2(\alpha - \alpha_0)^2.
 ```
 Performs multiple iterations in which all parameters ``p_0``, ``p_1`` and ``p_2`` are adapted.
 We do not check the [`SufficientDecreaseCondition`](@ref) here. We instead repeatedly build new quadratic polynomials until a minimum is found (to sufficient accuracy).
-The iteration may also stop after it reaches the maximum number of iterations (see [`MAX_NUMBER_OF_ITERATIONS_FOR_QUADRATIC_LINESEARCH`](@ref)).
+The iteration may also stop after it reaches the maximum number of iterations, the
+`linesearch_max_iterations` field of [`Options`](@ref) (see [`linesearch_iterations`](@ref)).
 
 # Keywords
 
@@ -70,7 +57,7 @@ function solve(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters())
     α = (α₀ > zero(T) && derivative(problem(ls), α₀, params) < zero(T)) ? α₀ : zero(T)
     s = method(ls).s
 
-    for _ in 1:max_number_of_quadratic_linesearch_iterations(T)
+    for _ in 1:config(ls).linesearch_max_iterations
         # fit p(α) = p₀ + p₁(α - a) + p₂(α - a)² with p₀ = y₀, p₁ = d₀ and
         # p₂ = (y₁ - y₀ - d₀(b - a)) / (b - a)²; the endpoint merits y₀, y₁ come
         # from the bracketing, so no re-evaluation is needed here.

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -48,7 +48,48 @@ end
 
 Quadratic(::Type{T}, ::SolverMethod) where {T} = Quadratic(T)
 
-function solve(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters()) where {T}
+"""
+    solve(ls::Linesearch{T,<:Quadratic}, α, params)
+
+Fit successive quadratics to approximate the line minimiser, report the outcome through
+[`linesearch_warnings`](@ref) and return the step length. See [`Quadratic`](@ref) and
+[`solve_with_status`](@ref).
+"""
+function solve(ls::Linesearch{T,<:Quadratic}, α::T, params=NullParameters()) where {T}
+    status = solve_with_status(ls, α, params)
+    linesearch_warnings(status, ls, params)
+    steplength(status)
+end
+
+function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters()) where {T}
+    φ₀ = value(problem(ls), zero(T), params)
+    d₀anchor = derivative(problem(ls), zero(T), params)
+
+    anchor = check_anchor(φ₀, d₀anchor, α₀)
+    isnothing(anchor) || return anchor
+
+    τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
+    αres = _quadratic_search(ls, α₀, params)
+
+    # `bracket_minimum_with_fixed_point` flips direction when the merit rises to the right of
+    # the bracketing *start* — which is α₀, not 0 — so even a decreasing anchor can yield a
+    # bracket, and hence a minimiser, left of zero once α₀ overshoots. A negative step is not a
+    # meaningful step length along a direction (see the α > 0 contract), so retry once from the
+    # α = 0 anchor, which `check_anchor` has established is decreasing.
+    if isnothing(αres) || αres ≤ zero(T)
+        αres = _quadratic_search(ls, zero(T), params)
+    end
+    isnothing(αres) && return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, 0, φ₀, d₀anchor, φ₀, τ, zero(T))
+    αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_NO_DESCENT, 0, φ₀, d₀anchor, φ₀, τ, zero(T))
+
+    φres = value(problem(ls), αres, params)
+    LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
+        0, φ₀, d₀anchor, φres, τ, zero(T))
+end
+
+# The quadratic-fit iteration itself. Returns `nothing` if the merit cannot be bracketed.
+# Private: `solve`/`solve_with_status` is the public entry point.
+function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) where {T}
     # Start the bracketing at the caller's α₀ when it lies on the descent side
     # (φ′(α₀) < 0, so the minimiser is to its right); otherwise keep the α = 0 anchor,
     # where a descent direction is guaranteed decreasing. `bracket_minimum_with_fixed_point`
@@ -61,7 +102,10 @@ function solve(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters())
         # fit p(α) = p₀ + p₁(α - a) + p₂(α - a)² with p₀ = y₀, p₁ = d₀ and
         # p₂ = (y₁ - y₀ - d₀(b - a)) / (b - a)²; the endpoint merits y₀, y₁ come
         # from the bracketing, so no re-evaluation is needed here.
-        a, b, y₀, y₁ = bracket_minimum_with_fixed_point(problem(ls), params, α, s)
+        bracket = bracket_minimum_with_fixed_point(problem(ls), params, α, s)
+        # `nothing` means the merit could not be bracketed from here (see `bracket_minimum`).
+        isnothing(bracket) && return nothing
+        a, b, y₀, y₁ = bracket
         d₀ = derivative(problem(ls), a, params)
         # `d₀` is the derivative at the bracket's left endpoint `a`; return that point
         # (not the loop's start `α`), which differ when the bracketer flipped because

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -68,7 +68,7 @@ function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullP
     anchor = check_anchor(φ₀, d₀, α₀)
     isnothing(anchor) || return anchor
 
-    τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
+    τ = armijo_tolerance(φ₀, armijo_ulps(T))
     αres, n = _quadratic_search(ls, α₀, params)
 
     # `bracket_minimum_with_fixed_point` flips direction when the merit rises to the right of

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -63,13 +63,13 @@ end
 
 function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters()) where {T}
     φ₀ = value(problem(ls), zero(T), params)
-    d₀anchor = derivative(problem(ls), zero(T), params)
+    d₀ = derivative(problem(ls), zero(T), params)
 
-    anchor = check_anchor(φ₀, d₀anchor, α₀)
+    anchor = check_anchor(φ₀, d₀, α₀)
     isnothing(anchor) || return anchor
 
     τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
-    αres = _quadratic_search(ls, α₀, params)
+    αres, n = _quadratic_search(ls, α₀, params)
 
     # `bracket_minimum_with_fixed_point` flips direction when the merit rises to the right of
     # the bracketing *start* — which is α₀, not 0 — so even a decreasing anchor can yield a
@@ -77,19 +77,27 @@ function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullP
     # meaningful step length along a direction (see the α > 0 contract), so retry once from the
     # α = 0 anchor, which `check_anchor` has established is decreasing.
     if isnothing(αres) || αres ≤ zero(T)
-        αres = _quadratic_search(ls, zero(T), params)
+        αres, nretry = _quadratic_search(ls, zero(T), params)
+        n += nretry
     end
-    isnothing(αres) && return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, 0, φ₀, d₀anchor, φ₀, τ, zero(T))
-    αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_NO_DESCENT, 0, φ₀, d₀anchor, φ₀, τ, zero(T))
+    # `bracket_minimum_with_fixed_point` fails only by exhausting `nmax` in both directions, i.e.
+    # for a merit that keeps decreasing. That is a failure to *report*, not a round-off floor:
+    # reporting a floor would make the outer iteration count a descending merit as stagnation.
+    isnothing(αres) && return LinesearchStatus{T}(α₀, LINESEARCH_EXHAUSTED, n, φ₀, d₀, φ₀, τ, zero(T))
+    # Still non-positive: no positive step improves the merit as far as this search can tell,
+    # which is the floor — `check_anchor` established above that the anchor itself descends.
+    αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, n, φ₀, d₀, φ₀, τ, zero(T))
 
     φres = value(problem(ls), αres, params)
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
-        0, φ₀, d₀anchor, φres, τ, zero(T))
+        n, φ₀, d₀, φres, τ, zero(T))
 end
 
-# The quadratic-fit iteration itself. Returns `nothing` if the merit cannot be bracketed.
+# The quadratic-fit iteration itself. Returns `(α, n)` with `n` the number of merit evaluations,
+# or `(nothing, n)` if the merit cannot be bracketed.
 # Private: `solve`/`solve_with_status` is the public entry point.
 function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) where {T}
+    n = 0
     # Start the bracketing at the caller's α₀ when it lies on the descent side
     # (φ′(α₀) < 0, so the minimiser is to its right); otherwise keep the α = 0 anchor,
     # where a descent direction is guaranteed decreasing. `bracket_minimum_with_fixed_point`
@@ -104,13 +112,14 @@ function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) wher
         # from the bracketing, so no re-evaluation is needed here.
         bracket = bracket_minimum_with_fixed_point(problem(ls), params, α, s)
         # `nothing` means the merit could not be bracketed from here (see `bracket_minimum`).
-        isnothing(bracket) && return nothing
+        isnothing(bracket) && return (nothing, n)
         a, b, y₀, y₁ = bracket
+        n += 2   # this round of the fit; the bracketer’s own evaluations are not counted
         d₀ = derivative(problem(ls), a, params)
         # `d₀` is the derivative at the bracket's left endpoint `a`; return that point
         # (not the loop's start `α`), which differ when the bracketer flipped because
         # the start was not on the descent side.
-        abs(d₀) < method(ls).ε && return a
+        abs(d₀) < method(ls).ε && return (a, n)
 
         # minimizer αₜ = a - p₁ / (2p₂); guard on the fitted curvature (denom = 2p₂(b-a)²).
         # A non-positive curvature (denom ≤ 0), a non-finite αₜ, or a minimizer outside
@@ -119,13 +128,13 @@ function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) wher
         αₜ = denom > zero(T) ? a - d₀ * (b - a)^2 / denom : (a + b) / 2
         (isfinite(αₜ) && a ≤ αₜ ≤ b) || (αₜ = (a + b) / 2)
 
-        (l2norm(αₜ - α) < method(ls).ε) && return αₜ
+        (l2norm(αₜ - α) < method(ls).ε) && return (αₜ, n)
 
         α = αₜ
         s *= method(ls).s_reduction
     end
 
-    α
+    (α, n)
 end
 
 Base.show(io::IO, ls::Quadratic) = print(io, "Quadratic Polynomial with ε = $(ls.ε), s = $(ls.s) and s_reduction = $(ls.s_reduction).")

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -79,7 +79,7 @@ function solve(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params,
     # Iterate rather than recurse: the depth is bounded by the iteration
     # maximum either way, but a loop keeps the stack flat and lets the
     # triple (a, b, c) and its values persist across rounds.
-    for _ in iteration_number:(max_number_of_quadratic_linesearch_iterations(T) - 1)
+    for _ in iteration_number:(config(ls).linesearch_max_iterations - 1)
         # The denominator vanishes when the three points are (nearly) collinear, i.e.
         # the quadratic fit is degenerate and χ becomes Inf/NaN or falls outside the
         # bracket.  Guard on the *result* (finite and inside [a, c]) rather than a

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -65,7 +65,10 @@ end
 
 BierlaireQuadratic(::Type{T}, ::SolverMethod) where {T} = BierlaireQuadratic(T)
 
-function solve(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params, iteration_number::Integer) where {T}
+# Run the three-point quadratic fit on a known bracket `a < b < c`. Returns `(b, f(b))` — the
+# merit value is carried by the loop anyway, so the caller can classify the outcome without a
+# further evaluation. Private: `solve`/`solve_with_status` is the public entry point.
+function _bierlaire_fit(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params, τ::T) where {T}
     f = x -> problem(ls).F(x, params)
     ε = method(ls).ε
     # Evaluate f once per point and reuse: the fit, the χ comparison and the
@@ -79,7 +82,11 @@ function solve(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params,
     # Iterate rather than recurse: the depth is bounded by the iteration
     # maximum either way, but a loop keeps the stack flat and lets the
     # triple (a, b, c) and its values persist across rounds.
-    for _ in iteration_number:(config(ls).linesearch_max_iterations - 1)
+    # Width of the bracket, tracked so that a non-contracting iteration can be detected. Without
+    # this the loop can sit on a single point until the budget runs out — see the comment on the
+    # bisection fallback below.
+    width = c - a
+    for _ in 1:(config(ls).linesearch_max_iterations - 1)
         # The denominator vanishes when the three points are (nearly) collinear, i.e.
         # the quadratic fit is degenerate and χ becomes Inf/NaN or falls outside the
         # bracket.  Guard on the *result* (finite and inside [a, c]) rather than a
@@ -93,6 +100,18 @@ function solve(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params,
         # absolute tolerance so the perturbation only fires when χ is essentially at b
         # (the former `b == χ` only caught exact equality, missing floating-point ties)
         χ = isapprox(b, χ; atol=ε) ? shift_χ_to_avoid_stalling(χ, a, b, c, ε) : χ
+        # `shift_χ_to_avoid_stalling` is not sufficient to guarantee progress. If χ coincides
+        # with a bracket point the update below cannot narrow the bracket: for χ == b both
+        # branch tests are false (it is the same point, so the merits are identical), so the
+        # triple becomes `c ← b`, `b ← b`, collapsing to `c == b` with `a` untouched. The next
+        # fit then has two coincident points, `den == 0`, and the `(a + c)/2` fallback plus the
+        # shift map straight back onto `b` — an iteration that never contracts and therefore
+        # never satisfies the convergence test, spinning to `linesearch_max_iterations`.
+        # Bisecting the wider sub-interval instead makes `c - a` strictly decrease every
+        # iteration, bounding the loop at O(log₂((c - a)/ε)) regardless of the merit's scale.
+        if χ == a || χ == b || χ == c
+            χ = (c - b) > (b - a) ? (b + c) / 2 : (a + b) / 2
+        end
         fχ = f(χ)
         # Carry the function values of the updated triple alongside the points, so the
         # termination check needs no further evaluations.
@@ -111,26 +130,68 @@ function solve(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params,
                 b, fb = χ, fχ
             end
         end
-        ((c - a) ≤ ε) && ((fa - fb) ≤ ε) && ((fc - fb) ≤ ε) && return b
+        # The bracket width is an α-space quantity, so an absolute `ε` is dimensionally right
+        # (α is a step-length fraction of order one). The merit differences are *not*: they
+        # scale with φ(0), so they are compared against the shared round-off allowance τ
+        # instead of against ε. Previously one absolute constant governed all three.
+        ((c - a) ≤ ε) && ((fa - fb) ≤ τ) && ((fc - fb) ≤ τ) && return (b, fb)
+
+        # The bisection fallback above guarantees contraction, so a width that fails to shrink
+        # means the bracket is already at the resolution of the arithmetic: nothing further can
+        # be resolved and continuing would only repeat the same point.
+        newwidth = c - a
+        newwidth < width || return (b, fb)
+        width = newwidth
     end
-    config(ls).verbosity ≥ 2 && @warn "Maximum number of iterations was reached."
-    b
+    (b, fb)
 end
 
-function solve(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, params, iteration_number::Integer) where {T}
-    # check if the minimum has already been reached
-    !(l2norm(derivative(problem(ls), α₀, params)) < method(ls).ξ) || return α₀
-    solve(ls, triple_point_finder(problem(ls), params, α₀)..., params, iteration_number)
+"""
+    solve(ls::Linesearch{T,<:BierlaireQuadratic}, α, params)
+
+Fit successive quadratics through three bracketing points to approximate the line minimiser,
+report the outcome through [`linesearch_warnings`](@ref) and return the step length. See
+[`BierlaireQuadratic`](@ref) and [`solve_with_status`](@ref).
+"""
+function solve(ls::Linesearch{T,<:BierlaireQuadratic}, α::T, params=NullParameters()) where {T}
+    status = solve_with_status(ls, α, params)
+    linesearch_warnings(status, ls, params)
+    steplength(status)
 end
 
-function solve(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, params=NullParameters()) where {T}
+function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, params=NullParameters()) where {T}
+    prob = problem(ls)
+    φ₀ = value(prob, zero(T), params)
+    d₀ = derivative(prob, zero(T), params)
+
+    # `triple_point_finder` searches rightward only and requires a decreasing merit at its
+    # start, so unlike the other bracketing searches it cannot recover from an ascent anchor by
+    # flipping. Checking the anchor here is what keeps it from being handed an impossible
+    # problem — the α = 0 anchor is *not* guaranteed decreasing when the direction came from a
+    # stale or regularized Jacobian.
+    anchor = check_anchor(φ₀, d₀, α₀)
+    isnothing(anchor) || return anchor
+
+    τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
+
+    # Near-stationarity shortcut: the minimum along this direction has already been reached.
+    l2norm(derivative(prob, α₀, params)) < method(ls).ξ &&
+        return LinesearchStatus{T}(α₀, LINESEARCH_STATIONARY, 0, φ₀, d₀, φ₀, τ, zero(T))
+
     # Start triple-point bracketing at the caller's α₀ when it lies on the descent side
-    # (φ′(α₀) < 0, so the minimiser is to its right). `triple_point_finder` only searches
-    # rightward and requires a decreasing merit at its start, so otherwise fall back to
-    # the α = 0 anchor, where a descent direction is guaranteed decreasing (starting at an
-    # α₀ past the minimiser would otherwise error). See issue #164.
-    start = (α₀ > zero(T) && derivative(problem(ls), α₀, params) < zero(T)) ? α₀ : zero(T)
-    solve(ls, start, params, 1)
+    # (φ′(α₀) < 0, so the minimiser is to its right), otherwise at the α = 0 anchor, which
+    # `check_anchor` has established is decreasing. See issue #164.
+    start = (α₀ > zero(T) && derivative(prob, α₀, params) < zero(T)) ? α₀ : zero(T)
+    triple = triple_point_finder(prob, params, start)
+    # `nothing` means the merit does not resolve a decrease from here (see
+    # `triple_point_finder`): no line search can improve on this point.
+    isnothing(triple) && return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, 0, φ₀, d₀, φ₀, τ, zero(T))
+
+    αres, φres = _bierlaire_fit(ls, triple..., params, τ)
+    αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, τ, zero(T))
+
+    LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
+        0, φ₀, d₀, φres, τ, zero(T))
 end
 
 

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -174,7 +174,7 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     anchor = check_anchor(φ₀, d₀, α₀)
     isnothing(anchor) || return anchor
 
-    τ = armijo_tolerance(φ₀, T(DEFAULT_ARMIJO_τ_ULPS))
+    τ = armijo_tolerance(φ₀, armijo_ulps(T))
 
     # Near-stationarity shortcut: the minimum along this direction has already been reached.
     l2norm(derivative(prob, α₀, params)) < method(ls).ξ &&

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -65,11 +65,13 @@ end
 
 BierlaireQuadratic(::Type{T}, ::SolverMethod) where {T} = BierlaireQuadratic(T)
 
-# Run the three-point quadratic fit on a known bracket `a < b < c`. Returns `(b, f(b))` — the
+# Run the three-point quadratic fit on a known bracket `a < b < c`. Returns `(b, f(b), n)` — the
 # merit value is carried by the loop anyway, so the caller can classify the outcome without a
-# further evaluation. Private: `solve`/`solve_with_status` is the public entry point.
+# further evaluation, and `n` is the number of merit evaluations, reported as the `trials` of the
+# resulting `LinesearchStatus`. Private: `solve`/`solve_with_status` is the public entry point.
 function _bierlaire_fit(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T, params, τ::T) where {T}
-    f = x -> problem(ls).F(x, params)
+    n = 0
+    f = x -> (n += 1; problem(ls).F(x, params))
     ε = method(ls).ε
     # Evaluate f once per point and reuse: the fit, the χ comparison and the
     # termination check below all need the same values.  The triple updates carry
@@ -134,16 +136,16 @@ function _bierlaire_fit(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T
         # (α is a step-length fraction of order one). The merit differences are *not*: they
         # scale with φ(0), so they are compared against the shared round-off allowance τ
         # instead of against ε. Previously one absolute constant governed all three.
-        ((c - a) ≤ ε) && ((fa - fb) ≤ τ) && ((fc - fb) ≤ τ) && return (b, fb)
+        ((c - a) ≤ ε) && ((fa - fb) ≤ τ) && ((fc - fb) ≤ τ) && return (b, fb, n)
 
         # The bisection fallback above guarantees contraction, so a width that fails to shrink
         # means the bracket is already at the resolution of the arithmetic: nothing further can
         # be resolved and continuing would only repeat the same point.
         newwidth = c - a
-        newwidth < width || return (b, fb)
+        newwidth < width || return (b, fb, n)
         width = newwidth
     end
-    (b, fb)
+    (b, fb, n)
 end
 
 """
@@ -183,15 +185,24 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     # `check_anchor` has established is decreasing. See issue #164.
     start = (α₀ > zero(T) && derivative(prob, α₀, params) < zero(T)) ? α₀ : zero(T)
     triple = triple_point_finder(prob, params, start)
-    # `nothing` means the merit does not resolve a decrease from here (see
-    # `triple_point_finder`): no line search can improve on this point.
-    isnothing(triple) && return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, 0, φ₀, d₀, φ₀, τ, zero(T))
+    # The two failures of `triple_point_finder` mean opposite things and must not be conflated:
+    # `:flat` says the merit does not resolve a decrease from here, so no line search can improve
+    # on this point (a floor, which the outer iteration counts as a stalled step), while
+    # `:unbracketable` says there *is* a decrease that could not be bracketed — reporting that as
+    # a floor would count a descending merit as stagnation.
+    if triple isa Symbol
+        oc = triple === :flat ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
+        return LinesearchStatus{T}(α₀, oc, 0, φ₀, d₀, φ₀, τ, zero(T))
+    end
 
-    αres, φres = _bierlaire_fit(ls, triple..., params, τ)
-    αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, τ, zero(T))
+    αres, φres, n = _bierlaire_fit(ls, triple..., params, τ)
+    # The fit works inside a bracket whose left end is ≥ 0, so a non-positive result means the
+    # arithmetic collapsed rather than that the anchor ascends (`check_anchor` ruled that out):
+    # no positive step improves the merit as far as this search can tell, which is the floor.
+    αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, n, φ₀, d₀, φ₀, τ, zero(T))
 
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
-        0, φ₀, d₀, φres, τ, zero(T))
+        n, φ₀, d₀, φres, τ, zero(T))
 end
 
 

--- a/src/linesearch/static.jl
+++ b/src/linesearch/static.jl
@@ -29,6 +29,14 @@ function solve(ls::Linesearch{T,<:Static}, α::T, params=NullParameters()) where
     method(ls).α
 end
 
+# `Static` ignores the caller's trial step and cannot fail, so it has nothing to report; the
+# outcome is `LINESEARCH_UNKNOWN` rather than `LINESEARCH_DECREASED` because no merit is ever
+# evaluated and hence no decrease has been established. It implements `solve_with_status`
+# anyway so that every built-in method goes through the same entry point (see
+# `solve_with_status`).
+solve_with_status(ls::Linesearch{T,<:Static}, α::T, params=NullParameters()) where {T} =
+    LinesearchStatus(method(ls).α, LINESEARCH_UNKNOWN)
+
 Base.show(io::IO, alg::Static) = print(io, "Static with α = " * string(alg.α) * ".")
 
 function change_precision(::Type{T}, method::Static) where {T}

--- a/src/linesearch/sufficient_decrease_condition.jl
+++ b/src/linesearch/sufficient_decrease_condition.jl
@@ -27,22 +27,42 @@ sdc(1.9), sdc(2.)
 
 We call the constant that pertains to the sufficient decrease condition ``c``. This is typically called ``c_1`` in the literature [nocedal2006numerical](@cite).
 See [`DEFAULT_WOLFE_c₁`](@ref) for the relevant constant
+
+The optional keyword `τ` slackens the condition by an absolute amount:
+```math
+f(\alpha) \leq f_0 + c\alpha{}d_0 + \tau.
+```
+It defaults to zero, i.e. the exact condition. Without it the accept/reject decision is
+taken by *rounding alone* as soon as ``c\alpha|d_0|`` drops below one unit in the last place
+of ``f_0``: the right-hand side then rounds back up to ``f_0`` and the test degenerates to
+``f(\alpha) \leq f_0``, which a merit that has reached its round-off floor passes or fails at
+random. See [`armijo_tolerance`](@ref) and [`backtracking_αmin`](@ref) for how
+[`Backtracking`](@ref) chooses ``\tau`` and derives a *meaningful* smallest step from it.
 """
 struct SufficientDecreaseCondition{T,FT} <: BacktrackingCondition{T}
     c::T
     f₀::T
     d₀::T
+    τ::T
 
     F::FT
 
-    function SufficientDecreaseCondition(c::Tc, f₀::T, d₀::T, F::FT) where {Tc<:Number,T<:Number,FT<:Callable}
+    function SufficientDecreaseCondition(c::Tc, f₀::T, d₀::T, F::FT; τ::T=zero(T)) where {Tc<:Number,T<:Number,FT<:Callable}
         @assert T == Tc "You are computing with mixed precision ($(T) and $(Tc)). This is probably not intended (and not supported)."
         @assert !isnan(f₀) "f₀ is NaN"
         @assert !isnan(d₀) "d₀ is NaN"
-        new{T,FT}(c, f₀, d₀, F)
+        @assert τ ≥ zero(T) "The round-off allowance τ has to be nonnegative, it is $(τ)."
+        new{T,FT}(c, f₀, d₀, τ, F)
     end
 end
 
+# The two-argument form takes a merit value `fα = F(α)` that the caller has already
+# computed, so a backtracking loop that needs `f(α)` for its interpolation model does not
+# pay for a second (possibly very expensive) evaluation of the merit.
+function (sdc::SufficientDecreaseCondition{T})(α::T, fα::T) where {T}
+    fα ≤ sdc.f₀ + sdc.c * α * sdc.d₀ + sdc.τ
+end
+
 function (sdc::SufficientDecreaseCondition{T})(α::T) where {T}
-    sdc.F(α) ≤ sdc.f₀ + sdc.c * α * sdc.d₀
+    sdc(α, sdc.F(α))
 end

--- a/src/linesearch/sufficient_decrease_condition.jl
+++ b/src/linesearch/sufficient_decrease_condition.jl
@@ -30,7 +30,7 @@ See [`DEFAULT_WOLFE_c₁`](@ref) for the relevant constant
 
 The optional keyword `τ` slackens the condition by an absolute amount:
 ```math
-f(\alpha) \leq f_0 + c\alpha{}d_0 + \tau.
+f(\alpha) \leq \min\{f_0,\ f_0 + c\alpha{}d_0 + \tau\}.
 ```
 It defaults to zero, i.e. the exact condition. Without it the accept/reject decision is
 taken by *rounding alone* as soon as ``c\alpha|d_0|`` drops below one unit in the last place
@@ -38,6 +38,12 @@ of ``f_0``: the right-hand side then rounds back up to ``f_0`` and the test dege
 ``f(\alpha) \leq f_0``, which a merit that has reached its round-off floor passes or fails at
 random. See [`armijo_tolerance`](@ref) and [`backtracking_αmin`](@ref) for how
 [`Backtracking`](@ref) chooses ``\tau`` and derives a *meaningful* smallest step from it.
+
+The ``\min`` bounds the slackening: ``\tau`` may reduce the decrease that is *demanded*, but it
+never accepts a step whose merit exceeds ``f_0``. For ``d_0 < 0`` — which both callers guarantee
+via [`check_anchor`](@ref) — the ``\min`` is inactive wherever ``f_0 + c\alpha{}d_0`` is
+representably below ``f_0``, so it changes nothing in double precision; it matters at low
+precision, where ``\tau`` can exceed the demanded ``c\alpha|d_0|`` outright.
 """
 struct SufficientDecreaseCondition{T,FT} <: BacktrackingCondition{T}
     c::T
@@ -59,8 +65,16 @@ end
 # The two-argument form takes a merit value `fα = F(α)` that the caller has already
 # computed, so a backtracking loop that needs `f(α)` for its interpolation model does not
 # pay for a second (possibly very expensive) evaluation of the merit.
+#
+# The `min` against `f₀` is what keeps the round-off allowance honest. Since `d₀ < 0` (both
+# callers establish that through `check_anchor`), the model right-hand side `f₀ + cαd₀` lies
+# below `f₀` mathematically, so the `min` is a no-op and τ slackens the demanded decrease as
+# intended. It only binds where `fl(f₀ + cαd₀)` has *rounded up* to `f₀` — and there, adding τ
+# would accept a step whose merit is up to τ *above* `f₀`. That is negligible relative to the
+# demanded `2c₁f₀ ≈ 10⁻⁴` in double precision, but in `Float16` four ulps is `3.9·10⁻³`, i.e.
+# twenty times the demanded decrease, so the unbounded form licenses a visible uphill step.
 function (sdc::SufficientDecreaseCondition{T})(α::T, fα::T) where {T}
-    fα ≤ sdc.f₀ + sdc.c * α * sdc.d₀ + sdc.τ
+    fα ≤ min(sdc.f₀, sdc.f₀ + sdc.c * α * sdc.d₀ + sdc.τ)
 end
 
 function (sdc::SufficientDecreaseCondition{T})(α::T) where {T}

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -85,13 +85,17 @@ end
 # conditions are checked through the shared `sdc`/`cc` condition objects.
 function _wolfe_zoom(ls::Linesearch{T}, φ, dφ, sdc::SufficientDecreaseCondition{T}, cc::CurvatureCondition{T}, αlo::T, αhi::T, φlo::T) where {T}
     αj = αlo
+    n = 0
     for _ in 1:config(ls).linesearch_max_iterations
         αj = (αlo + αhi) / 2
         φj = φ(αj)
-        if !sdc(αj) || φj ≥ φlo
+        n += 1
+        # `sdc(αj, φj)` rather than `sdc(αj)`: the one-argument form would evaluate the merit a
+        # second time at the very point that was just evaluated, doubling the cost of the zoom.
+        if !sdc(αj, φj) || φj ≥ φlo
             αhi = αj
         else
-            cc(αj) && return αj
+            cc(αj) && return (αj, φj, n)
             dj = dφ(αj)
             if dj * (αhi - αlo) ≥ zero(T)
                 αhi = αlo
@@ -101,7 +105,9 @@ function _wolfe_zoom(ls::Linesearch{T}, φ, dφ, sdc::SufficientDecreaseConditio
         end
         isapprox(αhi, αlo; atol=eps(T)) && break
     end
-    αlo
+    # `φlo` tracks `αlo` through every update, so the merit at the returned step is known and the
+    # caller does not have to re-evaluate it.
+    (αlo, φlo, n)
 end
 
 """
@@ -161,7 +167,10 @@ function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullPa
     αprev = zero(T)
     φprev = φ0
     αi = clamp(α > zero(T) ? α : one(T), eps(T), αmax)
-    αvalid = αi   # last trial step that satisfied sufficient decrease
+    αvalid = αi   # last trial step that satisfied sufficient decrease, and its merit
+    # Seeded with the anchor merit so that a zero `linesearch_max_iterations` — the only way to
+    # reach the tail without having recorded a pair — reports the floor rather than a stale value.
+    φvalid = φ0
 
     # `n` counts the trial steps α > 0 at which the merit was evaluated, for the status.
     n = 0
@@ -170,26 +179,29 @@ function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullPa
     # the α = 0 anchor. Returning that would freeze the outer iterate (`x .+= 0 .* d`), so the
     # contract's α > 0 guarantee is enforced here: a non-positive result means no positive step
     # improved the merit, which is the round-off floor, and the caller's trial step is returned.
-    function wolfe_status(αres)
-        αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ0, d0, φ0, τ, zero(T))
-        φres = φ(αres)
+    # `φres` is always a merit the caller has already computed, never a fresh evaluation: for a
+    # `NonlinearSolver` that would be a full residual evaluation per solver step.
+    function wolfe_status(αres, φres, extra=0)
+        αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n + extra, φ0, d0, φ0, τ, zero(T))
         LinesearchStatus{T}(αres, φres ≤ φ0 - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
-            n, φ0, d0, φres, τ, zero(T))
+            n + extra, φ0, d0, φres, τ, zero(T))
     end
 
     for i in 1:config(ls).linesearch_max_iterations
         φi = φ(αi)
         n += 1
-        if !sdc(αi) || (i > 1 && φi ≥ φprev)
-            return wolfe_status(_wolfe_zoom(ls, φ, dφ, sdc, cc, αprev, αi, φprev))
+        # The two-argument `sdc` reuses `φi`; the one-argument form would evaluate the merit
+        # again at the same point.
+        if !sdc(αi, φi) || (i > 1 && φi ≥ φprev)
+            return wolfe_status(_wolfe_zoom(ls, φ, dφ, sdc, cc, αprev, αi, φprev)...)
         end
         # αi satisfies sufficient decrease from here on
-        cc(αi) && return wolfe_status(αi)
+        cc(αi) && return wolfe_status(αi, φi)
         di = dφ(αi)
         if di ≥ zero(T)
-            return wolfe_status(_wolfe_zoom(ls, φ, dφ, sdc, cc, αi, αprev, φi))
+            return wolfe_status(_wolfe_zoom(ls, φ, dφ, sdc, cc, αi, αprev, φi)...)
         end
-        αvalid = αi
+        αvalid, φvalid = αi, φi
         # ascend toward αmax; stop expanding once the cap is reached
         αi == αmax && break
         αprev = αi
@@ -202,5 +214,6 @@ function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullPa
     # curvature condition was never met, so this is reported as an exhausted search even though
     # the step itself is Armijo-acceptable.
     αvalid > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ0, d0, φ0, τ, zero(T))
-    LinesearchStatus{T}(αvalid, LINESEARCH_EXHAUSTED, n, φ0, d0, φ(αvalid), τ, zero(T))
+    # `φvalid` was recorded alongside `αvalid`, so reporting it costs no extra evaluation.
+    LinesearchStatus{T}(αvalid, LINESEARCH_EXHAUSTED, n, φ0, d0, φvalid, τ, zero(T))
 end

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -107,10 +107,17 @@ end
 """
     solve(ls::Linesearch{T,<:StrongWolfe}, α, params)
 
-Run the strong-Wolfe bracketing line search starting from the trial step `α`.
-See [`StrongWolfe`](@ref).
+Run the strong-Wolfe bracketing line search starting from the trial step `α`, report the
+outcome through [`linesearch_warnings`](@ref) and return the accepted step length.
+See [`StrongWolfe`](@ref) and [`solve_with_status`](@ref).
 """
 function solve(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) where {T}
+    status = solve_with_status(ls, α, params)
+    linesearch_warnings(status, ls, params)
+    steplength(status)
+end
+
+function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) where {T}
     m = method(ls)
     c₁ = m.c₁
     c₂ = m.c₂
@@ -136,14 +143,18 @@ function solve(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) 
     φ0 = φ(zero(T))
     d0 = dφ(zero(T))
 
-    # The strong Wolfe conditions are only meaningful for a descent direction.
-    if d0 ≥ zero(T)
-        config(ls).verbosity ≥ 1 && @warn "StrongWolfe: φ'(0) = $(d0) ≥ 0 is not a descent direction; returning α = $(α)."
-        return α
-    end
+    # The strong Wolfe conditions are only meaningful for a finite, decreasing anchor. The
+    # former test was `d0 ≥ zero(T)`, which a `NaN` derivative slips past (`NaN ≥ 0` is false)
+    # only to trip `SufficientDecreaseCondition`'s `@assert !isnan(d₀)` below and abort the
+    # enclosing solve; `check_anchor` covers the non-finite case too.
+    anchor = check_anchor(φ0, d0, α)
+    isnothing(anchor) || return anchor
 
     # The strong Wolfe conditions are the Armijo (sufficient decrease) condition
-    # plus the strong curvature condition.
+    # plus the strong curvature condition. `StrongWolfe` keeps the *exact* Armijo test (τ = 0
+    # inside `sdc`); τ is used only to classify the outcome, i.e. to tell a step that genuinely
+    # decreased the merit from one accepted where nothing can decrease it.
+    τ = armijo_tolerance(φ0, T(DEFAULT_ARMIJO_τ_ULPS))
     sdc = SufficientDecreaseCondition(c₁, φ0, d0, φ)
     cc = CurvatureCondition(c₂, d0, dφ, Val(:Strong))
 
@@ -152,16 +163,31 @@ function solve(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) 
     αi = clamp(α > zero(T) ? α : one(T), eps(T), αmax)
     αvalid = αi   # last trial step that satisfied sufficient decrease
 
+    # `n` counts the trial steps α > 0 at which the merit was evaluated, for the status.
+    n = 0
+    # `_wolfe_zoom` returns its `αlo`, which is seeded with `αprev = 0` on the first expansion
+    # round, so a merit that fails sufficient decrease immediately can drive the zoom to return
+    # the α = 0 anchor. Returning that would freeze the outer iterate (`x .+= 0 .* d`), so the
+    # contract's α > 0 guarantee is enforced here: a non-positive result means no positive step
+    # improved the merit, which is the round-off floor, and the caller's trial step is returned.
+    function wolfe_status(αres)
+        αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ0, d0, φ0, τ, zero(T))
+        φres = φ(αres)
+        LinesearchStatus{T}(αres, φres ≤ φ0 - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
+            n, φ0, d0, φres, τ, zero(T))
+    end
+
     for i in 1:config(ls).linesearch_max_iterations
         φi = φ(αi)
+        n += 1
         if !sdc(αi) || (i > 1 && φi ≥ φprev)
-            return _wolfe_zoom(ls, φ, dφ, sdc, cc, αprev, αi, φprev)
+            return wolfe_status(_wolfe_zoom(ls, φ, dφ, sdc, cc, αprev, αi, φprev))
         end
         # αi satisfies sufficient decrease from here on
-        cc(αi) && return αi
+        cc(αi) && return wolfe_status(αi)
         di = dφ(αi)
         if di ≥ zero(T)
-            return _wolfe_zoom(ls, φ, dφ, sdc, cc, αi, αprev, φi)
+            return wolfe_status(_wolfe_zoom(ls, φ, dφ, sdc, cc, αi, αprev, φi))
         end
         αvalid = αi
         # ascend toward αmax; stop expanding once the cap is reached
@@ -172,7 +198,9 @@ function solve(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) 
     end
 
     # Return the last trial step that satisfied sufficient decrease — never the
-    # freshly-doubled, unchecked `αi` from the expansion, and never the zero step.
-    config(ls).verbosity ≥ 1 && @warn "StrongWolfe: no step satisfying the strong Wolfe conditions found within (0, $(αmax)]; returning the last sufficient-decrease step α = $(αvalid)."
-    αvalid
+    # freshly-doubled, unchecked `αi` from the expansion, and never the zero step. The strong
+    # curvature condition was never met, so this is reported as an exhausted search even though
+    # the step itself is Armijo-acceptable.
+    αvalid > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ0, d0, φ0, τ, zero(T))
+    LinesearchStatus{T}(αvalid, LINESEARCH_EXHAUSTED, n, φ0, d0, φ(αvalid), τ, zero(T))
 end

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -160,7 +160,7 @@ function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullPa
     # plus the strong curvature condition. `StrongWolfe` keeps the *exact* Armijo test (τ = 0
     # inside `sdc`); τ is used only to classify the outcome, i.e. to tell a step that genuinely
     # decreased the merit from one accepted where nothing can decrease it.
-    τ = armijo_tolerance(φ0, T(DEFAULT_ARMIJO_τ_ULPS))
+    τ = armijo_tolerance(φ0, armijo_ulps(T))
     sdc = SufficientDecreaseCondition(c₁, φ0, d0, φ)
     cc = CurvatureCondition(c₂, d0, dφ, Val(:Strong))
 

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -85,7 +85,7 @@ end
 # conditions are checked through the shared `sdc`/`cc` condition objects.
 function _wolfe_zoom(ls::Linesearch{T}, φ, dφ, sdc::SufficientDecreaseCondition{T}, cc::CurvatureCondition{T}, αlo::T, αhi::T, φlo::T) where {T}
     αj = αlo
-    for _ in 1:config(ls).max_iterations
+    for _ in 1:config(ls).linesearch_max_iterations
         αj = (αlo + αhi) / 2
         φj = φ(αj)
         if !sdc(αj) || φj ≥ φlo
@@ -152,7 +152,7 @@ function solve(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) 
     αi = clamp(α > zero(T) ? α : one(T), eps(T), αmax)
     αvalid = αi   # last trial step that satisfied sufficient decrease
 
-    for i in 1:config(ls).max_iterations
+    for i in 1:config(ls).linesearch_max_iterations
         φi = φ(αi)
         if !sdc(αi) || (i > 1 && φi ≥ φprev)
             return _wolfe_zoom(ls, φ, dφ, sdc, cc, αprev, αi, φprev)

--- a/src/nonlinear/dogleg_solver.jl
+++ b/src/nonlinear/dogleg_solver.jl
@@ -274,13 +274,19 @@ function solver_step!(x::AbstractVector{T}, s::DogLegSolver{T}, state::Nonlinear
     x
 end
 
-function DogLegSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT; jacobian::Jacobian=JacobianAutodiff(nlp.F, x), refactorize::Integer=1, options_kwargs...) where {T,AT<:AbstractVector{T},NLST,LST,LSoT,LiSeT,CT}
-    config = Options(T; options_kwargs...)
-
+function DogLegSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT, config::Options{T}; jacobian::Jacobian=JacobianAutodiff(nlp.F, x), refactorize::Integer=1) where {T,AT<:AbstractVector{T},NLST,LST,LSoT,LiSeT<:Linesearch{T},CT}
     NonlinearSolver(x, nlp, ls, linearsolver, linesearch, cache, config; method=DogLeg(refactorize), jacobian=jacobian)
 end
 
-function DogLegSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; linear_solver_method=LU(), (DF!)=missing, jacobian=missing, kwargs...) where {T}
+# See the corresponding `NewtonSolver` method: the line search is rebuilt on the solver's
+# `Options` so that solver and line search cannot be configured inconsistently.
+function DogLegSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT; jacobian::Jacobian=JacobianAutodiff(nlp.F, x), refactorize::Integer=1, options_kwargs...) where {T,AT<:AbstractVector{T},NLST,LST,LSoT,LiSeT<:Linesearch{T},CT}
+    config = Options(T; options_kwargs...)
+    DogLegSolver(x, nlp, ls, linearsolver, with_config(linesearch, config), cache, config; jacobian=jacobian, refactorize=refactorize)
+end
+
+function DogLegSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; linear_solver_method=LU(), (DF!)=missing, jacobian=missing, refactorize=1, options_kwargs...) where {T}
+    config = Options(T; options_kwargs...)
     nlp = NonlinearProblem(F, DF!, x, y)
     jacobian = resolve_jacobian(F, DF!, jacobian, x, y)
     cache = DogLegCache(x, y)
@@ -290,8 +296,8 @@ function DogLegSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; l
     # search; the (structurally mandatory) `linesearch` field is filled with a trivial
     # `Static` step.  A `linesearch` keyword is deliberately not accepted — it would be
     # silently ignored (any stray keyword falls through to `Options` and errors there).
-    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), Static(one(T)))
-    DogLegSolver(x, nlp, linearproblem, linearsolver, ls, cache; jacobian=jacobian, kwargs...)
+    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), Static(one(T)), config)
+    DogLegSolver(x, nlp, linearproblem, linearsolver, ls, cache, config; jacobian=jacobian, refactorize=refactorize)
 end
 
 # Same pattern as the NewtonSolver/PicardSolver convenience form: `F` as a

--- a/src/nonlinear/dogleg_solver.jl
+++ b/src/nonlinear/dogleg_solver.jl
@@ -86,7 +86,7 @@ where ``\mathbf{J}`` is the Jacobian matrix and ``\mathbf{r}`` is the residual v
 
 The [`DogLegSolver`](@ref) then interpolates between these two directions (this interpolation is piecewise linear).
 
-As for the (quasi-)[`NewtonSolver`](@ref), the [`Jacobian`](@ref) is only re-evaluated and refactored every `refactorize` iterations (see [`DogLeg`](@ref)), and always on a fresh state or the first step (`iteration ≤ 1`), or when `force_refactorize = true` (used by [`solver_step!`](@ref) to recover from a collapsed trust-region radius). In between, the stale Jacobian and its factorization are reused for both directions. The default `refactorize = 1` refactorizes on every step.
+As for the (quasi-)[`NewtonSolver`](@ref), the [`Jacobian`](@ref) is only re-evaluated and refactored every `refactorize` iterations (see [`DogLeg`](@ref)), and always on a fresh state or the first step (`iteration ≤ 1`), or when `force_refactorize = true` (used by [`solver_step!`](@ref) to recover from a collapsed trust-region radius, and after any step that did not move the iterate — see [`needs_refresh`](@ref)). In between, the stale Jacobian and its factorization are reused for both directions. The default `refactorize = 1` refactorizes on every step.
 """
 function directions!(s::DogLegSolver{T}, x::AbstractVector{T}, params, iteration=1; force_refactorize::Bool=false) where {T}
     # the Newton direction
@@ -184,8 +184,12 @@ function solver_step!(x::AbstractVector{T}, s::DogLegSolver{T}, state::Nonlinear
     # again.  Without this, `while Δ > eps(T)` would never run, the iterate would
     # freeze, and the solve would silently spin to `max_iterations`.
     Δ = trust_radius(cache(s))
-    force_refresh = Δ ≤ eps(T)
-    force_refresh && (Δ = config(s).dogleg_radius_initial)
+    collapsed = Δ ≤ eps(T)
+    collapsed && (Δ = config(s).dogleg_radius_initial)
+
+    # A step that did not move the iterate for any other reason (`needs_refresh`) gets the same
+    # treatment: the Jacobian that produced the rejected step is the one to replace.
+    force_refresh = collapsed || needs_refresh(state)
 
     directions!(s, x, params, iteration_number(state); force_refactorize=force_refresh)
     any(isnan, direction₁(cache(s))) && throw(NonlinearSolverException("NaN detected in direction₁ vector"))

--- a/src/nonlinear/linesearch_problem.jl
+++ b/src/nonlinear/linesearch_problem.jl
@@ -12,6 +12,13 @@ search returns (e.g. the next `direction!` step and the convergence check), so
 writing trial iterates into them would be an aliasing hazard. The line search
 therefore only *reads* the current direction from the shared cache and the
 current iterate from `params.x`; every write goes to a closure-owned buffer.
+
+`params` may carry an optional `φ₀` field holding the merit at the ``\\alpha = 0``
+anchor. Every line search evaluates that anchor first, and it is exactly the residual
+the solver has *already* computed at the current iterate, so [`solver_step!`](@ref)
+passes it along and saves one `F` evaluation per solver step — the most expensive
+single operation for a large residual. A caller who drives `solver_step!` by hand from
+a state whose `value` is stale must not supply it.
 """
 function linesearch_problem(nlp::NonlinearProblem, jacobian::Jacobian{T}, cache::Union{NonlinearSolverCache{T},DogLegCache{T}}) where {T}
     # private scratch buffers for the line search (see the docstring for why)
@@ -20,6 +27,9 @@ function linesearch_problem(nlp::NonlinearProblem, jacobian::Jacobian{T}, cache:
     jₜ = zero(jacobianmatrix(cache))
 
     function f(α::Number, params)
+        # `haskey` on a `NamedTuple` is resolved at compile time, so the guard costs nothing
+        # and the closure stays usable with the bare `(x, parameters)` form.
+        (iszero(α) && haskey(params, :φ₀)) && return convert(T, params.φ₀)
         compute_new_iterate!(xₜ, params.x, α, direction(cache))
         value!(yₜ, nlp, xₜ, params.parameters)
         L2norm(yₜ)

--- a/src/nonlinear/newton_solver.jl
+++ b/src/nonlinear/newton_solver.jl
@@ -83,15 +83,24 @@ true
 """
 const NewtonSolver{T} = NonlinearSolver{T,Newton}
 
-function NewtonSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT; jacobian::Jacobian=JacobianAutodiff(nlp.F, x), refactorize::Integer=1, options_kwargs...) where {T,AT<:AbstractVector{T},NLST,LST,LSoT,LiSeT,CT}
-    config = Options(T; options_kwargs...)
-
+function NewtonSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT, config::Options{T}; jacobian::Jacobian=JacobianAutodiff(nlp.F, x), refactorize::Integer=1) where {T,AT<:AbstractVector{T},NLST,LST,LSoT,LiSeT<:Linesearch{T},CT}
     if refactorize > 1 && typeof(method(linesearch)) <: Static
-        config.verbosity ≥ 1 && (@warn "Static line search will not work with refactorize = $(refactorize). Setting refactorize = 1.")
+        verbosity(config) ≥ 1 && (@warn "Static line search will not work with refactorize = $(refactorize). Setting refactorize = 1.")
         refactorize = 1
     end
 
     NonlinearSolver(x, nlp, ls, linearsolver, linesearch, cache, config; method=Newton(refactorize), jacobian=jacobian)
+end
+
+# Backwards-compatible form that builds the `Options` from keywords.  The `linesearch` handed
+# in here was built with an `Options` of its own (`Linesearch(problem, method)` defaults it) —
+# precisely the plumbing defect this chain used to have, since the solver's `verbosity` and
+# `linesearch_max_iterations` then never reached the line search.  It is therefore rebuilt on
+# the solver's `Options` (see `with_config`): its problem and method are kept, only the
+# options are replaced.
+function NewtonSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT; jacobian::Jacobian=JacobianAutodiff(nlp.F, x), refactorize::Integer=1, options_kwargs...) where {T,AT<:AbstractVector{T},NLST,LST,LSoT,LiSeT<:Linesearch{T},CT}
+    config = Options(T; options_kwargs...)
+    NewtonSolver(x, nlp, ls, linearsolver, with_config(linesearch, config), cache, config; jacobian=jacobian, refactorize=refactorize)
 end
 
 """
@@ -105,14 +114,18 @@ end
 - `refactorize`
 - `options_kwargs`: see [`Options`](@ref)
 """
-function NewtonSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; linear_solver_method=LU(), (DF!)=missing, linesearch=Backtracking(T), jacobian=missing, refactorize=1, kwargs...) where {T}
+function NewtonSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; linear_solver_method=LU(), (DF!)=missing, linesearch=Backtracking(T), jacobian=missing, refactorize=1, options_kwargs...) where {T}
+    # The `Options` are built here, once, and shared by the solver *and* its line search, so
+    # that `NewtonSolver(…; verbosity = 0)` silences the line search too and the inner ladder
+    # is bounded by `linesearch_max_iterations` from the same place.
+    config = Options(T; options_kwargs...)
     nlp = NonlinearProblem(F, DF!, x, y)
     jacobian = resolve_jacobian(F, DF!, jacobian, x, y)
     cache = NonlinearSolverCache(x, y)
     linearproblem = LinearProblem(alloc_j(x, y))
     linearsolver = LinearSolver(linear_solver_method, y)
-    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), linesearch)
-    NewtonSolver(x, nlp, linearproblem, linearsolver, ls, cache; jacobian=jacobian, refactorize=refactorize, kwargs...)
+    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), linesearch, config)
+    NewtonSolver(x, nlp, linearproblem, linearsolver, ls, cache, config; jacobian=jacobian, refactorize=refactorize)
 end
 
 function NewtonSolver(x::AT, y::AT; F=missing, kwargs...) where {T,AT<:AbstractVector{T}}

--- a/src/nonlinear/newton_solver.jl
+++ b/src/nonlinear/newton_solver.jl
@@ -134,22 +134,23 @@ function NewtonSolver(x::AT, y::AT; F=missing, kwargs...) where {T,AT<:AbstractV
 end
 
 """
-    direction!(d, x, s, params, iteration)
+    direction!(d, x, s, params, iteration; stalled=false)
 
-Compute the Newton direction (for the [`NewtonSolver`](@ref)).
+Compute the Newton direction (for the [`NewtonSolver`](@ref)). `stalled` is forwarded to
+[`maybe_refactorize!`](@ref); see [`needs_refresh`](@ref).
 """
-function direction!(d::AbstractVector{T}, x::AbstractVector{T}, s::NewtonSolver{T}, params, iteration) where {T}
+function direction!(d::AbstractVector{T}, x::AbstractVector{T}, s::NewtonSolver{T}, params, iteration; stalled::Bool=false) where {T}
     # first we update the rhs of the linearproblem
     value!(rhs(linearproblem(s)), nonlinearproblem(s), x, params)
     rhs(linearproblem(s)) .*= -1
     # for a quasi-Newton method the Jacobian isn't updated in every iteration
-    # (see `maybe_refactorize!`).
-    maybe_refactorize!(s, x, params, iteration)
+    # (see `maybe_refactorize!`), unless the previous step stalled.
+    maybe_refactorize!(s, x, params, iteration; stalled=stalled)
     ldiv!(d, linearsolver(s), rhs(linearproblem(s)))
 end
 
-function direction!(s::NewtonSolver, x::AbstractVector, params, iteration)
-    direction!(direction(cache(s)), x, s, params, iteration)
+function direction!(s::NewtonSolver, x::AbstractVector, params, iteration; stalled::Bool=false)
+    direction!(direction(cache(s)), x, s, params, iteration; stalled=stalled)
 end
 
 # check_jacobian / print_jacobian operate on the Jacobian matrix, not the Jacobian

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -41,7 +41,9 @@ struct NonlinearSolver{T,MT<:NonlinearSolverMethod,NLST<:NonlinearProblem,LST<:A
     cache::CT
     config::Options{T}
 
-    function NonlinearSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT, config::Options{T}; method::MT=Newton(), jacobian::JT=JacobianAutodiff(nlp.F, x), options_kwargs...) where {T,AT<:AbstractVector{T},MT<:NonlinearSolverMethod,JT<:Jacobian{T},NLST<:NonlinearProblem,LST<:AbstractLinearProblem,LSoT<:AbstractLinearSolver,LiSeT<:Linesearch{T},CT<:AbstractNonlinearSolverCache{T}}
+    # No `options_kwargs...` here: the `Options` arrive ready-made as `config`, so a keyword
+    # sink would only swallow misspelled option names silently.
+    function NonlinearSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch::LiSeT, cache::CT, config::Options{T}; method::MT=Newton(), jacobian::JT=JacobianAutodiff(nlp.F, x)) where {T,AT<:AbstractVector{T},MT<:NonlinearSolverMethod,JT<:Jacobian{T},NLST<:NonlinearProblem,LST<:AbstractLinearProblem,LSoT<:AbstractLinearSolver,LiSeT<:Linesearch{T},CT<:AbstractNonlinearSolverCache{T}}
         new{T,MT,NLST,LST,JT,LSoT,LiSeT,CT}(nlp, ls, jacobian, linearsolver, linesearch, method, cache, config)
     end
 end
@@ -122,18 +124,28 @@ function resolve_jacobian(F, DF!, jacobian, x::AbstractVector{T}, y) where {T}
 end
 
 """
-    maybe_refactorize!(s, x, params, iteration; force=false)
+    maybe_refactorize!(s, x, params, iteration; force=false, stalled=false)
 
 Re-evaluate the [`Jacobian`](@ref) at `x`, copy it into the [`LinearProblem`](@ref)
 (adding the diagonal `regularization_factor`), and refactorize the
 [`LinearSolver`](@ref) — but only on a refactorization step: a fresh state or the
 first step (`iteration ≤ 1`), every `refactorize` iterations (see [`Newton`](@ref)),
-or when `force`d (used by the [`DogLegSolver`](@ref) to recover from a collapsed
+when the previous step made no progress (`stalled`, see [`needs_refresh`](@ref)), or
+when `force`d (used by the [`DogLegSolver`](@ref) to recover from a collapsed
 trust-region radius). Otherwise the stale Jacobian and its factorization are reused
 (quasi-Newton). Returns the solver `s`.
+
+`stalled` is what makes the quasi-Newton mode safe to combine with `max_stalls`: a step
+that did not move the iterate would otherwise rebuild the *same* direction from the same
+stale Jacobian on the next `refactorize - 1` iterations and reproduce the same negligible
+step, so the solve would be given up on (see [`stalled_step`](@ref)) for a reason a fresh
+Jacobian could have fixed. Refreshing immediately means the second consecutive stall is
+one that a fresh Jacobian did *not* fix, which is the conclusive evidence `max_stalls = 2`
+assumes. It is also the response [`check_anchor`](@ref) prescribes for an ascent anchor,
+which is a stale-Jacobian symptom.
 """
-function maybe_refactorize!(s::NonlinearSolver, x, params, iteration; force::Bool=false)
-    (force || mod(iteration, method(s).refactorize) == 0 || iteration ≤ 1) || return s
+function maybe_refactorize!(s::NonlinearSolver, x, params, iteration; force::Bool=false, stalled::Bool=false)
+    (force || stalled || mod(iteration, method(s).refactorize) == 0 || iteration ≤ 1) || return s
     jacobian!(s, x, params)
     lp = linearproblem(s)
     matrix(lp) .= jacobianmatrix(s)
@@ -197,7 +209,9 @@ julia> solver_step!(x, s, state, NullParameters())
 ```
 """
 function solver_step!(x::AbstractVector{T}, s::NonlinearSolver{T}, state::NonlinearSolverState{T}, params) where {T}
-    direction!(s, x, params, iteration_number(state))
+    # A previous step that made no progress gets a freshly evaluated Jacobian rather than the
+    # stale one that produced it (see `maybe_refactorize!`).
+    direction!(s, x, params, iteration_number(state); stalled=needs_refresh(state))
     any(isnan, direction(cache(s))) && throw(NonlinearSolverException("NaN detected in direction vector"))
 
     nan_recovery!(s, x, params)
@@ -207,9 +221,21 @@ function solver_step!(x::AbstractVector{T}, s::NonlinearSolver{T}, state::Nonlin
     lsparams = (x=x, parameters=params, φ₀=L2norm(value(state)))
     lsstatus = solve_with_status(linesearch(s), one(T), lsparams)
     linesearch_warnings(lsstatus, linesearch(s), lsparams)
-    # A line search that reports the merit's round-off floor knows the iteration cannot make
-    # progress here, one iteration before the step-based diagnosis of `stalled_step` sees it.
-    isfloor(lsstatus) && flag_stall!(state)
+
+    # A line search that reports the merit's round-off floor or a non-descent anchor knows the
+    # iteration cannot make progress along this direction, one iteration before the step-based
+    # diagnosis of `stalled_step` sees it. Recording it here forces a fresh Jacobian on the next
+    # step and gives up after `max_stalls` if that does not help.
+    nodescent = outcome(lsstatus) === LINESEARCH_NO_DESCENT
+    (isfloor(lsstatus) || nodescent) && flag_stall!(state)
+
+    # The step is not taken along a direction the line search has *rejected outright*: no α can
+    # decrease the merit along an ascent direction, so moving would only make the forced
+    # refactorization start from a worse point. (The `LINESEARCH_FLOOR` step *is* taken — it is
+    # the smallest informative one, and it is not an ascent direction.) The line search itself
+    # still returns α > 0 as its contract requires; whether to use it is the caller's call.
+    nodescent && return x
+
     compute_new_iterate!(x, steplength(lsstatus), direction(cache(s)))
 
     x
@@ -263,7 +289,7 @@ out of the solve.
 
 # Examples
 
-```jldoctest; setup = :(using SimpleSolvers)
+```jldoctest; setup = :(using SimpleSolvers; using SimpleSolvers: isconverged, status)
 julia> F(y, x, params) = y .= x .^ 2 .- 2;
 
 julia> x = [1.0]; s = NewtonSolver(x, similar(x); F = F, verbosity = 0);

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -202,8 +202,15 @@ function solver_step!(x::AbstractVector{T}, s::NonlinearSolver{T}, state::Nonlin
 
     nan_recovery!(s, x, params)
 
-    α = solve(linesearch(s), one(T), (x=x, parameters=params))
-    compute_new_iterate!(x, α, direction(cache(s)))
+    # `params.φ₀` hands the line search the merit at the α = 0 anchor, which the solver has
+    # just evaluated at the current iterate — see `linesearch_problem`.
+    lsparams = (x=x, parameters=params, φ₀=L2norm(value(state)))
+    lsstatus = solve_with_status(linesearch(s), one(T), lsparams)
+    linesearch_warnings(lsstatus, linesearch(s), lsparams)
+    # A line search that reports the merit's round-off floor knows the iteration cannot make
+    # progress here, one iteration before the step-based diagnosis of `stalled_step` sees it.
+    isfloor(lsstatus) && flag_stall!(state)
+    compute_new_iterate!(x, steplength(lsstatus), direction(cache(s)))
 
     x
 end
@@ -219,11 +226,20 @@ function solve!(x::AbstractArray, s::NonlinearSolver, state::NonlinearSolverStat
     initialize!(s, x)
     initialize!(state, x, value!(value(cache(s)), nonlinearproblem(s), x, params))
 
-    while true
+    # The stopping criteria are tested *before* the first step as well. An initial guess that
+    # already satisfies them must not be perturbed by a full solver step — including a line
+    # search asked to improve an already-exact residual, which is one source of the spurious
+    # "did not satisfy the sufficient decrease condition" warnings. Only the absolute branch is
+    # reachable at iteration 0: `rxₛ` and `rfₛ` are `NaN` until the first `update!` (see
+    # `initialize!`), so this fires exactly when ‖F(x₀)‖ ≤ f_abstol — for the default
+    # `f_abstol = 0` only at an exact root. A caller who insists on at least one iteration
+    # (`min_iterations ≥ 1`) still gets one, and a `NaN` initial residual still gets a step
+    # (the `havenan` branch requires `iterations ≥ 1`).
+    while !meets_stopping_criteria(state, config(s))
         increase_iteration_number!(state)
         solver_step!(x, s, state, params)
         update!(state, x, value!(value(cache(s)), nonlinearproblem(s), x, params))
-        meets_stopping_criteria(state, config(s)) && break
+        record_stall!(state, config(s))
     end
 
     status = NonlinearSolverStatus(state, config(s))
@@ -232,5 +248,34 @@ function solve!(x::AbstractArray, s::NonlinearSolver, state::NonlinearSolverStat
 
     x
 end
+
+"""
+    status(solver, state)
+
+Return the [`NonlinearSolverStatus`](@ref) for the [`NonlinearSolverState`](@ref) `state` as
+assessed with the [`Options`](@ref) of `solver`.
+
+[`solve!`](@ref) returns the solution `x` (updated in place), not a status, so this is how a
+caller inspects the *outcome* of a solve — in particular whether it converged
+([`isconverged`](@ref)) or merely stagnated at the residual floor ([`isstalled`](@ref)). The
+state is the caller's own object (it is passed to `solve!`), so nothing has to be threaded back
+out of the solve.
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers)
+julia> F(y, x, params) = y .= x .^ 2 .- 2;
+
+julia> x = [1.0]; s = NewtonSolver(x, similar(x); F = F, verbosity = 0);
+
+julia> state = SolverState(s);
+
+julia> solve!(x, s, state);
+
+julia> isconverged(status(s, state))
+true
+```
+"""
+status(s::NonlinearSolver, state::NonlinearSolverState) = NonlinearSolverStatus(state, config(s))
 
 solve!(x::AbstractArray, s::NonlinearSolver, params=NullParameters()) = solve!(x, s, NonlinearSolverState(x, value(cache(s))), params)

--- a/src/nonlinear/nonlinear_solver_state.jl
+++ b/src/nonlinear/nonlinear_solver_state.jl
@@ -10,7 +10,7 @@ The `NonlinearSolverState` to be used together with a [`NonlinearSolver`](@ref).
 
 ```jldoctest; setup = :(using SimpleSolvers)
 julia> state = NonlinearSolverState(zeros(3))
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], NaN)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], NaN, 0, false)
 ```
 """
 mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T}} <: AbstractSolverState
@@ -24,6 +24,13 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
     r₀::T   # the initial residual ‖F(x₀)‖, set by `initialize!`; reference scale
             # for the relative-residual convergence test (`NaN` until initialized)
 
+    stalls::Int      # number of *consecutive* stalled steps (a step that did not move the
+                     # iterate while the residual is not small); maintained by
+                     # `record_stall!`, consumed by `meets_stopping_criteria`
+    stallflag::Bool  # set by `flag_stall!` when the line search itself reported that the
+                     # merit cannot be decreased; OR-ed into the verdict of the next
+                     # `record_stall!`, which clears it again
+
     function NonlinearSolverState(X::AbstractVector{T}, Y::AbstractVector{T}=X) where {T}
         x = zero(X)
         x̄ = zero(X)
@@ -35,10 +42,17 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
         y .= T(NaN)
         ȳ .= T(NaN)
 
-        new{T,typeof(x),typeof(y)}(0, x, x̄, y, ȳ, T(NaN))
+        new{T,typeof(x),typeof(y)}(0, x, x̄, y, ȳ, T(NaN), 0, false)
     end
 end
 
+"""
+    iteration_number(state)
+
+Return the number of iterations taken so far, as counted by
+[`increase_iteration_number!`](@ref) on `state::`[`NonlinearSolverState`](@ref). Compare this
+to [`stall_number`](@ref).
+"""
 iteration_number(state::NonlinearSolverState) = state.iterations
 solution(state::NonlinearSolverState) = state.x
 value(state::NonlinearSolverState) = state.y
@@ -77,6 +91,35 @@ function initialize!(state::NonlinearSolverState{T}, x::AbstractVector{T}, y::Ab
     state.r₀ = l2norm(y)   # record the initial residual as the relative-convergence scale
     state.x̄ .= T(NaN)
     state.ȳ .= T(NaN)
+    state.stalls = 0
+    state.stallflag = false
+end
+
+"""
+    stall_number(state)
+
+Return the number of *consecutive* stalled steps recorded in
+`state::`[`NonlinearSolverState`](@ref) by [`record_stall!`](@ref). Compare this to
+[`iteration_number`](@ref).
+"""
+stall_number(state::NonlinearSolverState) = state.stalls
+
+"""
+    flag_stall!(state)
+
+Record that the line search of the current step reported that the merit cannot be decreased
+(see [`isfloor`](@ref)). The flag is OR-ed into the verdict of the next
+[`record_stall!`](@ref), which clears it again.
+
+This is how a line search that *knows* it is at the round-off floor reports one iteration
+earlier than the step-based diagnosis of [`stalled_step`](@ref) — which remains the primary
+mechanism, since it is the only one that also covers a [`Static`](@ref) step along an
+underflowed direction, a collapsed [`DogLegSolver`](@ref) trust-region radius, and a locally
+expanding [`PicardSolver`](@ref) map.
+"""
+function flag_stall!(state::NonlinearSolverState)
+    state.stallflag = true
+    state
 end
 
 """
@@ -99,10 +142,10 @@ julia> y = zero(x); f(y, x, NullParameters())
  0.06120871905481365
 
 julia> state = NonlinearSolverState(x)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN], [NaN], [NaN], [NaN], NaN)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN], [NaN], [NaN], [NaN], NaN, 0, false)
 
 julia> update!(state, x, y)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.25], [NaN], [0.06120871905481365], [NaN], NaN)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.25], [NaN], [0.06120871905481365], [NaN], NaN, 0, false)
 
 julia> x = ones(1) / 2
 1-element Vector{Float64}:
@@ -113,7 +156,7 @@ julia> f(y, x, NullParameters())
  0.0
 
 julia> update!(state, x, y)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.5], [0.25], [0.0], [0.06120871905481365], NaN)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.5], [0.25], [0.0], [0.06120871905481365], NaN, 0, false)
 ```
 
 The [`NonlinearSolverState`](@ref) stores the previous solution, the previous value, the current solution and the current value.

--- a/src/nonlinear/nonlinear_solver_state.jl
+++ b/src/nonlinear/nonlinear_solver_state.jl
@@ -107,20 +107,38 @@ stall_number(state::NonlinearSolverState) = state.stalls
 """
     flag_stall!(state)
 
-Record that the line search of the current step reported that the merit cannot be decreased
-(see [`isfloor`](@ref)). The flag is OR-ed into the verdict of the next
-[`record_stall!`](@ref), which clears it again.
+Record that the line search of the current step reported that it cannot make progress along
+the current direction — either the merit is at its round-off floor ([`isfloor`](@ref)) or the
+anchor is not a descent direction at all (`LINESEARCH_NO_DESCENT`, see
+[`LinesearchOutcome`](@ref)). The flag is OR-ed into the verdict of the next
+[`record_stall!`](@ref), which clears it again, and it makes [`needs_refresh`](@ref) true for
+the next step.
 
-This is how a line search that *knows* it is at the round-off floor reports one iteration
-earlier than the step-based diagnosis of [`stalled_step`](@ref) — which remains the primary
-mechanism, since it is the only one that also covers a [`Static`](@ref) step along an
-underflowed direction, a collapsed [`DogLegSolver`](@ref) trust-region radius, and a locally
-expanding [`PicardSolver`](@ref) map.
+This is how a line search that *knows* it cannot help reports one iteration earlier than the
+step-based diagnosis of [`stalled_step`](@ref) — which remains the primary mechanism, since it
+is the only one that also covers a [`Static`](@ref) step along an underflowed direction, a
+collapsed [`DogLegSolver`](@ref) trust-region radius, and a locally expanding
+[`PicardSolver`](@ref) map.
 """
 function flag_stall!(state::NonlinearSolverState)
     state.stallflag = true
     state
 end
+
+"""
+    needs_refresh(state)
+
+`true` when the previous step made no progress, i.e. when a stall has been flagged for the
+current step ([`flag_stall!`](@ref)) or the consecutive-stall counter is nonzero
+([`stall_number`](@ref)).
+
+[`solver_step!`](@ref) passes this to [`maybe_refactorize!`](@ref) as its `stalled` keyword, so
+a quasi-Newton solver rebuilds its [`Jacobian`](@ref) immediately after a step that did not
+move the iterate instead of waiting for the next `refactorize` multiple. Both sources are
+consulted because [`record_stall!`](@ref) consumes the flag into the counter once per
+iteration, and a caller who drives [`solver_step!`](@ref) by hand may never call it.
+"""
+needs_refresh(state::NonlinearSolverState) = state.stallflag || stall_number(state) > 0
 
 """
     update!(state, x, y)

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -8,12 +8,14 @@ Stores absolute and successive residuals for `x` and `f`. It is used as a diagno
 
 # Keys
 - `iterations`: number of iterations
+- `stalls`: number of *consecutive* stalled steps, see [`stalled_step`](@ref) and [`isstalled`](@ref),
 - `rxₛ`: successive residual in `x`,
 - `rfₐ`: absolute residual in `f`,
 - `rfₛ`: successive residual in `f`,
 - `x_converged::Bool`
 - `f_converged::Bool`
 - `f_increased::Bool`
+- `stalled::Bool`: the *last* step stalled, see [`stalled_step`](@ref)
 
 # Examples
 
@@ -34,6 +36,7 @@ rfₛ= NaN
 """
 struct NonlinearSolverStatus{T}
     iterations::Int
+    stalls::Int
 
     rxₛ::T
     rfₐ::T
@@ -42,6 +45,7 @@ struct NonlinearSolverStatus{T}
     x_converged::Bool
     f_converged::Bool
     f_increased::Bool
+    stalled::Bool
 end
 
 @doc raw"""
@@ -96,38 +100,134 @@ Also see [`meets_stopping_criteria`](@ref).
 """
 function assess_convergence(rxₛ::Number, rfₐ::Number, rfₛ::Number, config::Options, state::NonlinearSolverState)
     # The iterate/value has stopped changing (successive-change criteria).
-    x_settled = rxₛ ≤ norm(solution(state)) * config.x_suctol
+    x_settled = iterate_settled(rxₛ, config, state)
     f_settled = rfₛ ≤ norm(value(state)) * config.f_suctol
 
-    # The residual counts as small when it passes the standard `atol + rtol·‖F₀‖`
-    # residual test with `atol = f_abstol` and `rtol = f_reltol` (relative to the initial
-    # residual `‖F(x₀)‖`). This lets a large-magnitude / ill-conditioned solve converge
-    # once its residual is reduced by `f_reltol` from `‖F(x₀)‖`, while a step that stalls
-    # near `‖F(x₀)‖` still fails. The relative term drops to zero for an uninitialized
-    # state (`initial_residual` is `NaN`), leaving the pure absolute `f_abstol` test.
-    r₀ = initial_residual(state)
-    relative_residual = isnan(r₀) ? zero(rfₐ) : config.f_reltol * r₀
-    residual_small = rfₐ ≤ config.f_abstol + relative_residual
+    small = residual_small(rfₐ, config, state)
 
-    x_converged = x_settled && residual_small
-    f_converged = (f_settled && residual_small) || rfₐ ≤ config.f_abstol
+    x_converged = x_settled && small
+    f_converged = (f_settled && small) || rfₐ ≤ config.f_abstol
 
     f_increased = norm(value(state)) > norm(previousvalue(state))
 
-    x_converged, f_converged, f_increased
+    # The iterate froze without the residual becoming small: no progress is possible along
+    # the current direction. See `stalled_step`.
+    stalled = x_settled && !small
+
+    x_converged, f_converged, f_increased, stalled
+end
+
+@doc raw"""
+    residual_small(rfₐ, config, state)
+
+Return `true` when the absolute residual `rfₐ` passes the standard
+``\mathrm{atol} + \mathrm{rtol}\cdot\|F(x_0)\|`` residual test,
+
+```math
+r^f_a \leq \texttt{f\_abstol} + \texttt{f\_reltol}\cdot\|F(x_0)\|,
+```
+
+with ``\|F(x_0)\|`` the [`initial_residual`](@ref) of `state`. This lets a large-magnitude or
+ill-conditioned solve converge once its residual is reduced by `f_reltol` from
+``\|F(x_0)\|``, while a step that stalls near ``\|F(x_0)\|`` still fails. The relative term
+drops to zero until the state has been initialized (`initial_residual` is `NaN`), leaving the
+pure absolute `f_abstol` test.
+
+This gate is shared by [`assess_convergence`](@ref), which requires it *in addition* to a
+successive-change criterion, and by [`stalled_step`](@ref), which requires its *negation*: a
+frozen iterate is convergence when the residual is small and stagnation when it is not. The
+two are therefore mutually exclusive by construction.
+"""
+function residual_small(rfₐ::Number, config::Options, state::NonlinearSolverState)
+    r₀ = initial_residual(state)
+    relative_residual = isnan(r₀) ? zero(rfₐ) : config.f_reltol * r₀
+    rfₐ ≤ config.f_abstol + relative_residual
+end
+
+"""
+    iterate_settled(rxₛ, config, state)
+
+Return `true` when the last step did not move the iterate, `rxₛ ≤ ‖x‖·x_suctol`. Used by
+[`assess_convergence`](@ref) and [`stalled_step`](@ref).
+"""
+iterate_settled(rxₛ::Number, config::Options, state::NonlinearSolverState) =
+    rxₛ ≤ norm(solution(state)) * config.x_suctol
+
+@doc raw"""
+    stalled_step(rxₛ, rfₐ, config, state)
+
+Return `true` when the last step *stalled*: it left the iterate unchanged (see
+[`iterate_settled`](@ref)) while the residual is **not** small (see
+[`residual_small`](@ref)).
+
+A stalled step is the failure mode that the residual gate in [`assess_convergence`](@ref)
+correctly refuses to call convergence, and that used to be invisible to the solver. The step
+length ``\alpha\|d\|`` has dropped below the round-off level of ``x``, so the merit
+``\|F\|^2`` cannot be reduced along the current direction — typically because the requested
+`f_abstol` lies *below the round-off floor of the residual itself*. Taking another step
+recomputes the same direction and the same negligible ``\alpha``, so the iteration would spin
+all the way to `max_iterations`, asking the line search on every one of those steps to improve
+a residual that is already pure round-off noise.
+
+[`meets_stopping_criteria`](@ref) therefore stops after `config.max_stalls` *consecutive*
+stalled steps (counted by [`record_stall!`](@ref)), and
+[`nonlinear_solver_warnings`](@ref) reports the achieved residual against the requested
+tolerance instead of the misleading `"Solver took 1000 iterations."`.
+
+!!! info
+    The condition is deliberately phrased in terms of the step actually taken rather than a
+    line-search return code. It is the same diagnosis for a [`Backtracking`](@ref) ladder that
+    exhausted, a [`StrongWolfe`](@ref) search that found no acceptable step, a
+    [`Static`](@ref) step along an underflowed direction, a [`DogLegSolver`](@ref) whose
+    trust-region radius collapsed and a [`PicardSolver`](@ref) whose fixed-point map is
+    locally expanding. A line search that *knows* it is at the round-off floor can report one
+    iteration earlier via [`flag_stall!`](@ref).
+"""
+function stalled_step(rxₛ::Number, rfₐ::Number, config::Options, state::NonlinearSolverState)
+    iterate_settled(rxₛ, config, state) && !residual_small(rfₐ, config, state)
+end
+
+"""
+    record_stall!(state, config)
+
+Update the consecutive-stall counter of `state::`[`NonlinearSolverState`](@ref): increment it
+when the last step [`stalled_step`](@ref) *or* the line search flagged a stall (see
+[`flag_stall!`](@ref)), and reset it to zero otherwise. The flag is cleared either way.
+Returns the new count (see [`stall_number`](@ref)).
+
+This must be called *exactly once per iteration* — [`solve!`](@ref) does so right after
+[`update!`](@ref). That is why the counter is not maintained inside
+[`assess_convergence`](@ref) or [`NonlinearSolverStatus`](@ref): those are pure and are
+evaluated more than once per iteration, so incrementing there would double-count. A
+hand-rolled iteration that drives [`solver_step!`](@ref) directly and never calls
+`record_stall!` simply keeps the count at zero and behaves exactly as before.
+"""
+function record_stall!(state::NonlinearSolverState, config::Options)
+    rxₛ, rfₐ, _ = residuals(state)
+    flagged = state.stallflag
+    state.stallflag = false
+    # The line-search flag substitutes for `iterate_settled` (it is the same news, one
+    # iteration earlier), but it is gated by the *same* residual test: at convergence the
+    # merit is also at its round-off floor, and that is success, not stagnation. Keeping the
+    # gate is what makes stagnation and convergence mutually exclusive (see `isstalled`).
+    stalled = (flagged || iterate_settled(rxₛ, config, state)) && !residual_small(rfₐ, config, state)
+    state.stalls = stalled ? state.stalls + 1 : 0
 end
 
 function NonlinearSolverStatus(state::NonlinearSolverState{T}, config::Options{T}) where {T}
     rxₛ, rfₐ, rfₛ = residuals(state)
-    x_converged, f_converged, f_increased = assess_convergence(rxₛ, rfₐ, rfₛ, config, state)
-    NonlinearSolverStatus{T}(iteration_number(state), rxₛ, rfₐ, rfₛ, x_converged, f_converged, f_increased)
+    x_converged, f_converged, f_increased, stalled = assess_convergence(rxₛ, rfₐ, rfₛ, config, state)
+    NonlinearSolverStatus{T}(iteration_number(state), stall_number(state), rxₛ, rfₐ, rfₛ, x_converged, f_converged, f_increased, stalled)
 end
 
+# The stall line is appended only when it is relevant, so the printout of a fresh status is
+# unchanged.
 Base.show(io::IO, status::NonlinearSolverStatus) = print(io,
     (@sprintf "i=%4i" status.iterations), ",\n",
     (@sprintf "rxₛ=%4e" status.rxₛ), ",\n",
     (@sprintf "rfₐ=%4e" status.rfₐ), ",\n",
-    (@sprintf "rfₛ=%4e" status.rfₛ))
+    (@sprintf "rfₛ=%4e" status.rfₛ),
+    status.stalls > 0 ? ",\n" * (@sprintf "stalls=%4i" status.stalls) : "")
 
 @doc raw"""
     print_status(status, config)
@@ -158,6 +258,22 @@ isconverged(status::NonlinearSolverStatus) = status.x_converged || status.f_conv
 havenan(status::NonlinearSolverStatus) = isnan(status.rxₛ) || isnan(status.rfₐ) || isnan(status.rfₛ)
 
 """
+    isstalled(status, config)
+
+Check whether the iteration has *stagnated*: `config.max_stalls` consecutive steps
+[`stalled_step`](@ref).
+
+Mutually exclusive with [`isconverged`](@ref) — a stalled step is by definition one whose
+residual is *not* small, whereas both convergence branches require that it is.
+
+A stagnated solve has reached the numerical floor of its residual and cannot improve it.
+Whether that counts as success is the caller's decision, which is why the status is queryable
+(see [`status`](@ref)): if `status.rfₐ` is acceptable to *you*, treat `isstalled` as success —
+and consider raising `f_abstol` above it, since the tolerance you asked for is not attainable.
+"""
+isstalled(status::NonlinearSolverStatus, config::Options) = status.stalls ≥ config.max_stalls
+
+"""
     meets_stopping_criteria(state, config)
 
 Determines whether the iteration stops based on the current [`NonlinearSolverState`](@ref).
@@ -167,6 +283,7 @@ Determines whether the iteration stops based on the current [`NonlinearSolverSta
 
 The function `meets_stopping_criteria` returns `true` if one of the following is satisfied:
 - the `status::`[`NonlinearSolverStatus`](@ref) is converged (checked with [`isconverged`](@ref)) and `state.iterations ≥ config.min_iterations`,
+- the `status` has *stagnated* (checked with [`isstalled`](@ref), i.e. `config.max_stalls` consecutive steps that did not move the iterate while the residual is not small) and `state.iterations ≥ config.min_iterations`,
 - `status.f_increased` and `config.allow_f_increases = false` (i.e. `f` increased even though we do not allow it),
 - `state.iterations ≥ config.max_iterations`,
 - `status.rfₐ > config.f_abstol_break` (by default `Inf`). In theory this returns `true` if the residual gets too big.
@@ -210,14 +327,33 @@ function meets_stopping_criteria(state::NonlinearSolverState, config::Options)
     status = NonlinearSolverStatus(state, config)
 
     (isconverged(status) && state.iterations ≥ config.min_iterations) ||
+        (isstalled(status, config) && state.iterations ≥ config.min_iterations) ||
         (status.f_increased && !config.allow_f_increases) ||
         state.iterations ≥ config.max_iterations ||
         status.rfₐ > config.f_abstol_break ||
         (havenan(status) && state.iterations ≥ 1)
 end
 
+"""
+    nonlinear_solver_warnings(status, config)
+
+Report a [`NonlinearSolverStatus`](@ref) at the end of a [`solve!`](@ref): the iteration count
+if it reached `warn_iterations`, *stagnation* at the residual floor (see [`isstalled`](@ref)
+and [`stalled_step`](@ref)), a disallowed residual increase, a residual beyond
+`f_abstol_break`, and `NaN`s. Compare this to [`linesearch_warnings`](@ref), which does the
+same for the inner line search, and to [`print_status`](@ref).
+
+All messages except the iteration count and the two hard-failure ones are gated on
+`config.verbosity ≥ 1`.
+"""
 function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Options)
     (config.warn_iterations > 0 && status.iterations ≥ config.warn_iterations) && (@warn "Solver took $(status.iterations) iterations.")
+    # A stagnated solve is not an error, but it did not achieve what was asked of it, so say
+    # what it *did* achieve and how to make the request attainable. This replaces the former
+    # pair of misleading messages (a line-search warning per iteration plus "Solver took 1000
+    # iterations."), neither of which named the actual problem.
+    (isstalled(status, config) && config.verbosity ≥ 1) &&
+        (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖). If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this.")
     (status.f_increased && !config.allow_f_increases) && (@warn "The function increased and the solver stopped!")
     (status.rfₐ > config.f_abstol_break) && (@warn "The residual rfₐ has reached the maximally allowed value $(config.f_abstol_break)!")
     (havenan(status) && status.iterations ≥ 1 && config.verbosity ≥ 1) && (@warn "Nonlinear solver encountered NaNs in solution or function value.")

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -352,8 +352,13 @@ function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Option
     # what it *did* achieve and how to make the request attainable. This replaces the former
     # pair of misleading messages (a line-search warning per iteration plus "Solver took 1000
     # iterations."), neither of which named the actual problem.
+    # `maxlog` for the same reason every line-search message has one: a caller that drives
+    # `solve!` in a loop — a time-stepping integrator, say — would otherwise get this once per
+    # step for as long as the problem stays unattainable, which is the message flood this
+    # replaced. Note that `maxlog` is keyed on the source location and so is process-global, not
+    # per solve; see `linesearch_warnings`.
     (isstalled(status, config) && config.verbosity ≥ 1) &&
-        (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖). If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this.")
+        (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖). If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this." maxlog = 3)
     (status.f_increased && !config.allow_f_increases) && (@warn "The function increased and the solver stopped!")
     (status.rfₐ > config.f_abstol_break) && (@warn "The residual rfₐ has reached the maximally allowed value $(config.f_abstol_break)!")
     (havenan(status) && status.iterations ≥ 1 && config.verbosity ≥ 1) && (@warn "Nonlinear solver encountered NaNs in solution or function value.")

--- a/src/nonlinear/picard_solver.jl
+++ b/src/nonlinear/picard_solver.jl
@@ -83,7 +83,9 @@ function direction!(it::PicardSolver, x::AbstractVector, params)
     direction!(direction(cache(it)), x, it, params)
 end
 
-direction!(it::PicardSolver, x::AbstractVector, params, iteration) = direction!(it, x, params)
+# The `iteration` and `stalled` arguments are part of the shared `direction!` interface; a
+# Picard step has no Jacobian to refactorize, so both are ignored.
+direction!(it::PicardSolver, x::AbstractVector, params, iteration; stalled::Bool=false) = direction!(it, x, params)
 
 "Backtracking shrink factor used by the [`PicardSolver`](@ref) residual safeguard."
 const DEFAULT_PICARD_BACKTRACKING_p = 0.5

--- a/src/nonlinear/picard_solver.jl
+++ b/src/nonlinear/picard_solver.jl
@@ -7,9 +7,15 @@ struct Picard <: NonlinearSolverMethod end
 
 const PicardSolver{T} = NonlinearSolver{T,Picard}
 
-function PicardSolver(x::AT, nlp::NLST, linesearch::LiSeT, cache::CT; jacobian, options_kwargs...) where {T,AT<:AbstractVector{T},NLST,LiSeT,CT}
-    config = Options(T; options_kwargs...)
+function PicardSolver(x::AT, nlp::NLST, linesearch::LiSeT, cache::CT, config::Options{T}; jacobian) where {T,AT<:AbstractVector{T},NLST,LiSeT<:Linesearch{T},CT}
     NonlinearSolver(x, nlp, NoLinearProblem(), NoLinearSolver(), linesearch, cache, config; jacobian=jacobian, method=Picard())
+end
+
+# See the corresponding `NewtonSolver` method: the line search is rebuilt on the solver's
+# `Options` so that solver and line search cannot be configured inconsistently.
+function PicardSolver(x::AT, nlp::NLST, linesearch::LiSeT, cache::CT; jacobian, options_kwargs...) where {T,AT<:AbstractVector{T},NLST,LiSeT<:Linesearch{T},CT}
+    config = Options(T; options_kwargs...)
+    PicardSolver(x, nlp, with_config(linesearch, config), cache, config; jacobian=jacobian)
 end
 
 """
@@ -48,7 +54,8 @@ solve!(x, s, state)
  0.0
 ```
 """
-function PicardSolver(x::AT, F::Callable, y::AT; (DF!)=missing, jacobian=missing, kwargs...) where {T,AT<:AbstractVector{T}}
+function PicardSolver(x::AT, F::Callable, y::AT; (DF!)=missing, jacobian=missing, options_kwargs...) where {T,AT<:AbstractVector{T}}
+    config = Options(T; options_kwargs...)
     nlp = NonlinearProblem(F, DF!, x, y)
     jacobian = resolve_jacobian(F, DF!, jacobian, x, y)
     cache = NonlinearSolverCache(x, y)
@@ -56,8 +63,8 @@ function PicardSolver(x::AT, F::Callable, y::AT; (DF!)=missing, jacobian=missing
     # mandatory) `linesearch` field is filled with a trivial `Static` step.  A
     # `linesearch` keyword is deliberately not accepted — it would be silently
     # ignored (any stray keyword falls through to `Options` and errors there).
-    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), Static(one(T)))
-    PicardSolver(x, nlp, ls, cache; jacobian=jacobian, kwargs...)
+    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), Static(one(T)), config)
+    PicardSolver(x, nlp, ls, cache, config; jacobian=jacobian)
 end
 
 function PicardSolver(x::AT, y::AT; F=missing, kwargs...) where {T,AT<:AbstractVector{T}}

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -7,6 +7,7 @@ using SimpleSolvers: BierlaireQuadratic, Quadratic, NullParameters
 using SimpleSolvers: factorize!, linearsolver, jacobian, jacobian!, cache, linesearch_problem, direction, compute_new_iterate, compute_new_iterate!, direction!, nonlinearproblem, iteration_number
 using SimpleSolvers: change_precision, bisection, bracket_root, triple_point_finder
 using SimpleSolvers: CurvatureCondition, SufficientDecreaseCondition
+using SimpleSolvers: issufficient, isfloor
 using SimpleSolvers: steplength, outcome, trials, armijo_tolerance, backtracking_αmin,
     backtracking_interpolation, with_config, problem, method, config
 
@@ -235,11 +236,31 @@ end
     @test !sdc(1.0)
     @test !sdc(1e-13)
 
-    # with τ = 4 ulps the decision at the degenerate α is taken by the allowance ...
+    # τ slackens the decrease that is *demanded* — a merit that misses the Armijo target by
+    # less than τ is accepted where the exact condition rejects it ...
+    target = 1.0 + 1e-4 * 0.1 * -2.0      # the right-hand side at α = 0.1, ≈ 1 - 2e-5
+    φ = α -> nextfloat(target, 2)         # misses it by 2 ulps, well inside τ = 4 ulps of φ₀
+    @test !SufficientDecreaseCondition(1e-4, 1.0, -2.0, φ)(0.1)
+    @test SufficientDecreaseCondition(1e-4, 1.0, -2.0, φ; τ=4eps(1.0))(0.1)
+
+    # ... but it never licenses a step where the demanded decrease is meaningful ...
     sdcτ = SufficientDecreaseCondition(1e-4, 1.0, -2.0, α -> nextfloat(1.0); τ=4eps(1.0))
-    @test sdcτ(1e-13)
-    # ... and never licenses a step where the demanded decrease is meaningful
     @test !sdcτ(1.0)
+    # ... and, thanks to the min against φ₀, it never licenses an *increase* either, not even at
+    # the degenerate α where fl(φ₀ + c₁αd₀) has rounded back up to φ₀. The unbounded form
+    # accepted here, which is a 0.4% uphill step in Float16 (4 ulps of φ₀ = 1).
+    @test !sdcτ(1e-13)
+    @test 1.0 + 1e-4 * 1e-13 * -2.0 == 1.0     # the right-hand side really has degenerated
+    # a *non-increase* at the same α is accepted, which is what keeps the ladder from shrinking
+    # to eps once the merit has reached its round-off floor
+    @test SufficientDecreaseCondition(1e-4, 1.0, -2.0, α -> 1.0; τ=4eps(1.0))(1e-13)
+
+    # the bound holds in the precision where it bites: 4 ulps of Float16 is 3.9e-3, twenty times
+    # the 2c₁ = 2e-4 demanded at α = 1, so an unbounded τ would accept a visible increase
+    τ16 = 4eps(Float16(1))
+    sdc16 = SufficientDecreaseCondition(Float16(1e-4), Float16(1), Float16(-2), α -> Float16(1) + τ16 / 2; τ=τ16)
+    @test !sdc16(Float16(1))
+    @test !sdc16(Float16(1e-3))
 
     @test_throws AssertionError SufficientDecreaseCondition(1e-4, 1.0, -2.0, sin; τ=-1.0)
 
@@ -728,15 +749,18 @@ end
     n = Ref(0)
     flat = x -> (n[] += 1; 1.0 + 1e-20 * x)
     n[] = 0
-    @test triple_point_finder(flat, 0.0) === nothing
+    @test triple_point_finder(flat, 0.0) === :flat
     @test n[] == 2                       # the anchor and one probe; was 12 followed by a throw
 
-    # a strictly increasing merit, and one with no minimum to the right, likewise report
-    @test triple_point_finder(x -> x + 1.0, 0.0) === nothing
-    @test triple_point_finder(x -> -x, 0.0) === nothing
+    # A strictly increasing merit, and one with no minimum to the right, likewise report rather
+    # than throw — but as `:unbracketable`, *not* `:flat`.  Both of these have a merit that
+    # varies far more than round-off, so a caller must not report them as a round-off floor: the
+    # second one is in fact descending without bound, which is the opposite of stagnation.
+    @test triple_point_finder(x -> x + 1.0, 0.0) === :unbracketable
+    @test triple_point_finder(x -> -x, 0.0) === :unbracketable
 
     # ... while a genuine overshoot still gets the δ-halving retry it needs
-    @test triple_point_finder(x -> (x - 0.001)^2, 0.0) !== nothing
+    @test triple_point_finder(x -> (x - 0.001)^2, 0.0) isa Tuple
 
     # the success path is unchanged
     a, b, c = triple_point_finder(x -> x^2, -1.0)
@@ -764,27 +788,56 @@ end
 end
 
 @testset "$(rpad("the line search contract holds for every method", 80))" begin
-    # One loop over every method × every pathological anchor.  This is the test that keeps the
-    # contract standardised: none of these may throw, and none may return α ≤ 0.
-    pathological = (
-        ("NaN merit", (α, _) -> NaN, (α, _) -> NaN),
-        ("NaN derivative", (α, _) -> 1.0 - α, (α, _) -> NaN),
-        ("Inf merit", (α, _) -> Inf, (α, _) -> -1.0),
-        ("ascent anchor", (α, _) -> α + 1.0, (α, _) -> 1.0),
-        ("stationary anchor", (α, _) -> -1.0, (α, _) -> 0.0),
-        ("flat to round-off", (α, _) -> α > zero(α) ? nextfloat(1.0) : 1.0, (α, _) -> -2.0),
-        ("minimiser at α < 0", (α, _) -> (α + 1.0)^2, (α, _) -> 2.0 * (α + 1.0)),
-        ("slope contradicts values", (α, _) -> 1.0 + α, (α, _) -> -2.0),
-    )
-    for m in (Static(), Backtracking(), StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
-        for (nm, f, d) in pathological
-            ls = Linesearch(LinesearchProblem{Float64}(f, d), m; verbosity=0)
-            st = @test_nowarn solve_with_status(ls, 1.0)
-            @test st isa LinesearchStatus
-            @test steplength(st) > 0.0            # the α > 0 guarantee
-            @test isfinite(steplength(st))
-            @test solve(ls, 1.0) == steplength(st)  # `solve` is a thin wrapper
+    # One loop over every element type × every method × every pathological anchor.  This is the
+    # test that keeps the contract standardised: none of these may throw, and none may return
+    # α ≤ 0.  The low-precision rows matter in their own right: `Float16` is the precision where
+    # τ = 4·ulp(φ(0)) is *larger* than the decrease the Armijo condition demands at α = 1, and
+    # where `backtracking_αmin`'s √eps clamp is always active, so it is where the bounds on the
+    # round-off allowance are load-bearing rather than decorative.
+    for T in (Float64, Float32, Float16)
+        one_T = one(T)
+        pathological = (
+            ("NaN merit", (α, _) -> T(NaN), (α, _) -> T(NaN)),
+            ("NaN derivative", (α, _) -> one_T - α, (α, _) -> T(NaN)),
+            ("Inf merit", (α, _) -> T(Inf), (α, _) -> -one_T),
+            ("ascent anchor", (α, _) -> α + one_T, (α, _) -> one_T),
+            ("stationary anchor", (α, _) -> -one_T, (α, _) -> zero(T)),
+            ("flat to round-off", (α, _) -> α > zero(α) ? nextfloat(one_T) : one_T, (α, _) -> -2one_T),
+            ("minimiser at α < 0", (α, _) -> (α + one_T)^2, (α, _) -> 2 * (α + one_T)),
+            ("slope contradicts values", (α, _) -> one_T + α, (α, _) -> -2one_T),
+        )
+        for m in (Static(T), Backtracking(T), StrongWolfe(T), Bisection(T), Quadratic(T), BierlaireQuadratic(T))
+            for (nm, f, d) in pathological
+                ls = Linesearch(LinesearchProblem{T}(f, d), m; verbosity=0)
+                st = @test_nowarn solve_with_status(ls, one_T)
+                @test st isa LinesearchStatus{T}
+                @test steplength(st) > zero(T)            # the α > 0 guarantee
+                @test isfinite(steplength(st))
+                @test solve(ls, one_T) == steplength(st)  # `solve` is a thin wrapper
+            end
         end
+    end
+end
+
+@testset "$(rpad("no method accepts a step that increases the merit", 80))" begin
+    # The round-off allowance τ slackens the *demanded* decrease, so it must never license a step
+    # whose merit is above φ(0). The bound is invisible in Float64 (τ/φ₀ ≈ 1e-15) and essential in
+    # Float16, where τ/φ₀ = 3.9e-3 is twenty times the 2c₁ = 2e-4 demanded at α = 1: an unbounded
+    # τ accepted α = 1 on this merit and reported it as a step.
+    for T in (Float64, Float32, Float16)
+        τ = 4 * eps(one(T))
+        # rises immediately, by less than τ — inside the unbounded allowance, outside the bounded one
+        creep = LinesearchProblem{T}((α, _) -> one(T) + (α > zero(α) ? τ / 2 : zero(T)), (α, _) -> -2one(T))
+        for m in (Backtracking(T), StrongWolfe(T), Bisection(T), Quadratic(T), BierlaireQuadratic(T))
+            st = solve_with_status(Linesearch(creep, m; verbosity=0), one(T))
+            @test !issufficient(st)                 # never reported as a genuine decrease
+            @test outcome(st) != LINESEARCH_DECREASED
+        end
+        # and the condition object itself rejects it at every α
+        sdc = SufficientDecreaseCondition(T(1e-4), one(T), -2one(T), α -> one(T) + τ / 2; τ=τ)
+        @test !sdc(one(T))
+        @test !sdc(T(1e-3))
+        @test !sdc(eps(T))
     end
 end
 
@@ -831,5 +884,65 @@ end
         @test α ≈ 1.0 atol = 1e-8
         @test maximum(count(==(u), αs) for u in unique(αs)) ≤ 3
         @test length(αs) ≤ 25
+    end
+end
+
+@testset "$(rpad("trials is a real evaluation count for every method", 80))" begin
+    # `trials` used to be a hardcoded 0 for Bisection/Quadratic/BierlaireQuadratic — so the
+    # round-off-floor message read "in 0 trial step(s)" — and StrongWolfe counted only its
+    # expansion loop, not its zoom phase.  What each method counts is the problem evaluations of
+    # its *own* iteration: the merit, except for `Bisection`, which drives on the derivative it
+    # bisects.  See the `trials` field of `LinesearchStatus`.
+    function counted(m)
+        nf, nd = Ref(0), Ref(0)
+        prob = LinesearchProblem{Float64}((α, _) -> (nf[] += 1; 1.0 - 2α + 1000α^2),
+            (α, _) -> (nd[] += 1; -2.0 + 2000α))
+        st = solve_with_status(Linesearch(prob, m; verbosity=0), 1.0)
+        (st, nf[], nd[])
+    end
+
+    # Backtracking and StrongWolfe drive on the merit alone, and their count is *exact*: every
+    # evaluation is either the α = 0 anchor or a counted trial.  StrongWolfe used to evaluate φ
+    # twice per trial — once directly, once inside the one-argument `sdc` — and once more when
+    # building its status, so this identity is the regression test for that fix.
+    for m in (Backtracking(), StrongWolfe())
+        st, nf, _ = counted(m)
+        @test trials(st) > 0
+        @test nf == trials(st) + 1
+    end
+
+    # The bracketing searches additionally spend evaluations inside `bracket_minimum` /
+    # `triple_point_finder`, which are not counted, so their `trials` is a lower bound on the
+    # total cost — but it is a real count of their own iteration, never zero and never inflated.
+    for m in (Quadratic(), BierlaireQuadratic())
+        st, nf, _ = counted(m)
+        @test 0 < trials(st) ≤ nf
+    end
+    let (st, _, nd) = counted(Bisection())
+        @test 0 < trials(st) ≤ nd
+    end
+end
+
+@testset "$(rpad("αmin is reported only where it means something", 80))" begin
+    # αmin is a shrinking-ladder quantity. `Backtracking` derives a real one; the bracketing and
+    # minimising searches have none, report zero, and must not name it in their messages.
+    noise = LinesearchProblem{Float64}((α, _) -> α > zero(α) ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
+    @test solve_with_status(Linesearch(noise, Backtracking(); verbosity=0), 1.0).αmin > 0
+    for m in (StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
+        @test iszero(solve_with_status(Linesearch(noise, m; verbosity=0), 1.0).αmin)
+    end
+
+    # the verbosity-2 floor message names αmin for Backtracking, and reports the true trial count
+    msg = @test_logs (:warn, r"smallest informative step is αmin") match_mode = :any solve(
+        Linesearch(noise, Backtracking(); verbosity=2), 1.0)
+    @test msg isa Float64
+    # ... and the count is whatever the method really spent, which for `BierlaireQuadratic` on
+    # this merit is legitimately zero: `triple_point_finder` recognises the flat merit from the
+    # anchor and one probe, so the fit never runs. A *genuine* zero is fine; the defect was a
+    # hardcoded one, which the previous testset pins down on a merit that does iterate.
+    for m in (StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
+        st = solve_with_status(Linesearch(noise, m; verbosity=0), 1.0)
+        @test trials(st) ≥ 0
+        @test iszero(st.αmin)
     end
 end

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -309,6 +309,20 @@ end
     @test SimpleSolvers.linesearch_iterations(Float64) == 60
     @test SimpleSolvers.linesearch_iterations(Float32) == 31
     @test SimpleSolvers.linesearch_iterations(Float16) == 18
+
+    # The quadratic searches are bounded by the same field (they used to carry their own
+    # `max_number_of_quadratic_linesearch_iterations`).  They converge on their `ε` tolerance
+    # long before the budget, so it acts purely as a backstop — but it is reachable, and it is
+    # now settable by the user like every other line search's.
+    quad = LinesearchProblem{Float64}((α, _) -> (α - 1.0)^2, (α, _) -> 2(α - 1.0))
+    for m in (Quadratic(), BierlaireQuadratic())
+        generous = solve(Linesearch(quad, m, Options(Float64; verbosity=0, linesearch_max_iterations=60)), 0.5)
+        @test generous ≈ 1.0 atol = 1e-8
+        # the default budget reaches the same answer, i.e. it is not the binding constraint
+        @test solve(Linesearch(quad, m; verbosity=0), 0.5) ≈ generous atol = 1e-12
+    end
+    # a budget of one iteration truncates the Bierlaire fit, proving the field reaches the loop
+    @test solve(Linesearch(quad, BierlaireQuadratic(), Options(Float64; verbosity=0, linesearch_max_iterations=1)), 0.5) ≉ 1.0
 end
 
 @testset "$(rpad("Quadratic Linesearch (Bierlaire)", 80))" begin

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -8,7 +8,7 @@ using SimpleSolvers: factorize!, linearsolver, jacobian, jacobian!, cache, lines
 using SimpleSolvers: change_precision, bisection, bracket_root, triple_point_finder
 using SimpleSolvers: CurvatureCondition, SufficientDecreaseCondition
 using SimpleSolvers: issufficient, isfloor
-using SimpleSolvers: steplength, outcome, trials, armijo_tolerance, backtracking_αmin,
+using SimpleSolvers: steplength, outcome, trials, armijo_tolerance, armijo_ulps, backtracking_αmin,
     backtracking_interpolation, with_config, problem, method, config
 
 f(x) = x^2 - 1
@@ -817,6 +817,68 @@ end
             end
         end
     end
+end
+
+@testset "$(rpad("armijo_ulps caps the round-off resolution at what the precision supports", 80))" begin
+    # τ = τ_ulps·ulp(φ₀) has to be at least ~an ulp to recognise a merit at its round-off floor,
+    # and far below the decrease the Armijo condition demands at α = 1 (2c₁·φ₀ for the canonical
+    # ‖F‖² Newton merit) to leave that condition meaningful.  Those are compatible only while
+    # eps(T) ≪ 2c₁ — true by a wide margin in Float64, comfortably in Float32, and *false* in
+    # Float16, where eps = 9.8e-4 already exceeds 2c₁ = 2e-4.  `armijo_ulps` caps the nominal 4
+    # accordingly, which is a no-op in the two precisions that can afford it.
+    @test armijo_ulps(Float64) == SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS
+    @test armijo_ulps(Float32) == SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS
+    @test armijo_ulps(Float16) < 1                       # no room for even a single ulp
+    @test armijo_ulps(Float16) > 0
+
+    for T in (Float64, Float32, Float16)
+        c₁ = T(SimpleSolvers.DEFAULT_WOLFE_c₁)
+        τ = armijo_tolerance(one(T), armijo_ulps(T))
+        demanded = 2 * c₁                                # the decrease demanded at α = 1
+        # the invariant the cap exists for; the slack absorbs the rounding of the cap itself,
+        # which in Float16 is computed in Float16
+        @test τ ≤ 1.1 * SimpleSolvers.ARMIJO_τ_DEMAND_FRACTION * demanded
+        # ... and a tighter c₁ tightens the cap rather than being ignored
+        @test armijo_ulps(T, c₁ / 1000) ≤ armijo_ulps(T, c₁)
+    end
+
+    # The cap is applied by the inner constructor, so *every* path into a `Backtracking{T}` gets
+    # a resolution the element type supports — including `change_precision`, which converts a
+    # method built for a different `T`, and an explicit value that is too large.
+    for T in (Float64, Float32, Float16)
+        @test Backtracking(T).τ_ulps == armijo_ulps(T, T(SimpleSolvers.DEFAULT_WOLFE_c₁))
+        @test change_precision(T, Backtracking()).τ_ulps == Backtracking(T).τ_ulps
+        @test Backtracking(T; τ_ulps=T(4)).τ_ulps ≤ armijo_ulps(T)
+        @test Backtracking(T; τ_ulps=zero(T)).τ_ulps == 0   # opting out still works
+    end
+end
+
+@testset "$(rpad("a small but genuine Float16 decrease is a decrease, not the floor", 80))" begin
+    # With the nominal 4 ulps, τ/φ₀ = 3.9e-3 in Float16 — twenty times the 2c₁ = 2e-4 the
+    # condition demands at α = 1.  A merit that really did decrease by two ulps was then
+    # classified `LINESEARCH_FLOOR`, which `solver_step!` feeds to `flag_stall!`: two such steps
+    # and a *converging* solve was reported as stagnated.  The cap fixes the classification.
+    T = Float16
+    φ = α -> one(T) - T(0.004) * α + T(0.002) * α^2       # minimum at α = 1, φ(1) = 0.998
+    prob = LinesearchProblem{T}((α, _) -> φ(α), (α, _) -> -T(0.004) + T(0.004) * α)
+
+    decrease = φ(zero(T)) - φ(one(T))
+    @test decrease == 2 * eps(T)                          # two ulps: the smallest Float16 can show
+
+    τ = armijo_tolerance(one(T), armijo_ulps(T))
+    τnominal = armijo_tolerance(one(T), T(SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS))
+    @test φ(one(T)) ≤ φ(zero(T)) - τ                      # counts as a decrease with the cap ...
+    @test !(φ(one(T)) ≤ φ(zero(T)) - τnominal)            # ... and did not without it
+
+    # the two methods that actually run an Armijo test report it as progress
+    for m in (Backtracking(T), StrongWolfe(T))
+        st = solve_with_status(Linesearch(prob, m; verbosity=0), one(T))
+        @test issufficient(st)
+        @test outcome(st) == LINESEARCH_DECREASED
+    end
+
+    # and Float64 is untouched: the same relative decrease is far above its τ either way
+    @test armijo_tolerance(1.0, armijo_ulps(Float64)) == armijo_tolerance(1.0, 4)
 end
 
 @testset "$(rpad("no method accepts a step that increases the merit", 80))" begin

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -262,16 +262,28 @@ end
     st = solve_with_status(Linesearch(noise, Backtracking(; τ_ulps=0.0); verbosity=0), 1.0)
     @test steplength(st) ≤ eps(1.0)
 
-    # the generic fallback makes `solve_with_status` usable for every LinesearchMethod
+    # Every built-in method reports a real outcome now, so none of them relies on the generic
+    # `LINESEARCH_UNKNOWN` fallback any more.  `Static` is the exception by nature: it ignores
+    # the caller's step and never evaluates the merit, so it has established nothing.
     prob = LinesearchProblem{Float64}((α, _) -> (α - 0.7)^2, (α, _) -> 2 * (α - 0.7))
-    for m in (Static(), Bisection(), Quadratic(), BierlaireQuadratic(), StrongWolfe())
+    for m in (Bisection(), Quadratic(), BierlaireQuadratic(), StrongWolfe(), Backtracking())
         ls = Linesearch(prob, m; verbosity=0)
         st = solve_with_status(ls, 1.0)
-        @test outcome(st) == LINESEARCH_UNKNOWN
-        @test steplength(st) == solve(ls, 1.0)
-        @test !issufficient(st)
+        @test outcome(st) == LINESEARCH_DECREASED
+        @test issufficient(st)
         @test !isfloor(st)
+        @test steplength(st) == solve(ls, 1.0)
     end
+
+    lstatic = Linesearch(prob, Static(); verbosity=0)
+    ststatic = solve_with_status(lstatic, 1.0)
+    @test outcome(ststatic) == LINESEARCH_UNKNOWN
+    @test !issufficient(ststatic)
+    @test !isfloor(ststatic)
+    @test steplength(ststatic) == solve(lstatic, 1.0)
+
+    # The generic `solve_with_status` fallback is kept for user-defined `LinesearchMethod`s
+    # (it reports `LINESEARCH_UNKNOWN`), but no built-in method dispatches to it any more.
 end
 
 @testset "$(rpad("with_config replaces the Options and keeps problem and method", 80))" begin
@@ -611,15 +623,30 @@ end
     end
 end
 
-@testset "$(rpad("Quadratic returns the tested bracket point (non-descent start)", 80))" begin
-    # When the start is not on the descent side, `bracket_minimum_with_fixed_point`
-    # flips and the bracket's left endpoint `a` (where the derivative is tested and
-    # the early-return fires) differs from the loop's start `α`.  The Quadratic search
-    # must return `a`, not `α`.  Here φ(α) = (α + 1)² is increasing at the α = 0 anchor
-    # (φ'(0) = 2 > 0) with its minimiser at α = -1.
+@testset "$(rpad("Quadratic returns the tested bracket point, and never a negative step", 80))" begin
+    # φ(α) = (α + 1)² is *increasing* at the α = 0 anchor (φ'(0) = 2 > 0) with its minimiser at
+    # α = -1.  `bracket_minimum_with_fixed_point` handles that by flipping direction, so this
+    # search used to return α ≈ -1 — a step *against* the direction.  That is meaningless as a
+    # step length (α scales a direction that is already chosen), and measured on a Newton solve
+    # the capability was emergent rather than designed: it arises only from a stale Jacobian, it
+    # was inherited from whichever bracketer each method happened to call, and `Bisection`
+    # produced steps as large as α = -3.  The α > 0 contract now applies to every method, so an
+    # ascent anchor is reported instead.
     prob = LinesearchProblem{Float64}((a, _) -> (a + 1.0)^2, (a, _) -> 2.0 * (a + 1.0))
-    ls = Linesearch(prob, Quadratic(); x_abstol=0.0)
-    @test solve(ls, 0.0) ≈ -1.0 atol = ∛(2eps())
+    ls = Linesearch(prob, Quadratic(); x_abstol=0.0, verbosity=0)
+    st = solve_with_status(ls, 0.0)
+    @test outcome(st) == LINESEARCH_NO_DESCENT
+    @test steplength(st) > 0.0
+    @test solve(ls, 0.0) == steplength(st)
+
+    # The original point of this test survives on a *descent* anchor: the bracket's left
+    # endpoint `a`, where the derivative is tested and the near-stationary early return fires,
+    # differs from the loop's start `α`, and it is `a` that must be returned.  Here the
+    # minimiser sits at α = +1.
+    descent = LinesearchProblem{Float64}((a, _) -> (a - 1.0)^2, (a, _) -> 2.0 * (a - 1.0))
+    lsd = Linesearch(descent, Quadratic(); x_abstol=0.0, verbosity=0)
+    @test solve(lsd, 0.0) ≈ 1.0 atol = ∛(2eps())
+    @test solve(lsd, 2.0) ≈ 1.0 atol = ∛(2eps())   # α₀ past the minimiser still lands on it
 end
 
 # Quadratic and BierlaireQuadratic validate their constructor parameters, like
@@ -691,4 +718,118 @@ end
     # ... and so does a non-descent direction
     up = LinesearchProblem{Float64}((α, _) -> α + 1.0, (α, _) -> 1.0)
     @test_logs (:warn, r"not a descent direction") match_mode = :any solve(Linesearch(up, Backtracking()), 1.0)
+end
+
+@testset "$(rpad("bracketing helpers report failure instead of throwing", 80))" begin
+    # A merit that is flat to round-off: `1.0 + 1e-20x` computes to exactly 1.0 for every small
+    # x, so no probe can find a decrease.  This used to halve δ five times and then throw,
+    # aborting the enclosing solve — and halving is precisely the wrong response, since a
+    # smaller probe is strictly *less* informative than the one that already failed.
+    n = Ref(0)
+    flat = x -> (n[] += 1; 1.0 + 1e-20 * x)
+    n[] = 0
+    @test triple_point_finder(flat, 0.0) === nothing
+    @test n[] == 2                       # the anchor and one probe; was 12 followed by a throw
+
+    # a strictly increasing merit, and one with no minimum to the right, likewise report
+    @test triple_point_finder(x -> x + 1.0, 0.0) === nothing
+    @test triple_point_finder(x -> -x, 0.0) === nothing
+
+    # ... while a genuine overshoot still gets the δ-halving retry it needs
+    @test triple_point_finder(x -> (x - 0.001)^2, 0.0) !== nothing
+
+    # the success path is unchanged
+    a, b, c = triple_point_finder(x -> x^2, -1.0)
+    @test a < b < c
+
+    # the sibling bracketers report `nothing` on exhaustion rather than erroring
+    @test bracket_minimum(x -> -x, 0.0; nmax=3) === nothing
+    @test SimpleSolvers.bracket_minimum_with_fixed_point(x -> -x, 0.0, 0.01, 2.0, 3) === nothing
+    @test bracket_minimum(x -> (x - 1)^2, 0.0) !== nothing
+end
+
+@testset "$(rpad("check_anchor", 80))" begin
+    @test outcome(SimpleSolvers.check_anchor(NaN, -1.0, 0.7)) == LINESEARCH_NO_DESCENT
+    @test outcome(SimpleSolvers.check_anchor(1.0, NaN, 0.7)) == LINESEARCH_NO_DESCENT
+    @test outcome(SimpleSolvers.check_anchor(Inf, -1.0, 0.7)) == LINESEARCH_NO_DESCENT
+    @test outcome(SimpleSolvers.check_anchor(1.0, 2.0, 0.7)) == LINESEARCH_NO_DESCENT
+    @test outcome(SimpleSolvers.check_anchor(1.0, 0.0, 0.7)) == LINESEARCH_STATIONARY
+    @test SimpleSolvers.check_anchor(1.0, -2.0, 0.7) === nothing   # healthy anchor: proceed
+
+    # the caller's trial step is handed back, and a non-positive one is replaced by the unit
+    # step so that the α > 0 guarantee holds regardless of what the caller passed
+    @test steplength(SimpleSolvers.check_anchor(1.0, 2.0, 0.7)) == 0.7
+    @test steplength(SimpleSolvers.check_anchor(1.0, 2.0, 0.0)) == 1.0
+    @test steplength(SimpleSolvers.check_anchor(1.0, 2.0, -3.0)) == 1.0
+end
+
+@testset "$(rpad("the line search contract holds for every method", 80))" begin
+    # One loop over every method × every pathological anchor.  This is the test that keeps the
+    # contract standardised: none of these may throw, and none may return α ≤ 0.
+    pathological = (
+        ("NaN merit", (α, _) -> NaN, (α, _) -> NaN),
+        ("NaN derivative", (α, _) -> 1.0 - α, (α, _) -> NaN),
+        ("Inf merit", (α, _) -> Inf, (α, _) -> -1.0),
+        ("ascent anchor", (α, _) -> α + 1.0, (α, _) -> 1.0),
+        ("stationary anchor", (α, _) -> -1.0, (α, _) -> 0.0),
+        ("flat to round-off", (α, _) -> α > zero(α) ? nextfloat(1.0) : 1.0, (α, _) -> -2.0),
+        ("minimiser at α < 0", (α, _) -> (α + 1.0)^2, (α, _) -> 2.0 * (α + 1.0)),
+        ("slope contradicts values", (α, _) -> 1.0 + α, (α, _) -> -2.0),
+    )
+    for m in (Static(), Backtracking(), StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
+        for (nm, f, d) in pathological
+            ls = Linesearch(LinesearchProblem{Float64}(f, d), m; verbosity=0)
+            st = @test_nowarn solve_with_status(ls, 1.0)
+            @test st isa LinesearchStatus
+            @test steplength(st) > 0.0            # the α > 0 guarantee
+            @test isfinite(steplength(st))
+            @test solve(ls, 1.0) == steplength(st)  # `solve` is a thin wrapper
+        end
+    end
+end
+
+@testset "$(rpad("StrongWolfe reports a non-finite anchor instead of asserting", 80))" begin
+    # A `NaN` derivative is not `≥ zero(T)`, so it used to slip past StrongWolfe's descent check
+    # and trip `SufficientDecreaseCondition`'s `@assert !isnan(d₀)`, throwing an `AssertionError`
+    # out of the enclosing solve.  It now matches `Backtracking` on the same problems.
+    for (f, d) in (((α, _) -> NaN, (α, _) -> NaN), ((α, _) -> 1.0 - α, (α, _) -> NaN))
+        prob = LinesearchProblem{Float64}(f, d)
+        sw = solve_with_status(Linesearch(prob, StrongWolfe(); verbosity=0), 0.7)
+        bt = solve_with_status(Linesearch(prob, Backtracking(); verbosity=0), 0.7)
+        @test outcome(sw) == outcome(bt) == LINESEARCH_NO_DESCENT
+        @test steplength(sw) == steplength(bt) == 0.7
+    end
+end
+
+@testset "$(rpad("cost is independent of the merit's scale", 80))" begin
+    # φ(α) = c·(α-1)² has its minimiser at α = 1 for every c > 0, so neither the returned step
+    # nor the number of merit evaluations may depend on c.  `BierlaireQuadratic` used to cost 15
+    # / 70 / 14 evaluations at c = 1 / 1e-6 / 1e-12: at c = 1e-6 it stalled on a single point
+    # (evaluating α = 0.99999999999999911 thirty-plus times in a row) and ran out its budget.
+    for m in (Backtracking(), StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
+        αs = Float64[]
+        counts = Int[]
+        for c in (1e-12, 1e-6, 1.0, 1e6, 1e12)
+            n = Ref(0)
+            prob = LinesearchProblem{Float64}((α, _) -> (n[] += 1; c * (α - 1.0)^2), (α, _) -> c * 2 * (α - 1.0))
+            push!(αs, solve(Linesearch(prob, m; verbosity=0), 0.5))
+            push!(counts, n[])
+        end
+        @test all(≈(first(αs)), αs)                        # same step at every scale
+        @test maximum(counts) - minimum(counts) ≤ 2        # and essentially the same cost
+        @test maximum(counts) ≤ 25
+    end
+end
+
+@testset "$(rpad("BierlaireQuadratic contracts its bracket every iteration", 80))" begin
+    # The no-stall canary for the scale at which it used to spin: no single α may be evaluated
+    # more than a couple of times.
+    for c in (1.0, 1e-6)
+        αs = Float64[]
+        prob = LinesearchProblem{Float64}((α, _) -> (push!(αs, α); c * (α - 1.0)^2), (α, _) -> c * 2 * (α - 1.0))
+        α = solve(Linesearch(prob, BierlaireQuadratic(); verbosity=0), 0.5)
+        @test α ≈ 1.0 atol = 1e-8
+        @test maximum(count(==(u), αs) for u in unique(αs)) ≤ 3
+        @test length(αs) ≤ 25
+    end
 end

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -6,7 +6,9 @@ using LinearAlgebra: rmul!, ldiv!
 using SimpleSolvers: BierlaireQuadratic, Quadratic, NullParameters
 using SimpleSolvers: factorize!, linearsolver, jacobian, jacobian!, cache, linesearch_problem, direction, compute_new_iterate, compute_new_iterate!, direction!, nonlinearproblem, iteration_number
 using SimpleSolvers: change_precision, bisection, bracket_root, triple_point_finder
-using SimpleSolvers: CurvatureCondition
+using SimpleSolvers: CurvatureCondition, SufficientDecreaseCondition
+using SimpleSolvers: steplength, outcome, trials, armijo_tolerance, backtracking_αmin,
+    backtracking_interpolation, with_config, problem, method, config
 
 f(x) = x^2 - 1
 g(x) = 2x
@@ -125,17 +127,188 @@ end
     @test Backtracking() isa Backtracking                       # defaults are valid
 end
 
-@testset "$(rpad("Backtracking exhaustion returns the last nonzero step", 80))" begin
-    # A strictly increasing merit with positive slope at 0 can never satisfy the
-    # sufficient-decrease condition, so the search exhausts.  It must return the last
-    # (nonzero) trial step, not the α₀ = 0 anchor: returning 0 would freeze the outer
-    # solver iterate (x .+= 0 .* d) and spin it to max_iterations.  The loop also stops
-    # once α underflows to eps instead of shrinking to a denormal over all iterations.
+@testset "$(rpad("Backtracking: non-descent and stationary anchors are reported, not searched", 80))" begin
+    # A merit with positive slope at 0 can never satisfy the sufficient-decrease condition, so
+    # the former 53 shrinking trials (which returned α ≈ eps) were 53 wasted merit
+    # evaluations.  The anchor is now tested up front and, consistently with StrongWolfe, the
+    # caller's trial step is returned — never the α₀ = 0 anchor, which would freeze the outer
+    # solver iterate (x .+= 0 .* d) and spin it to max_iterations.
     prob = LinesearchProblem{Float64}((α, _) -> α + 1.0, (α, _) -> 1.0)  # φ'(0) = 1 > 0
     ls = Linesearch(prob, Backtracking(); verbosity=0)
-    α = solve(ls, 1.0)
-    @test α > zero(α)          # nonzero step, not the α₀ = 0 anchor
-    @test α ≤ eps(1.0)         # shrunk down to the negligible-step floor, no further
+    st = solve_with_status(ls, 0.7)
+    @test outcome(st) == LINESEARCH_NO_DESCENT
+    @test steplength(st) == 0.7   # the caller's step, not the α₀ = 0 anchor
+    @test steplength(st) > zero(steplength(st))
+    @test trials(st) == 0         # nothing beyond the anchor was evaluated
+    @test solve(ls, 0.7) == steplength(st)
+    # ... and it agrees with StrongWolfe, which has the same up-front descent check
+    @test solve(ls, 0.7) == solve(Linesearch(prob, StrongWolfe(); verbosity=0), 0.7)
+
+    # A stationary anchor (φ'(0) = 0, e.g. a vanishing Newton direction at an exact root) is
+    # benign: it must not warn at the default verbosity, since it happens on the last
+    # iteration of a converged solve.
+    flat = LinesearchProblem{Float64}((α, _) -> -1.0, (α, _) -> 0.0)
+    lsflat = Linesearch(flat, Backtracking())     # verbosity = 1, the default
+    @test outcome(solve_with_status(lsflat, 1.0)) == LINESEARCH_STATIONARY
+    @test (@test_logs solve(lsflat, 1.0)) == 1.0
+
+    # A merit whose slope contradicts its values (a stale or regularized Jacobian, an inexact
+    # linear solve) is a genuine failure and must be told apart from the round-off floor.
+    lying = LinesearchProblem{Float64}((α, _) -> 1.0 + α, (α, _) -> -2.0)
+    @test outcome(solve_with_status(Linesearch(lying, Backtracking(); verbosity=0), 1.0)) == LINESEARCH_EXHAUSTED
+end
+
+@testset "$(rpad("Backtracking: stagnation at the merit's round-off floor", 80))" begin
+    φ₀ = 1.0
+
+    # Fixture A — the *silent* variant.  The merit is frozen below α_move = 1e-6 (there the
+    # trial iterate x + α·δx no longer differs from x in floating point) and increases above
+    # it, so no α decreases it; d₀ = -2φ₀ is the exact-Newton slope of ‖F‖².
+    # Before: the Armijo right-hand side φ₀ + c₁·α·d₀ rounds back up to φ₀ for
+    # α < α* = eps/(4c₁) = 5.55e-13, the frozen merit tied it, and the search reported
+    # *success* at α = 2.2737367544323206e-13 after 43 trials — with no warning whatsoever.
+    frozen = LinesearchProblem{Float64}((α, _) -> α ≤ 1e-6 ? φ₀ : φ₀ * (1 + α), (α, _) -> -2φ₀)
+    ls = Linesearch(frozen, Backtracking(); verbosity=0)
+    st = solve_with_status(ls, 1.0)
+    @test outcome(st) == LINESEARCH_FLOOR   # the tie is *not* reported as a decrease
+    @test !issufficient(st)
+    @test isfloor(st)
+    @test trials(st) < 43                   # 14 (was 43)
+    @test steplength(st) > 1e-8             # stops at the frozen scale, not at 2.3e-13
+    @test solve(ls, 1.0) == steplength(st)  # `solve` still returns the step length
+
+    # Fixture B — the *reported* variant: every α > 0 lands one ulp above φ₀, i.e. ‖F‖² is
+    # pure round-off noise.  Before: 53 halvings down to α = eps(1.0) = 2.220446049250313e-16
+    # and a warning claiming the sufficient decrease condition failed "within 1000
+    # iterations" — neither the count nor the reason was true.
+    noise = LinesearchProblem{Float64}((α, _) -> α > zero(α) ? nextfloat(φ₀) : φ₀, (α, _) -> -2φ₀)
+    lsn = Linesearch(noise, Backtracking(); verbosity=0)
+    stn = solve_with_status(lsn, 1.0)
+    @test outcome(stn) == LINESEARCH_FLOOR
+    @test isfloor(stn)
+    @test trials(stn) < 53                          # 33 (was 53)
+    @test steplength(stn) > eps(1.0)                # the αmin floor, not eps(1.0)
+    @test steplength(stn) == stn.αmin
+    @test solve(lsn, 1.0) == steplength(stn)
+
+    # αmin sits a factor 2·τ_ulps above the α* at which fl(φ₀ + c₁αd₀) rounds back to φ₀, so
+    # the search never enters the region where the test is decided by rounding.
+    αstar = eps(1.0) / (4 * SimpleSolvers.DEFAULT_WOLFE_c₁)
+    @test stn.τ == 4eps(φ₀)
+    @test stn.αmin ≈ 2 * SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS * αstar
+    @test stn.αmin == 4.440892098500626e-12
+end
+
+@testset "$(rpad("armijo_tolerance / backtracking_αmin / interpolation", 80))" begin
+    @test armijo_tolerance(1.0, 4.0) == 4eps(1.0)
+    @test armijo_tolerance(1e-20, 4.0) == 4eps(1e-20)
+
+    τ = armijo_tolerance(1.0, 4.0)
+    @test backtracking_αmin(1e-4, -2.0, τ) == 4.440892098500626e-12
+    @test backtracking_αmin(1e-4, -0.0, τ) == sqrt(eps(1.0))   # no division by zero
+    @test backtracking_αmin(1e-4, -1e30, τ) == eps(1.0)        # clamped from below
+    @test backtracking_αmin(1e-4, -1e-30, τ) == sqrt(eps(1.0)) # clamped from above
+    @test backtracking_αmin(1e-4, -2.0, 0.0) == eps(1.0)       # τ = 0 keeps the old floor
+
+    # the interpolated step always stays inside [BACKTRACKING_SHRINK_MIN·α, p·α]
+    for (φα, αp, φp) in [(3.0, NaN, NaN), (3.0, 2.0, 5.0), (NaN, NaN, NaN), (Inf, 1.5, 2.0)]
+        αₙ = backtracking_interpolation(1.0, -2.0, 1.0, φα, αp, φp, 0.5)
+        @test SimpleSolvers.BACKTRACKING_SHRINK_MIN ≤ αₙ ≤ 0.5
+    end
+
+    # φ(α) = 1 - 2α + 1000α²: α = 1 overshoots badly.  Plain halving needs 10 trials,
+    # safeguarded interpolation fewer — and one merit evaluation per trial plus the anchor
+    # (the two-argument SufficientDecreaseCondition must not re-evaluate the merit).
+    n = Ref(0)
+    prob = LinesearchProblem{Float64}((α, _) -> (n[] += 1; 1.0 - 2α + 1000α^2), (α, _) -> -2.0 + 2000α)
+    st = solve_with_status(Linesearch(prob, Backtracking(); verbosity=0), 1.0)
+    @test issufficient(st)
+    @test trials(st) < 10
+    @test n[] == trials(st) + 1
+    @test steplength(st) ≤ 0.5
+end
+
+@testset "$(rpad("SufficientDecreaseCondition round-off allowance", 80))" begin
+    # τ = 0 (the default) is the exact former condition: a merit one ulp above φ₀ is rejected
+    # at every α — including the α where the right-hand side rounds back to φ₀.
+    sdc = SufficientDecreaseCondition(1e-4, 1.0, -2.0, α -> nextfloat(1.0))
+    @test !sdc(1.0)
+    @test !sdc(1e-13)
+
+    # with τ = 4 ulps the decision at the degenerate α is taken by the allowance ...
+    sdcτ = SufficientDecreaseCondition(1e-4, 1.0, -2.0, α -> nextfloat(1.0); τ=4eps(1.0))
+    @test sdcτ(1e-13)
+    # ... and never licenses a step where the demanded decrease is meaningful
+    @test !sdcτ(1.0)
+
+    @test_throws AssertionError SufficientDecreaseCondition(1e-4, 1.0, -2.0, sin; τ=-1.0)
+
+    # the two-argument form uses the merit value supplied by the caller
+    n = Ref(0)
+    sdc2 = SufficientDecreaseCondition(1e-4, 1.0, -2.0, α -> (n[] += 1; 0.0))
+    @test sdc2(1.0, 0.0)
+    @test n[] == 0
+    @test sdc2(1.0)
+    @test n[] == 1
+end
+
+@testset "$(rpad("Backtracking: τ_ulps validation and generic solve_with_status fallback", 80))" begin
+    @test_throws AssertionError Backtracking(; τ_ulps=-1.0)
+    @test Backtracking(; τ_ulps=0.0) isa Backtracking
+    @test Backtracking().τ_ulps == SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS
+
+    # τ_ulps = 0 recovers the exact condition, i.e. the old ladder down to the eps floor
+    noise = LinesearchProblem{Float64}((α, _) -> α > zero(α) ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
+    st = solve_with_status(Linesearch(noise, Backtracking(; τ_ulps=0.0); verbosity=0), 1.0)
+    @test steplength(st) ≤ eps(1.0)
+
+    # the generic fallback makes `solve_with_status` usable for every LinesearchMethod
+    prob = LinesearchProblem{Float64}((α, _) -> (α - 0.7)^2, (α, _) -> 2 * (α - 0.7))
+    for m in (Static(), Bisection(), Quadratic(), BierlaireQuadratic(), StrongWolfe())
+        ls = Linesearch(prob, m; verbosity=0)
+        st = solve_with_status(ls, 1.0)
+        @test outcome(st) == LINESEARCH_UNKNOWN
+        @test steplength(st) == solve(ls, 1.0)
+        @test !issufficient(st)
+        @test !isfloor(st)
+    end
+end
+
+@testset "$(rpad("with_config replaces the Options and keeps problem and method", 80))" begin
+    prob = LinesearchProblem{Float64}((α, _) -> (α - 0.7)^2, (α, _) -> 2 * (α - 0.7))
+    ls = Linesearch(prob, Backtracking())
+    @test config(ls).verbosity == 1
+
+    ls2 = with_config(ls, Options(Float64; verbosity=0, linesearch_max_iterations=7))
+    @test problem(ls2) === problem(ls)
+    @test method(ls2) === method(ls)
+    @test config(ls2).verbosity == 0
+    @test config(ls2).linesearch_max_iterations == 7
+    @test config(ls).verbosity == 1   # the original is untouched
+
+    # a mismatched element type is rejected rather than silently accepted
+    @test_throws MethodError with_config(ls, Options(Float32))
+end
+
+@testset "$(rpad("linesearch_max_iterations bounds the ladder, max_iterations does not", 80))" begin
+    noise = LinesearchProblem{Float64}((α, _) -> α > zero(α) ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
+
+    unbounded = solve_with_status(Linesearch(noise, Backtracking(), Options(Float64; verbosity=0)), 1.0)
+    @test outcome(unbounded) == LINESEARCH_FLOOR
+
+    # the inner budget reaches the ladder, and a spent budget is *not* reported as the floor
+    capped = solve_with_status(Linesearch(noise, Backtracking(), Options(Float64; verbosity=0, linesearch_max_iterations=3)), 1.0)
+    @test trials(capped) == 3
+    @test outcome(capped) == LINESEARCH_EXHAUSTED
+
+    # the outer budget does not
+    outer = solve_with_status(Linesearch(noise, Backtracking(), Options(Float64; verbosity=0, max_iterations=1)), 1.0)
+    @test trials(outer) == trials(unbounded)
+    @test outcome(outer) == LINESEARCH_FLOOR
+
+    @test SimpleSolvers.linesearch_iterations(Float64) == 60
+    @test SimpleSolvers.linesearch_iterations(Float32) == 31
+    @test SimpleSolvers.linesearch_iterations(Float16) == 18
 end
 
 @testset "$(rpad("Quadratic Linesearch (Bierlaire)", 80))" begin
@@ -358,7 +531,7 @@ end
     # The debug `println` and hard `error("Max iteration number exceeded")` were
     # A tight tolerance forces exhaustion here.
     fslow(α, _) = α - 1 / 3
-    cfg = Options(Float64; max_iterations=2, x_suctol=0.0, f_abstol=0.0, verbosity=0)
+    cfg = Options(Float64; linesearch_max_iterations=2, x_suctol=0.0, f_abstol=0.0, verbosity=0)
     local αbest
     @test (αbest = bisection(fslow, 0.0, 1.0, NullParameters(), cfg)) isa Float64
     @test 0.0 ≤ αbest ≤ 1.0
@@ -480,4 +653,28 @@ end
         @test α ≈ α_expected atol = 1e-8
         @test cnt[] ≤ bound
     end
+end
+
+@testset "$(rpad("the benign outcomes do not warn at the default verbosity", 80))" begin
+    # Reaching the merit's round-off floor is the *normal* final state of a converged solve, so
+    # reporting it at the default verbosity would mean warning about success.  Measured on
+    # GeometricProblems, gating it at `verbosity ≥ 1` newly surfaced a message on three
+    # previously-silent, correctly-converging integrations.  Whether an irreducible merit
+    # matters is the outer iteration's call (see `stalled_step`).
+    noise = LinesearchProblem{Float64}((α, _) -> α > zero(α) ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
+    lsdefault = Linesearch(noise, Backtracking())          # verbosity = 1, the default
+    @test outcome(solve_with_status(lsdefault, 1.0)) == LINESEARCH_FLOOR
+    @test (@test_logs solve(lsdefault, 1.0)) == solve(lsdefault, 1.0)   # silent
+
+    # ... but it is available for diagnosis
+    lsverbose = Linesearch(noise, Backtracking(); verbosity=2)
+    @test_logs (:warn, r"round-off floor") match_mode = :any solve(lsverbose, 1.0)
+
+    # a genuine inconsistency between the slope and the values *does* warn at verbosity 1
+    lying = LinesearchProblem{Float64}((α, _) -> 1.0 + α, (α, _) -> -2.0)
+    @test_logs (:warn, r"did not satisfy|no step satisfied") match_mode = :any solve(Linesearch(lying, Backtracking()), 1.0)
+
+    # ... and so does a non-descent direction
+    up = LinesearchProblem{Float64}((α, _) -> α + 1.0, (α, _) -> 1.0)
+    @test_logs (:warn, r"not a descent direction") match_mode = :any solve(Linesearch(up, Backtracking()), 1.0)
 end

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -4,6 +4,8 @@ using SimpleSolvers: NonlinearSolverState, assess_convergence, residuals, update
 using SimpleSolvers: meets_stopping_criteria, nonlinear_solver_warnings, NonlinearSolverStatus
 using SimpleSolvers: linesearch_problem, cache, jacobianmatrix, solution, value, direction, direction!, NullParameters
 using SimpleSolvers: trust_radius, DOGLEG_Δ_INITIAL
+using SimpleSolvers: config, linesearch, stall_number, record_stall!, flag_stall!,
+    stalled_step, residual_small, iterate_settled, initial_residual
 using Test
 using Random
 using ForwardDiff
@@ -608,8 +610,12 @@ end
     x = zeros(T, n)
     y = zeros(T, n)
 
-    nl₁ = NonlinearSolver(Newton(), x, y; F=Fnan, jacobian=J₁, verbosity=2)
-    nl₂ = NonlinearSolver(Newton(), x, y; F=Fnan, jacobian=J₂, verbosity=2)
+    # `min_iterations = 1` is needed to reach the pathology at all: `Fnan(0) = exp(-Inf) = 0`
+    # exactly, so x = 0 *is* a root and `solve!` now tests the stopping criteria before the
+    # first step (see the `while !meets_stopping_criteria(…)` loop) and returns without
+    # computing a direction.  Forcing one iteration restores the path under test.
+    nl₁ = NonlinearSolver(Newton(), x, y; F=Fnan, jacobian=J₁, verbosity=2, min_iterations=1)
+    nl₂ = NonlinearSolver(Newton(), x, y; F=Fnan, jacobian=J₂, verbosity=2, min_iterations=1)
 
     x₁ = zeros(T, n)
     x₂ = zeros(T, n)
@@ -621,6 +627,15 @@ end
     # `NonlinearSolverException` (NaN in the direction vector).
     @test_throws SingularException solve!(x₁, nl₁)
     @test_throws NonlinearSolverException solve!(x₂, nl₂)
+
+    # Without the forced iteration the initial guess is recognised as a root and returned
+    # untouched — no Jacobian, no direction, no line search.
+    nl₃ = NonlinearSolver(Newton(), x, y; F=Fnan, jacobian=J₂, verbosity=0)
+    x₃ = zeros(T, n)
+    state₃ = SolverState(nl₃)
+    @test solve!(x₃, nl₃, state₃) == zeros(T, n)
+    @test iteration_number(state₃) == 0
+    @test isconverged(status(nl₃, state₃))
 
 end
 
@@ -782,4 +797,163 @@ end
     dogleg_test(Float64)
     dogleg_test(Float32)
 
+end
+
+@testset "$(rpad("the line search shares the solver's Options", 80))" begin
+    # Before, every solver built its `Linesearch` with an `Options` of its own, constructed
+    # from nothing but defaults.  So `verbosity = 0` on the solver did not silence the line
+    # search (downstream packages had to swallow the messages with a `NullLogger`), and a
+    # user-supplied iteration budget never reached the inner ladder.
+    F(y, x, params) = y .= x .^ 2 .- 2.0
+    x = [1.0]
+    y = zero(x)
+
+    for make in (NewtonSolver, PicardSolver, DogLegSolver)
+        s = make(x, F, y; verbosity=0, max_iterations=17, linesearch_max_iterations=9)
+        @test config(linesearch(s)) === config(s)
+        @test config(linesearch(s)).verbosity == 0
+        @test config(linesearch(s)).linesearch_max_iterations == 9
+    end
+
+    # ... and the same holds for the constructor that is handed a ready-made `Linesearch`
+    # carrying its own (default) `Options`: it is rebuilt on the solver's config.
+    s = NewtonSolver(x, F, y; linesearch=Backtracking(), verbosity=0)
+    @test config(linesearch(s)) === config(s)
+    @test config(linesearch(s)).verbosity == 0
+end
+
+@testset "$(rpad("verbosity = 0 silences a stagnating solve completely", 80))" begin
+    # The regression test for the reported warning flood: a residual whose round-off floor
+    # (≈ 1e-8 here, from the cancellation in `(1e8 + x) - 1e8`) lies far above the requested
+    # `f_abstol` cannot be driven to the tolerance.  Before, this produced one line-search
+    # warning per iteration for `max_iterations` iterations plus a "Solver took 1000
+    # iterations." message, and none of it could be silenced through the public API.
+    Ffloor(y, x, params) = y .= ((1e8 .+ x) .- 1e8) .- 1e-9
+
+    x = [1.0]
+    s = NewtonSolver(x, Ffloor, zero(x); f_abstol=1e-20, f_reltol=0.0, verbosity=0)
+    state = SolverState(s)
+    @test_logs solve!(x, s, state)          # no messages at all
+
+    st = status(s, state)
+    @test isstalled(st, config(s))
+    @test !isconverged(st)
+    @test iteration_number(state) ≤ 4       # was `max_iterations` (1000)
+    @test iteration_number(state) < config(s).max_iterations
+    @test st.rfₐ ≈ 1e-9 rtol = 1e-6         # the achievable floor is reported
+    @test st.stalls == config(s).max_stalls
+
+    # stagnation and convergence are mutually exclusive
+    @test !(isconverged(st) && isstalled(st, config(s)))
+
+    # at the default verbosity the stagnation warning names the achieved residual and the
+    # requested tolerance
+    x2 = [1.0]
+    s2 = NewtonSolver(x2, Ffloor, zero(x2); f_abstol=1e-20, f_reltol=0.0)
+    @test_logs (:warn, r"stagnated") match_mode = :any solve!(x2, s2, SolverState(s2))
+
+    # raising `f_abstol` above the floor makes the very same problem converge, quietly
+    x3 = [1.0]
+    s3 = NewtonSolver(x3, Ffloor, zero(x3); f_abstol=1e-6, f_reltol=0.0)
+    state3 = SolverState(s3)
+    @test_logs solve!(x3, s3, state3)
+    @test isconverged(status(s3, state3))
+    @test !isstalled(status(s3, state3), config(s3))
+    @test stall_number(state3) == 0
+end
+
+@testset "$(rpad("stall predicates and the consecutive-stall counter", 80))" begin
+    config₀ = Options(Float64; f_abstol=1e-10, f_reltol=0.0, x_suctol=1e-12)
+
+    # a frozen iterate whose residual is *large*: stagnation
+    state = NonlinearSolverState([1.0])
+    initialize!(state, [1.0], [1.0])          # r₀ = 1
+    update!(state, [1.0], [1.0])              # x̄ = x, ȳ = y ⇒ rxₛ = 0, rfₐ = 1
+    rxₛ, rfₐ, _ = residuals(state)
+    @test iterate_settled(rxₛ, config₀, state)
+    @test !residual_small(rfₐ, config₀, state)
+    @test stalled_step(rxₛ, rfₐ, config₀, state)
+
+    # ... and the same frozen iterate with a *small* residual is convergence, not stagnation
+    update!(state, [1.0], [0.0])
+    rxₛ₂, rfₐ₂, _ = residuals(state)
+    @test iterate_settled(rxₛ₂, config₀, state)
+    @test residual_small(rfₐ₂, config₀, state)
+    @test !stalled_step(rxₛ₂, rfₐ₂, config₀, state)
+
+    # the counter increments on consecutive stalls and resets on progress
+    state2 = NonlinearSolverState([1.0])
+    initialize!(state2, [1.0], [1.0])
+    @test stall_number(state2) == 0
+    update!(state2, [1.0], [1.0])
+    @test record_stall!(state2, config₀) == 1
+    @test record_stall!(state2, config₀) == 2
+    update!(state2, [5.0], [1.0])             # the iterate moved
+    @test record_stall!(state2, config₀) == 0
+
+    # a line-search floor flag counts as a stall, but only while the residual is not small
+    update!(state2, [5.0], [1.0])
+    flag_stall!(state2)
+    @test record_stall!(state2, config₀) == 1
+    update!(state2, [9.0], [0.0])             # residual small ⇒ success, not stagnation
+    flag_stall!(state2)
+    @test record_stall!(state2, config₀) == 0
+end
+
+@testset "$(rpad("pre-step convergence check and the merit-evaluation canary", 80))" begin
+    # An initial guess that already satisfies the stopping criteria must not be perturbed by a
+    # full solver step — including a line search asked to improve an already-exact residual.
+    n = Ref(0)
+    Fexact(y, x, params) = (n[] += 1; y .= x .- 1.0)
+
+    x = [1.0]
+    s = NewtonSolver(x, Fexact, zero(x); verbosity=0)
+    state = SolverState(s)
+    n[] = 0
+    solve!(x, s, state)
+    @test iteration_number(state) == 0
+    @test n[] == 1                 # the single residual evaluation of `initialize!`
+    @test isconverged(status(s, state))
+    @test x == [1.0]
+
+    # `min_iterations` still forces a step
+    x2 = [1.0]
+    s2 = NewtonSolver(x2, Fexact, zero(x2); verbosity=0, min_iterations=1)
+    state2 = SolverState(s2)
+    solve!(x2, s2, state2)
+    @test iteration_number(state2) == 1
+
+    # The α = 0 anchor — which every line search evaluates first — costs no residual
+    # evaluation when the caller supplies the merit it has already computed as `params.φ₀`
+    # (`solver_step!` does).  Only α = 0 is short-circuited; every other trial step is
+    # evaluated as before.
+    Fcount(y, x, params) = (n[] += 1; y .= x .^ 2 .- 2.0)
+    x3 = [1.0]
+    s3 = NewtonSolver(x3, Fcount, zero(x3); verbosity=0)
+    state3 = NonlinearSolverState(x3)
+    initialize!(s3, x3)
+    initialize!(state3, x3, [-1.0])
+    direction!(s3, x3, NullParameters(), 1)
+    prob = SimpleSolvers.problem(linesearch(s3))
+
+    shared = (x=x3, parameters=NullParameters(), φ₀=1.0)
+    plain = (x=x3, parameters=NullParameters())
+
+    n[] = 0
+    @test value(prob, 0.0, shared) == 1.0
+    @test n[] == 0                       # the anchor is taken from `params.φ₀`
+
+    n[] = 0
+    @test value(prob, 0.0, plain) == 1.0  # ... and is otherwise computed, to the same value
+    @test n[] == 1
+
+    n[] = 0
+    value(prob, 0.5, shared)
+    @test n[] == 1                       # a trial step α ≠ 0 is always evaluated
+
+    # a whole solver step evaluates the residual a bounded number of times (the residual is
+    # also evaluated through the autodiff Jacobian, twice here)
+    n[] = 0
+    solver_step!(x3, s3, state3, NullParameters())
+    @test n[] == 6
 end

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -4,6 +4,7 @@ using SimpleSolvers: NonlinearSolverState, assess_convergence, residuals, update
 using SimpleSolvers: meets_stopping_criteria, nonlinear_solver_warnings, NonlinearSolverStatus
 using SimpleSolvers: linesearch_problem, cache, jacobianmatrix, solution, value, direction, direction!, NullParameters
 using SimpleSolvers: trust_radius, DOGLEG_Δ_INITIAL
+using SimpleSolvers: isconverged, isstalled, status
 using SimpleSolvers: config, linesearch, stall_number, record_stall!, flag_stall!,
     stalled_step, residual_small, iterate_settled, initial_residual
 using SimpleSolvers: compute_new_iterate!, increase_iteration_number!, Bisection, Quadratic,
@@ -1068,4 +1069,87 @@ end
             any(!isfinite, x) && break
         end
     end
+end
+
+@testset "$(rpad("an ascent direction freezes the iterate and forces a fresh Jacobian", 80))" begin
+    # A deterministic ascent anchor. The direction is computed from the *regularized* Jacobian
+    # `J + λI` while the line search's φ'(0) = 2F·(J·d) uses the raw `J`, so for J = -1 and λ = 2
+    # the two disagree in sign: d = -(J+λ)⁻¹F = (x - 1) points *away* from the root at x = 1 and
+    # φ'(0) = -2F²J/(J+λ) = +2F² > 0.  (`check_anchor` names exactly this cause: a direction that
+    # did not come from an exact, freshly factorized Newton solve.)
+    Fneg(y, x, params) = y .= -(x .- 1.0)
+    DFneg!(J, x, params) = (J .= -1.0)
+
+    x = [0.0]
+    s = NewtonSolver(x, Fneg, zero(x); DF! = DFneg!, regularization_factor=2.0, verbosity=0)
+    state = SolverState(s)
+    solve!(x, s, state)
+
+    # The step is not taken: moving along a direction the line search rejected outright would
+    # only make the retry start from a worse point.  Before, the full step was taken, the iterate
+    # moved away from the root, nothing counted it as a stall, and the solve ran to
+    # `max_iterations` while diverging.
+    @test x == [0.0]
+    @test iteration_number(state) ≤ 4
+    @test iteration_number(state) < config(s).max_iterations
+    st = status(s, state)
+    @test isstalled(st, config(s))
+    @test !isconverged(st)
+
+    # the line search really is reporting a non-descent anchor here
+    SimpleSolvers.initialize!(s, x)
+    st0 = SolverState(s)
+    SimpleSolvers.initialize!(st0, x, SimpleSolvers.value!(value(cache(s)), SimpleSolvers.nonlinearproblem(s), x, NullParameters()))
+    direction!(s, x, NullParameters(), 1)
+    lsst = solve_with_status(SimpleSolvers.linesearch(s), 1.0,
+        (x=x, parameters=NullParameters(), φ₀=SimpleSolvers.L2norm(value(st0))))
+    @test SimpleSolvers.outcome(lsst) == LINESEARCH_NO_DESCENT
+    @test lsst.d₀ > 0
+end
+
+@testset "$(rpad("a stalled step forces a refactorization whatever refactorize is", 80))" begin
+    # `maybe_refactorize!` used to refresh only on `mod(iteration, refactorize) == 0`, so with
+    # `refactorize = 5` the stale Jacobian survived iterations 6–9. Two consecutive stalls in that
+    # window would end the solve (`max_stalls = 2`) for a reason a fresh Jacobian could have
+    # fixed. A stall now refreshes immediately, which is what makes `max_stalls = 2` conclusive
+    # for every `refactorize` rather than only for `refactorize = 1`.
+    njac = Ref(0)
+    Fq(y, x, params) = y .= x .^ 2 .- 2.0
+    DFq!(J, x, params) = (njac[] += 1; J .= 0.0; J[1, 1] = 2x[1])
+
+    x = [1.0]
+    s = NewtonSolver(x, Fq, zero(x); DF! = DFq!, refactorize=5, verbosity=0)
+
+    njac[] = 0
+    SimpleSolvers.maybe_refactorize!(s, x, NullParameters(), 7)
+    @test njac[] == 0                     # mid-cycle: the stale factorization is reused
+
+    SimpleSolvers.maybe_refactorize!(s, x, NullParameters(), 7; stalled=true)
+    @test njac[] == 1                     # ... unless the previous step stalled
+
+    SimpleSolvers.maybe_refactorize!(s, x, NullParameters(), 10)
+    @test njac[] == 2                     # and the refactorize cycle still fires
+
+    # `needs_refresh` is what `solver_step!` feeds in, from either source of the verdict
+    state = NonlinearSolverState([1.0])
+    initialize!(state, [1.0], [1.0])
+    @test !SimpleSolvers.needs_refresh(state)
+    flag_stall!(state)
+    @test SimpleSolvers.needs_refresh(state)      # flagged by the line search this step
+    record_stall!(state, config(s))               # consumes the flag into the counter
+    @test !state.stallflag
+    @test SimpleSolvers.needs_refresh(state)      # still true, now via the counter
+    update!(state, [5.0], [1.0])                  # the iterate moved
+    record_stall!(state, config(s))
+    @test SimpleSolvers.needs_refresh(state) == false
+
+    # end to end: a solve that stagnates with refactorize = 5 still stops on the stall counter
+    # rather than running to max_iterations
+    Ffloor(y, x, params) = y .= ((1e8 .+ x) .- 1e8) .- 1e-9
+    x2 = [1.0]
+    s2 = NewtonSolver(x2, Ffloor, zero(x2); f_abstol=1e-20, f_reltol=0.0, refactorize=5, verbosity=0)
+    state2 = SolverState(s2)
+    solve!(x2, s2, state2)
+    @test isstalled(status(s2, state2), config(s2))
+    @test iteration_number(state2) < config(s2).max_iterations
 end

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -177,13 +177,22 @@ for T ∈ (Float64, Float32)
         (NewtonSolver, (linesearch=Backtracking(T),), 2),
         (NewtonSolver, (linesearch=Bisection(T),), 2),
         (NewtonSolver, (linesearch=Quadratic(T),), 32),
-        (NewtonSolver, (linesearch=BierlaireQuadratic(T),), 2),
+        # `tolfac = 64` for the two BierlaireQuadratic rows: since these searches are bounded by
+        # `linesearch_max_iterations` (60 for Float64) rather than their former private cap of
+        # 20, they resolve the one-dimensional subproblem further, and on *this* seeded starting
+        # point (x₀ = 0.32597672886359486) the outer Newton iteration then meets its convergence
+        # test one step earlier, at 44 eps from the root instead of 0.  Over 300 random starts
+        # the change is a clear improvement, which is why the looser fixture tolerance is the
+        # right trade: for Float64 the 95th-percentile error drops from 1.9e6 to 9.7e3 eps with
+        # a fresh Jacobian and from 6.0e6 to 8.5e4 eps with `refactorize = 5` (median 8599 →
+        # 1.0), and three starts that used to throw in `triple_point_finder` no longer do.
+        (NewtonSolver, (linesearch=BierlaireQuadratic(T),), 64),
         (NewtonSolver, (linesearch=StrongWolfe(T),), 2),
         (NewtonSolver, (linesearch=Static(T), refactorize=5), 2),
         (NewtonSolver, (linesearch=Backtracking(T), refactorize=5), 2),
         (NewtonSolver, (linesearch=Bisection(T), refactorize=5), 2),
         (NewtonSolver, (linesearch=Quadratic(T), refactorize=5), 32),
-        (NewtonSolver, (linesearch=BierlaireQuadratic(T), refactorize=5), 8),
+        (NewtonSolver, (linesearch=BierlaireQuadratic(T), refactorize=5), 64),  # see above
         (NewtonSolver, (linesearch=StrongWolfe(T), refactorize=5), 2),
         # DogLegSolver is a trust-region method: it sets the step length via the
         # trust-region radius, not a line search, so it takes no `linesearch`

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -6,6 +6,8 @@ using SimpleSolvers: linesearch_problem, cache, jacobianmatrix, solution, value,
 using SimpleSolvers: trust_radius, DOGLEG_Δ_INITIAL
 using SimpleSolvers: config, linesearch, stall_number, record_stall!, flag_stall!,
     stalled_step, residual_small, iterate_settled, initial_residual
+using SimpleSolvers: compute_new_iterate!, increase_iteration_number!, Bisection, Quadratic,
+    StrongWolfe, Backtracking, steplength, solve_with_status
 using Test
 using Random
 using ForwardDiff
@@ -177,22 +179,20 @@ for T ∈ (Float64, Float32)
         (NewtonSolver, (linesearch=Backtracking(T),), 2),
         (NewtonSolver, (linesearch=Bisection(T),), 2),
         (NewtonSolver, (linesearch=Quadratic(T),), 32),
-        # `tolfac = 64` for the two BierlaireQuadratic rows: since these searches are bounded by
-        # `linesearch_max_iterations` (60 for Float64) rather than their former private cap of
-        # 20, they resolve the one-dimensional subproblem further, and on *this* seeded starting
-        # point (x₀ = 0.32597672886359486) the outer Newton iteration then meets its convergence
-        # test one step earlier, at 44 eps from the root instead of 0.  Over 300 random starts
-        # the change is a clear improvement, which is why the looser fixture tolerance is the
-        # right trade: for Float64 the 95th-percentile error drops from 1.9e6 to 9.7e3 eps with
-        # a fresh Jacobian and from 6.0e6 to 8.5e4 eps with `refactorize = 5` (median 8599 →
-        # 1.0), and three starts that used to throw in `triple_point_finder` no longer do.
-        (NewtonSolver, (linesearch=BierlaireQuadratic(T),), 64),
+        # These rows briefly carried `tolfac = 64`, when folding the quadratic searches into
+        # `linesearch_max_iterations` cost this seeded start (x₀ = 0.32597672886359486) accuracy.
+        # Fixing the single-point stall in the fit removed the cause — those large errors were
+        # solves hitting the iteration cap, not converging poorly — so the tolerance is back to
+        # the 2 eps every other method meets.  Measured over 300 random starts, the Float64
+        # 95th-percentile error is now 0.5 eps with a fresh Jacobian and 1.6 eps with
+        # `refactorize = 5` (median 0.50), against 9.7e3 and 8.5e4 eps before.
+        (NewtonSolver, (linesearch=BierlaireQuadratic(T),), 2),
         (NewtonSolver, (linesearch=StrongWolfe(T),), 2),
         (NewtonSolver, (linesearch=Static(T), refactorize=5), 2),
         (NewtonSolver, (linesearch=Backtracking(T), refactorize=5), 2),
         (NewtonSolver, (linesearch=Bisection(T), refactorize=5), 2),
         (NewtonSolver, (linesearch=Quadratic(T), refactorize=5), 32),
-        (NewtonSolver, (linesearch=BierlaireQuadratic(T), refactorize=5), 64),  # see above
+        (NewtonSolver, (linesearch=BierlaireQuadratic(T), refactorize=5), 2),  # see above
         (NewtonSolver, (linesearch=StrongWolfe(T), refactorize=5), 2),
         # DogLegSolver is a trust-region method: it sets the step length via the
         # trust-region radius, not a line search, so it takes no `linesearch`
@@ -965,4 +965,107 @@ end
     n[] = 0
     solver_step!(x3, s3, state3, NullParameters())
     @test n[] == 6
+end
+
+@testset "$(rpad("no line search returns α ≤ 0 during a Newton solve", 80))" begin
+    # `Bisection` and `Quadratic` inherit a direction flip from `bracket_minimum`, which used to
+    # let them return a *negative* step inside a Newton solve — measured at up to α = -3 for
+    # Bisection (49 of ~3750 line-search calls with refactorize = 5).  A negative α steps against
+    # a direction that has already been chosen, so the α > 0 contract now forbids it.  Driving
+    # the solver loop by hand is the only way to observe every α the line search returns.
+    fscalar(x::T) where {T<:Number} = exp(x) * (x^3 - 5x^2 + 2x) + 2one(T)
+    Fls!(y, x, params) = y .= fscalar.(x)
+
+    Random.seed!(4321)
+    for lsmethod in (Bisection, Quadratic, BierlaireQuadratic, Backtracking, StrongWolfe)
+        for refac in (1, 5)
+            for _ in 1:20
+                x = rand(1)
+                nl = NewtonSolver(x, similar(x); F=Fls!, linesearch=lsmethod(Float64),
+                    verbosity=0, refactorize=refac)
+                SimpleSolvers.initialize!(nl, x)
+                state = NonlinearSolverState(x)
+                SimpleSolvers.initialize!(state, x, [fscalar(x[1])])
+                for it in 1:12
+                    SimpleSolvers.increase_iteration_number!(state)
+                    direction!(nl, x, NullParameters(), it)
+                    any(isnan, direction(cache(nl))) && break
+                    α = solve(SimpleSolvers.linesearch(nl), 1.0, (x=x, parameters=NullParameters()))
+                    @test α > 0.0
+                    compute_new_iterate!(x, α, direction(cache(nl)))
+                end
+            end
+        end
+    end
+end
+
+@testset "$(rpad("BierlaireQuadratic no longer aborts a solve", 80))" begin
+    # The exact starting points measured to throw
+    # `ERROR: The function f must be decreasing at 0.0` out of `triple_point_finder`, which
+    # aborted the whole solve.  Two distinct causes: an ascent anchor from a stale Jacobian
+    # (refactorize = 5) and a merit flat to round-off (Float32, refactorize = 1).
+    #
+    # What must hold for *every* one of them is that the bracketing failure is reported rather
+    # than raised.  Two of the Float32 quasi-Newton starts still fail — but through the
+    # pre-existing, legitimate channel of a direction vector that goes `NaN`/`Inf` under a stale
+    # Jacobian, which `solver_step!` raises deliberately and which this change does not touch.
+    fscalar(x::T) where {T<:Number} = exp(x) * (x^3 - 5x^2 + 2x) + 2one(T)
+    Fb!(y, x, params) = y .= fscalar.(x)
+    roots = (-4.735035753706987262178160540350200552633, -0.6737697823920028217727631890832279199433,
+        0.7613128434711647120463439168731683731732, 4.560440205363600153577140702025401006278)
+
+    fixtures = ((Float64, 5, 0.1440401297), (Float64, 5, 0.2834847806), (Float64, 5, 0.2831226663),
+                (Float32, 1, 0.2834847867), (Float32, 1, 0.2831226587),
+                (Float32, 5, 0.2834847867), (Float32, 5, 0.2831226587))
+
+    for (T, refac, x₀) in fixtures
+        x = T[x₀]
+        nl = NewtonSolver(x, similar(x); F=Fb!, linesearch=BierlaireQuadratic(T),
+            verbosity=0, refactorize=refac)
+        state = SolverState(nl)
+        # The bracketing error must be gone.  A `NonlinearSolverException` (NaN direction) is a
+        # different, legitimate failure and is allowed through.
+        try
+            solve!(x, nl, state)
+        catch e
+            @test e isa NonlinearSolverException
+            @test !(e isa ErrorException && occursin("must be decreasing", e.msg))
+            continue
+        end
+        @test iteration_number(state) ≤ config(nl).max_iterations
+    end
+
+    # The five starts that are genuinely solvable now converge — including
+    # x₀ = 0.1440401297, which was expected to be unreachable.
+    for (T, refac, x₀) in ((Float64, 5, 0.1440401297), (Float64, 5, 0.2834847806),
+                           (Float64, 5, 0.2831226663), (Float32, 1, 0.2834847867),
+                           (Float32, 1, 0.2831226587))
+        x = T[x₀]
+        nl = NewtonSolver(x, similar(x); F=Fb!, linesearch=BierlaireQuadratic(T),
+            verbosity=0, refactorize=refac)
+        state = SolverState(nl)
+        solve!(x, nl, state)
+        @test isconverged(status(nl, state))
+        @test minimum(abs(Float64(x[1]) - r) for r in roots) < 1e-5
+    end
+
+    # And `triple_point_finder` itself never raises for any of them: the situation is reported
+    # through the status instead.
+    for (T, refac, x₀) in fixtures
+        x = T[x₀]
+        nl = NewtonSolver(x, similar(x); F=Fb!, linesearch=BierlaireQuadratic(T),
+            verbosity=0, refactorize=refac)
+        SimpleSolvers.initialize!(nl, x)
+        state = NonlinearSolverState(x)
+        SimpleSolvers.initialize!(state, x, T[fscalar(x₀)])
+        for it in 1:8
+            increase_iteration_number!(state)
+            direction!(nl, x, NullParameters(), it)
+            any(!isfinite, direction(cache(nl))) && break
+            st = SimpleSolvers.solve_with_status(linesearch(nl), one(T), (x=x, parameters=NullParameters()))
+            @test steplength(st) > zero(T)
+            compute_new_iterate!(x, steplength(st), direction(cache(nl)))
+            any(!isfinite, x) && break
+        end
+    end
 end

--- a/test/smoke_tests.jl
+++ b/test/smoke_tests.jl
@@ -115,6 +115,22 @@ end
     @test ls_prob isa LinesearchProblem
     @test Linesearch(ls_prob, Static()) isa Linesearch
     @test Linesearch(ls_prob) isa Linesearch
+    @test SimpleSolvers.with_config(Linesearch(ls_prob), Options(T)) isa Linesearch
+
+    # the status API is available for every line search method
+    for m in (Static(), Backtracking(), Bisection(), Quadratic(), BierlaireQuadratic(), StrongWolfe())
+        st = solve_with_status(Linesearch(ls_prob, m; verbosity=0), one(T))
+        @test st isa LinesearchStatus
+        @test st.outcome isa LinesearchOutcome
+        @test issufficient(st) isa Bool
+        @test isfloor(st) isa Bool
+    end
+    @test LINESEARCH_DECREASED isa LinesearchOutcome
+    @test LINESEARCH_FLOOR isa LinesearchOutcome
+    @test LINESEARCH_EXHAUSTED isa LinesearchOutcome
+    @test LINESEARCH_NO_DESCENT isa LinesearchOutcome
+    @test LINESEARCH_STATIONARY isa LinesearchOutcome
+    @test LINESEARCH_UNKNOWN isa LinesearchOutcome
 end
 
 
@@ -123,6 +139,7 @@ end
     @test NonlinearProblem(F_vec!, J_vec!, xvec, xvec) isa NonlinearProblem
 
     @test Options() isa Options
+    @test Options(; linesearch_max_iterations=10, max_stalls=3) isa Options
     @test NonlinearSolverException("msg") isa NonlinearSolverException
     @test NonlinearSolverState(xvec) isa NonlinearSolverState
 
@@ -133,4 +150,10 @@ end
     @test DogLegSolver(xvec, yr; F=F_vec!) isa NonlinearSolver
 
     @test NonlinearSolver(Newton(), xvec, yr; F=F_vec!) isa NonlinearSolver
+
+    ns = NewtonSolver(xvec, yr; F=F_vec!, verbosity=0)
+    nstate = SolverState(ns)
+    @test status(ns, nstate) isa NonlinearSolverStatus
+    @test isconverged(status(ns, nstate)) isa Bool
+    @test isstalled(status(ns, nstate), SimpleSolvers.config(ns)) isa Bool
 end

--- a/test/smoke_tests.jl
+++ b/test/smoke_tests.jl
@@ -6,6 +6,7 @@
 # were once broken have been fixed; every check below is a plain `@test`.
 
 using SimpleSolvers
+using SimpleSolvers: issufficient, isfloor, isconverged, isstalled, status
 using Test
 
 const T = Float64


### PR DESCRIPTION
Fixes the `Backtracking` line-search warning that floods downstream packages
(GeometricIntegrators, GeometricProblems, ChargedParticleDynamics):

```
┌ Warning: Backtracking line search did not satisfy the sufficient decrease condition within 1000 iterations. Returning the last trial step α = 2.220446049250313e-16.
└ @ SimpleSolvers src/linesearch/backtracking.jl:127
```

Five commits: the fix itself, then a budget unification, then a standardised contract across
all six line searches (which fixed two `BierlaireQuadratic` defects found on the way), then two
rounds of fixes from reviewing those.

## Root cause

`2.220446049250313e-16 == eps(1.0) == 1.0·0.5^52`, so the ladder always exited via its
`α ≤ eps` guard after ~53 trials — **the iteration count in the message was never true**, and
neither was the implied diagnosis.

The sufficient decrease condition `φ(α) ≤ φ(0) + c₁·α·φ'(0)` demands a decrease *proportional
to* `α` with no round-off allowance. Once `c₁·α·|φ'(0)|` falls below one ulp of `φ(0)` — at
`α* = eps/(4c₁) ≈ 5.55e-13` for the `‖F‖²` merit of a Newton step, independent of problem
scale — the right-hand side rounds back up to `φ(0)` exactly and the accept/reject decision is
made by **rounding alone**. Two failure modes follow, and **the reported warning is the less
harmful one**:

| regime | behaviour before |
|---|---|
| trial point stops moving above `α*` | the condition **"succeeded"** at `α ≈ 2.3e-13`, purely because a frozen merit tied a rounded right-hand side. The returned step did not move `x` at all — **and nothing was reported** |
| `‖δx‖ ≳ 400‖x‖` (near-singular J), or `\|φ'(0)\| ≳ 2500·φ(0)` (inexact solve, stale quasi-Newton Jacobian, regularization) | the ladder ran to `α = eps` and emitted the warning above |

Either way the outer iterate froze, the solve spun to `max_iterations`, and a second
misleading warning (`"Solver took 1000 iterations."`) followed.

The user-visible cause is an `f_abstol` below the residual's own round-off floor — and
`f_reltol` does *not* rescue it, since it is anchored at `‖F(x₀)‖` and therefore becomes
*tighter* the better the initial guess is. That trap is now documented in `Options`.

## Changes

**1. Algorithm.** An explicit round-off resolution `τ = τ_ulps·ulp(φ(0))`, from which the
smallest *informative* step `αmin = τ/(c₁|φ'(0)|) = 2·τ_ulps·α*` follows, so the search stays
clear of the region where the test is decided by rounding. The condition is
`φ(α) ≤ min{φ(0), φ(0) + c₁αφ'(0) + τ}` — the `min` bounds the slackening, so `τ` may reduce
the decrease *demanded* but can never accept a merit above `φ(0)`.

`τ_ulps` is **precision-aware** (`armijo_ulps(T, c₁)`). `τ` must be at least ~an ulp of `φ(0)`
to recognise a merit at its round-off floor, and far below the `2c₁·φ(0)` the condition demands
at `α = 1` to leave that condition meaningful — compatible only while `eps(T) ≪ 2c₁`. That holds
by ten orders of magnitude in `Float64` and by a factor 400 in `Float32`, so the nominal 4 ulps
stands in both and their behaviour is *bit-identical* to a fixed 4 (verified over five methods ×
four fixtures). It fails outright in `Float16`, where `eps(T) = 9.8e-4` already exceeds
`2c₁ = 2e-4`: the nominal `τ` was twenty times the demanded decrease, which both removed the
sufficient-decrease safeguard at every `α` and classified a genuine two-ulp decrease as
`LINESEARCH_FLOOR` — which `solver_step!` counts towards `max_stalls`, so a converging
half-precision solve could be reported as stagnated. The cap (at one percent of the demanded
decrease) drops `Float16` to ~2e-3 ulps, in effect the exact condition; the floor is still
detected without `τ`, both by the condition degenerating to `φ(α) ≤ φ(0)` at a small enough step
and by the bit-frozen-merit check.

Plus an up-front descent check (a non-descent anchor no longer costs 53 wasted merit evaluations), bit-frozen-merit
detection, and safeguarded quadratic/cubic interpolation confined to `[0.1α, p·α]` — so `p` is
now an *upper bound* on the shrink factor and the trial sequence is pointwise never longer
than before.

**2. Public status API.** `solve_with_status` returns a `LinesearchStatus` carrying
`(α, outcome, trials, φ₀, d₀, φ, τ, αmin)`, with a `LinesearchOutcome` enum that separates a
genuine decrease from an irreducible merit — the distinction the step length alone cannot
express. All six methods report a genuine outcome; `solve` keeps returning `T`, so no caller
breaks.

**3. Plumbing.** `config(linesearch(s)) === config(s)` now holds for `NewtonSolver`,
`PicardSolver` and `DogLegSolver`, so `verbosity = 0` finally silences the line search
(downstream had to use a `NullLogger`), and `max_iterations` no longer doubles as the ladder
budget — that is now `linesearch_max_iterations`, defaulting to `linesearch_iterations(T)`
(60 for `Float64`) rather than 1000. Both quadratic searches use the same field, so their
budget is settable too.

**4. Termination, and acting on what the line search reports.** A stagnating solve stops after
`max_stalls = 2` steps instead of running to `max_iterations`, with one actionable warning
naming the achieved residual against the requested tolerance. A stall is diagnosed from the
step actually taken, so it also covers a `Static` step along an underflowed direction, a
collapsed DogLeg radius and an expanding Picard map. A stall now also **forces a fresh Jacobian
on the next step** (`maybe_refactorize!(…; stalled)`), which is what makes `max_stalls = 2`
conclusive for any `refactorize` rather than only for `refactorize = 1`. And a
`LINESEARCH_NO_DESCENT` report is acted on: the iterate is left in place — moving along a
direction the line search rejected outright would only make the retry start from a worse point
— and a stall recorded, which triggers exactly the Jacobian refresh `check_anchor` prescribes.
`solve!` also tests the stopping criteria *before* the first step, and
`SimpleSolvers.status(solver, state)` makes the outcome inspectable (`solve!` returns `x`, so
it was previously unreachable).

**5. The line-search contract** (`638e956`). Investigating a crash showed the six line searches
differing along eight independent axes, only some principled. Every method reached through
`solve`/`solve_with_status` now guarantees: it never throws (unhandleable situations are
reported, not raised); it returns `α > 0`; it reports through `linesearch_warnings` only; a
non-finite or ascending anchor is reported rather than assumed away; and its cost is bounded
independently of the merit's scale. What is deliberately *not* standardised is the meaning of
the input `α`, because there are two families — condition-satisfying and `α`-relative
(`Backtracking`, `StrongWolfe`, `Static`) versus minimising and `α`-independent (`Bisection`,
`Quadratic`, `BierlaireQuadratic`, which check no Wolfe condition).

## Fixed along the way

- **`BierlaireQuadratic` could abort a whole solve** with `ERROR: The function f must be
  decreasing at 0.0` from `triple_point_finder` — 3 of 300 random starts. Two causes, both
  measured: an ascent anchor (`φ'(0) = +2.06e-15` for `Float64`, `+1.10e-02` for `Float32`,
  both at `refactorize = 5`), and a merit flat to round-off. Halving `δ` answers neither.
- **`BierlaireQuadratic` could stall on a single point** until its budget ran out: `φ(α) =
  c(α−1)²` cost 15/70/14 evaluations at `c = 1/1e-6/1e-12`, evaluating
  `α = 0.99999999999999911` thirty-plus times. When `χ` lands on `b` the bracket never
  contracts. Bisecting the wider sub-interval fixes it; cost is now 15/16/16/15/15 across merit
  scales `1e-12 … 1e12`. Over 300 random starts the `Float64` 95th-percentile distance to the
  root improves from 9.7e3 to 0.5 `eps` with a fresh Jacobian and from 8.5e4 to 1.6 `eps` with
  `refactorize = 5` (median 8599 → 0.50).
- `StrongWolfe` threw an `AssertionError` on a NaN merit or derivative, and could return
  `α = 0` from its zoom phase. It also evaluated the merit **twice per trial step** (once
  directly, once inside the one-argument `sdc`) plus once more when building its status; all
  three now reuse the value in scope.
- `Quadratic` and `Bisection` could return negative steps — up to `α = -3`, 49 of ~3750 calls
  at `refactorize = 5` — inherited from `bracket_minimum`'s direction flip. Verified: 0 negative
  steps in ~45000 calls.
- `triple_point_finder` conflated two opposite failures under one `nothing`. It now returns
  `:flat` (no resolvable decrease → `FLOOR`) or `:unbracketable` (a decrease that could not be
  bracketed → `EXHAUSTED`); conflating them made the outer iteration count a *descending* merit
  as stagnation.
- `LinesearchStatus.trials` was a hardcoded `0` for the three minimising searches, so the floor
  message read "in 0 trial step(s)". It is a real count everywhere now, exact for `Backtracking`
  and `StrongWolfe`.
- The stagnation warning had no `maxlog`, so a caller looping `solve!` per time step would see
  it once per step — reproducing the flood this PR removes.
- The round-off resolution was a fixed 4 ulps at every precision, which in `Float16` exceeds the
  decrease the sufficient decrease condition demands (see change 1 above).

## Verification

- **4116 assertions pass**; Aqua clean; docs build clean (doctests and cross-references). The
  contract matrix (6 methods × 8 pathological anchors) and the scale-invariance test run for
  `Float64`, `Float32` *and* `Float16` — the precision where the `τ` cap and `αmin`'s √eps clamp
  are load-bearing rather than decorative.
- **`Float64`/`Float32` are bit-identical** to the pre-`armijo_ulps` state: every returned step,
  outcome, trial count, `τ` and `αmin` matches across five methods × four fixtures × two
  precisions. The cap only ever binds in `Float16`.
- **Measured against SimpleSolvers 0.9.2** in a throwaway environment over 15
  GeometricProblems integrations: **402 → 4** user-visible messages. The remaining 4 are the
  genuinely unsolvable case (`ThreeBody` with a collisional initial condition, where no root
  exists), down from 402 for that case alone. Every other integration went to **0**. 12 of 14
  trajectories bit-for-bit identical; the exceptions are Lyapunov amplification of round-off in
  `LotkaVolterra2d` lode Gauss(2) (29 eps by step 1000) and the collisional `ThreeBody`.
- Throw sweep (300 starts × 5 methods × 2 precisions × 2 `refactorize` settings): no
  "must be decreasing", no "Unable to bracket", no `AssertionError`, no `α ≤ 0`.

⚠️ The downstream sweep predates the final commit. Freezing the iterate on
`LINESEARCH_NO_DESCENT` is the change that could move a trajectory, so it should be repeated
before merging.

One measurement changed the design: gating the round-off-floor message at `verbosity ≥ 1`
newly surfaced a warning on three *previously silent, correctly converging* solves. Reaching
the merit's floor is the normal final state of a converged solve, so that outcome (and the
stationary-anchor one) is reported only at `verbosity ≥ 2`; whether an irreducible merit
matters is the outer iteration's call, and it makes it.

## Breaking — version 0.10.0

`bracket_minimum` is **exported** and no longer throws, so `a, b = bracket_minimum(f, x)` on an
unbracketable `f` now fails with `MethodError: iterate(::Nothing)` where it used to raise a
descriptive error, and code relying on the throw to detect failure proceeds silently. With the
rest of the list below, a downstream `SimpleSolvers = "0.9"` bound must not pick this up
silently — hence the minor bump rather than 0.9.3.

- `assess_convergence` returns a 4-tuple `(x_converged, f_converged, f_increased, stalled)`.
  Existing `a, b, _ = …` destructurings keep working.
- `NonlinearSolverStatus` gained `stalls::Int`/`stalled::Bool`; `NonlinearSolverState` gained
  `stalls::Int`/`stallflag::Bool`; `Options` gained `linesearch_max_iterations`/`max_stalls`;
  `Backtracking` gained `τ_ulps::T` (positionally defaulted, and capped at `armijo_ulps(T, c₁)`
  by the inner constructor — so a `Float16` method gets ~2e-3 ulps whichever way it is built,
  including via `change_precision`).
- Removed: `max_number_of_quadratic_linesearch_iterations` and its two constants; the
  `solve(::Linesearch{<:Bisection}, α₀, α₁, params)` and `BierlaireQuadratic`
  `solve(ls, α₀, params, iteration_number)` overloads.
- `triple_point_finder` returns `Union{Symbol,…}` on failure (unexported).
- Exported: `LinesearchStatus`, `LinesearchOutcome`, the six `LINESEARCH_*` values,
  `solve_with_status`, `NonlinearSolverStatus`. Deliberately **not** exported:
  `issufficient`, `isfloor`, `steplength`, `outcome`, `trials`, `isconverged`, `isstalled`,
  `status` — generic names a package doing `using SimpleSolvers` may want for itself, `status`
  most of all (a downstream definition would be a method-definition error, not a shadowing
  warning). Reach them as `SimpleSolvers.status` and so on.
- With `min_iterations = 0` and `f_abstol > 0`, an already-satisfying initial guess now takes
  **zero** steps instead of one, and `f_abstol_break` can fire before any step.

Three existing tests were re-recorded, all for substantive reasons: the `φ'(0) > 0` exhaustion
test (now caught up front), the NaN-detection test (`exp(-1/x²)` is exactly `0` at `x = 0`, so
the pre-step check correctly returns without stepping from a root; it now passes
`min_iterations = 1`), and the `τ` slackening test (the `min` against `φ(0)` correctly rejects
what the unbounded form accepted).

Also adds the 0.9.1/0.9.2 CHANGELOG sections that were never written, and marks the 0.9.0
"default line search is now `StrongWolfe`" entry as reverted in 0.9.1 (commit 264be0a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
