### PR TITLE
Let Backtracking lengthen a step, and drop the α₀ that never configured one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,13 @@ factor of 217, which is precisely the knob `α₀` appeared to offer and did not
   still satisfies the sufficient decrease condition and strictly improves the merit. A shrunken
   step is never expanded again — the longer steps below it have already been rejected. Two
   further keys tune it, `q` (an upper bound on the growth factor per round, the counterpart of
-  `p`) and `nexpand` (the cap on expansion trials).
+  `p`) and `nexpand` (the cap on expansion trials, applied from *within* the
+  `linesearch_max_iterations` of `Options` rather than beside it, so the whole search still
+  spends at most that many merit evaluations). This is the one place where a line search leaves
+  the interval `[0, α]` the caller offered: the largest step it can try is `q^nexpand · α`, a
+  thousand times the trial step on the defaults. A trial whose merit is not finite is rejected at
+  the cost of that one evaluation, but a merit that *throws* outside its domain is the caller's
+  to guard — one more reason the phase is opt-in.
 - The step it grows to is chosen by a new `SimpleSolvers.backtracking_extrapolation`, from the
   *same* quadratic model through `φ(0)`, `φ'(0)` and `φ(α)` that `backtracking_interpolation`
   uses on the way down. All three values are already known when the trial step is accepted, so
@@ -69,9 +75,11 @@ iterations), `2` and above all do, hence the default of 3. On `q`, the range 4�
 rather than a cliff — `q = 100` reaches 594/398 on the two `_DFP` rows — and the default of 10 is
 the conservative point on it rather than the best on this one problem.
 
-**Behaviour is unchanged unless `expand = true`.** The whole 0.10.1 test suite passes unedited,
-including the iteration counts, the `trials` counts and the zero-allocation assertions, and
-`NewtonSolver`'s default line search still shrinks only. GeometricIntegrators' Runge-Kutta suite
+**Behaviour is unchanged unless `expand = true`.** No expectation of the 0.10.1 test suite was
+adjusted to make this pass — every iteration count, `trials` count and zero-allocation assertion
+stands as it was, and the only edits to the test files are new cases and the addition of
+`Backtracking(T; expand = true)` to loops that already ran over every method. `NewtonSolver`'s
+default line search still shrinks only. GeometricIntegrators' Runge-Kutta suite
 passes (128 assertions) with bit-identical trajectories for `Gauss(1)`…`Gauss(4)`. To fix an
 under-scaled direction, ask for it:
 `NewtonSolver(x, F, y; linesearch = Backtracking(T; expand = true))`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,80 @@
 
 All notable changes to SimpleSolvers.jl are documented here.
 
+## [0.11.0]
+
+`Backtracking` can now lengthen a step, and no longer carries a field that pretended to
+configure one. Both halves of [issue #174](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/174).
+
+### The defects
+
+**`Backtracking.α₀` was never read.** It was stored, documented as *"the initial step size α"*,
+printed by `show`, compared by `isapprox` and converted by `change_precision` — but neither
+`solve` nor `solve_with_status` ever looked at it. The trial step was, and remains, the `α`
+argument. `Backtracking(; α₀ = 10.0)` therefore configured nothing.
+
+**The search could only shrink.** A backtracking search returns the trial step it was given
+whenever that step is acceptable, so on a direction whose natural scale is *larger* than the
+trial step it pins `α` at the caller's ceiling on every iteration. On the SVD test problem of
+JuliaGNI/GeometricOptimizers.jl#31 that cost a DFP direction — which wants `α ≈ 11` throughout —
+**49 679** iterations against **134** for `Bisection`, whose rightward bracketing is immune. It
+is a property of the search, not of DFP: BFGS, already scaled like a Newton step, is unaffected
+(113 against 143). Handing the same `Backtracking` a trial step of 3 instead of 1 is worth a
+factor of 217, which is precisely the knob `α₀` appeared to offer and did not.
+
+### Fixed
+
+- **Breaking**: the `α₀` key of `Backtracking` and the constant `SimpleSolvers.DEFAULT_ARMIJO_α₀`
+  are removed, along with the positional `Backtracking{T}(α₀, c₁, c₂, p[, τ_ulps])` form. The
+  trial step now has exactly one source, the `α` argument of `solve`/`solve_with_status`. No
+  behaviour changes, because nothing read the field.
+- `Backtracking` gained an **expansion phase**, behind a new `expand` key that is `false` by
+  default: with it set, an accepted *first* trial step is lengthened while each longer trial
+  still satisfies the sufficient decrease condition and strictly improves the merit. A shrunken
+  step is never expanded again — the longer steps below it have already been rejected. Two
+  further keys tune it, `q` (an upper bound on the growth factor per round, the counterpart of
+  `p`) and `nexpand` (the cap on expansion trials).
+- The step it grows to is chosen by a new `SimpleSolvers.backtracking_extrapolation`, from the
+  *same* quadratic model through `φ(0)`, `φ'(0)` and `φ(α)` that `backtracking_interpolation`
+  uses on the way down. All three values are already known when the trial step is accepted, so
+  the decision whether to expand at all costs no merit evaluation: a direction scaled like a
+  Newton step is at its model minimum and returns after the single trial the shrink-only search
+  would have made. That is what allowed the phase to be worth having at all — for the merit of a
+  `NonlinearSolver`, one evaluation is a full residual evaluation. It is also why the phase does
+  not consult the curvature condition, which would cost a full Jacobian per trial; `StrongWolfe`
+  remains the method for that.
+
+### Measured
+
+On the `St(20,3)²` SVD problem of GeometricOptimizers (`test/optimizer_convergence/svd_optim.jl`,
+seed 1234), iterations to convergence:
+
+| method + retraction | `Backtracking` | `Backtracking(; expand = true)` | `Bisection` |
+|---|---|---|---|
+| `_DFP` + Geodesic | 49 679 | **830** | 134 |
+| `_DFP` + Cayley | 29 081 | **1 237** | 96 |
+| `_BFGS` + Geodesic | 113 | 93 | 143 |
+| `_BFGS` + Cayley | 136 | 118 | 93 |
+
+The `Backtracking` column reproduces 0.10.1's numbers exactly, which is the check that the
+default path is untouched. The well-scaled `_BFGS` rows are not merely unharmed but slightly
+better, because an occasional step *is* longer than the trial one. `_DFP` is still behind
+`Bisection` on iteration count, but ahead of it on wall clock (0.2 s against 0.5 s for
+Geodesic): a `Bisection` iteration spends of the order of 580 merit evaluations against
+`Backtracking`'s 25.
+
+On `nexpand`, the same problem: `1` is too few for `_DFP` (it does not converge within 60 000
+iterations), `2` and above all do, hence the default of 3. On `q`, the range 4–100 is a plateau
+rather than a cliff — `q = 100` reaches 594/398 on the two `_DFP` rows — and the default of 10 is
+the conservative point on it rather than the best on this one problem.
+
+**Behaviour is unchanged unless `expand = true`.** The whole 0.10.1 test suite passes unedited,
+including the iteration counts, the `trials` counts and the zero-allocation assertions, and
+`NewtonSolver`'s default line search still shrinks only. GeometricIntegrators' Runge-Kutta suite
+passes (128 assertions) with bit-identical trajectories for `Gauss(1)`…`Gauss(4)`. To fix an
+under-scaled direction, ask for it:
+`NewtonSolver(x, F, y; linesearch = Backtracking(T; expand = true))`.
+
 ## [0.10.1]
 
 Compile-time and allocation fixes. No behaviour change: the same messages, at the same `verbosity`

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleSolvers"
 uuid = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Michael Kraus"]
 
 [deps]

--- a/docs/src/linesearch/backtracking.md
+++ b/docs/src/linesearch/backtracking.md
@@ -114,6 +114,64 @@ cc = CurvatureCondition(c₂, problem.D(0., params), alpha -> problem.D(alpha, p
 cc(αₜ)
 ```
 
+## [Lengthening the step](@id backtracking_expansion)
+
+A backtracking search only ever *shrinks*. It therefore hands back the trial step it was given
+whenever that step is acceptable — and on a search direction whose natural scale is **larger**
+than the trial step, that is every single iteration. The step is pinned at the caller's ceiling
+and the outer solve crawls.
+
+This is a property of the search rather than of the method that produced the direction. In the
+case that prompted it ([issue #174](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/174)) a
+DFP direction wanted ``\alpha \approx 11`` throughout and took **49 679** iterations with
+`Backtracking` against **134** with [`Bisection`](@ref), which brackets rightwards and is
+therefore immune; BFGS, whose direction is already scaled like a Newton step, was unaffected.
+Note that no caller-side rule for the initial step fixes this: the scale deficit is *persistent*,
+not an artefact of initialisation, so every heuristic that recomputes ``\alpha`` from the current
+iterate helps the under-scaled method and hurts the well-scaled one.
+
+Setting `expand` makes the search two-sided. When the first trial step is accepted, it is
+lengthened (see [`SimpleSolvers.backtracking_extrapolation`](@ref)) while each longer trial keeps
+satisfying the [sufficient decrease condition](@ref "The Sufficient Decrease Condition") and
+strictly improving the merit:
+
+```@example expand
+using SimpleSolvers
+using SimpleSolvers: steplength, trials
+
+# a direction under-scaled by an order of magnitude: the merit is minimised at α = 11,
+# but the caller only offers α = 1
+prob = LinesearchProblem{Float64}((α, _) -> (α - 11.0)^2, (α, _) -> 2(α - 11.0))
+
+shrink = solve_with_status(Linesearch(prob, Backtracking()), 1.0)
+grow   = solve_with_status(Linesearch(prob, Backtracking(; expand = true)), 1.0)
+
+(shrink = (steplength(shrink), trials(shrink)), expand = (steplength(grow), trials(grow)))
+```
+
+The step reaches the right *scale* — that is the whole of the problem — in two merit evaluations
+rather than one.
+
+It is off by default, and the reason is worth stating: a well-scaled direction is the common
+case, and it must not pay for a feature it cannot use. It does not. The model that decides
+whether to expand is the same quadratic through ``\varphi(0)``, ``\varphi'(0)`` and
+``\varphi(\alpha)`` that [`SimpleSolvers.backtracking_interpolation`](@ref) uses on the way down,
+so all three values are already in hand and the decision is free:
+
+```@example expand
+newton = LinesearchProblem{Float64}((α, _) -> (α - 1.0)^2, (α, _) -> 2(α - 1.0))
+st = solve_with_status(Linesearch(newton, Backtracking(; expand = true)), 1.0)
+
+(steplength(st), trials(st))   # α = 1 is the model minimum: no extra evaluation is spent
+```
+
+That matters because for the merit of a [`NonlinearSolver`](@ref) one evaluation is a full
+residual evaluation, the most expensive single operation of a solver step. It is also why the
+phase does not test the [curvature condition](@ref "The Curvature Condition") to decide when to
+stop growing, which would cost a full [`Jacobian`](@ref) per trial. Where curvature control is
+genuinely required, use [`StrongWolfe`](@ref), which brackets on the derivative; where an actual
+line *minimiser* is wanted, use [`Bisection`](@ref) or [`Quadratic`](@ref).
+
 ## Stagnation at the round-off floor
 
 The sufficient decrease condition demands a decrease *proportional to* ``\alpha``:

--- a/docs/src/linesearch/backtracking.md
+++ b/docs/src/linesearch/backtracking.md
@@ -172,6 +172,17 @@ stop growing, which would cost a full [`Jacobian`](@ref) per trial. Where curvat
 genuinely required, use [`StrongWolfe`](@ref), which brackets on the derivative; where an actual
 line *minimiser* is wanted, use [`Bisection`](@ref) or [`Quadratic`](@ref).
 
+!!! note "The search leaves the interval the caller offered"
+    This is the one phase that evaluates ``\varphi`` beyond ``\alpha``. The largest step it can
+    try is ``q^{\mathrm{nexpand}}\alpha``, i.e. a thousand times the trial step on the defaults.
+    A trial whose merit is infinite or `NaN` is simply rejected, at the cost of that one
+    evaluation; a merit that *throws* outside its domain is the caller's to guard. Setting
+    `expand` is therefore a statement that ``\varphi`` is evaluable that far out.
+
+    What it does *not* do is spend more evaluations than it was allowed to: `nexpand` bounds the
+    phase from within the `linesearch_max_iterations` of [`Options`](@ref), not beside it, so the
+    whole search — ladder and expansion together — still stops at that budget.
+
 ## Stagnation at the round-off floor
 
 The sufficient decrease condition demands a decrease *proportional to* ``\alpha``:

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -91,9 +91,9 @@ The keys are:
 - `c₁`=""" * string(DEFAULT_WOLFE_c₁) * raw""": the constant ``c_1`` in the [`SufficientDecreaseCondition`](@ref) (Armijo condition). Also see [`DEFAULT_WOLFE_c₁`](@ref).
 - `c₂`=""" * string(DEFAULT_WOLFE_c₂) * raw""": the constant on whose basis the [`CurvatureCondition`](@ref) is tested. We should have ``c_2\in(c_1, 1).`` The closer this constant is to 1, the easier it is to satisfy the [`CurvatureCondition`](@ref).
 - `p`=""" * string(DEFAULT_ARMIJO_p) * raw""": an *upper bound* on the factor by which ``\alpha`` is decreased in every step until the stopping criterion is satisfied. The actual factor is chosen by interpolation and confined to ``[`` [`BACKTRACKING_SHRINK_MIN`](@ref) ``\cdot\alpha, p\alpha]``, so the trial sequence is never longer than the plain ``\alpha \gets p\alpha`` ladder.
-- `expand`=`false`: whether the search may *lengthen* the trial step (the expansion phase described below). Off by default, so a `Backtracking` is the classical one-sided algorithm unless it is asked for.
+- `expand`=`false`: whether the search may *lengthen* the trial step (the expansion phase described below). Off by default, so a `Backtracking` is the classical one-sided algorithm unless it is asked for. Setting it requires the merit to be *evaluable* — finite or not, but not throwing — out to ``q^{\mathrm{nexpand}}\alpha``, since that is the largest step the phase can try.
 - `q`=""" * string(DEFAULT_BACKTRACKING_q) * raw""": an *upper bound* on the factor by which ``\alpha`` is increased in one expansion round — the counterpart of ``p``. Only used when `expand` is set. See [`DEFAULT_BACKTRACKING_q`](@ref).
-- `nexpand`=""" * string(DEFAULT_BACKTRACKING_NEXPAND) * raw""": the cap on the number of expansion trials, each of which costs one merit evaluation. Only used when `expand` is set. See [`DEFAULT_BACKTRACKING_NEXPAND`](@ref).
+- `nexpand`=""" * string(DEFAULT_BACKTRACKING_NEXPAND) * raw""": the cap on the number of expansion trials, each of which costs one merit evaluation. It bounds the phase from within the `linesearch_max_iterations` of [`Options`](@ref) rather than beside it: whichever of the two is smaller applies, so the whole search still spends at most `linesearch_max_iterations` merit evaluations. Only used when `expand` is set. See [`DEFAULT_BACKTRACKING_NEXPAND`](@ref).
 - `τ_ulps`=[`armijo_ulps`](@ref)`(T, c₁)` (""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""" in `Float64` and `Float32`, less in `Float16`): the round-off resolution of the merit, in units in the last place of ``\varphi(0)``. It slackens the [`SufficientDecreaseCondition`](@ref) (never past ``\varphi(0)``), fixes ``\alpha_\mathrm{min}``, and separates a genuine decrease from one within the noise. A value larger than [`armijo_ulps`](@ref)`(T, c₁)` is capped to it, since above that ``\tau`` would swamp the decrease the condition demands. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
 
 # Implementation
@@ -137,6 +137,16 @@ With `expand = true` and the *first* trial step accepted, the search may also le
 [`SufficientDecreaseCondition`](@ref) *and* strictly improves the merit; at most `nexpand` such
 trials are made and the best step seen is returned. A shrunken step is never expanded again:
 once the ladder has backtracked, the longer steps are already known to fail.
+
+This is the one place where the search leaves the interval ``[0, \alpha]`` the caller offered.
+The largest step it can try is ``q^{\mathrm{nexpand}}\alpha`` — a thousand times the trial step
+on the defaults — and a trial whose merit is not finite is simply rejected, at the cost of the
+one evaluation. A merit that *throws* outside its domain is the caller's to guard, and it is one
+reason the phase is opt-in.
+
+The trials it spends come out of the `linesearch_max_iterations` budget of [`Options`](@ref),
+not out of a second budget beside it, so termination case 4 above still bounds the whole search:
+the phase makes at most `nexpand` trials *and* at most as many as that budget has left.
 
 This is what makes the search two-sided. A shrink-only search returns the trial step it was
 given whenever that step is acceptable, so on a direction whose natural scale is *larger* than
@@ -316,9 +326,12 @@ the step grows by the full factor ``q``. A denominator that is not *finite* is a
 entirely, namely no model at all, and returns `α`.
 
 Everything the model needs has already been evaluated, so the decision costs no merit
-evaluation. That is what the lower bound [`BACKTRACKING_GROW_MIN`](@ref) is for: unless the
-model wants a step at least that multiple of ``\alpha``, `α` is returned unchanged and the
-search stops without spending one. A direction scaled like a Newton step has
+evaluation. That is what the lower bound [`BACKTRACKING_GROW_MIN`](@ref) is for: unless the step
+the search would actually try is at least that multiple of ``\alpha``, `α` is returned unchanged
+and the search stops without spending one. The test is on the *clamped* step rather than on
+``\alpha^\star`` itself, which matters only for ``q <`` [`BACKTRACKING_GROW_MIN`](@ref): there
+the clamp, not the model, is what decides, and a convex model must not be allowed to buy a
+growth by ``q`` that a non-convex one is refused. A direction scaled like a Newton step has
 ``\alpha^\star \approx \alpha`` at ``\alpha = 1`` and therefore pays nothing at all, and a merit
 sitting at its round-off floor (``\varphi(\alpha) \approx \varphi(0)``) gives
 ``\alpha^\star \approx \alpha/2``, so the model declines to expand into rounding noise without
@@ -331,8 +344,16 @@ function backtracking_extrapolation(φ₀::T, d₀::T, α::T, φα::T, q::T) whe
     # strength of a `NaN`. (`backtracking_interpolation` guards its model the same way.)
     isfinite(den) || return α
     αₙ = den > zero(T) ? -d₀ * α^2 / den : q * α
-    (isfinite(αₙ) && αₙ ≥ T(BACKTRACKING_GROW_MIN) * α) || return α
-    min(αₙ, q * α)
+    isfinite(αₙ) || return α
+    # The gate is applied to the *clamped* step — the one that would actually be tried — rather
+    # than to the raw minimiser. For `q ≥ BACKTRACKING_GROW_MIN`, which every default is, the two
+    # agree: the clamp cannot pull a step that passed the gate back below it. For a smaller `q`
+    # they do not, and gating the raw minimiser would then let a convex model spend a merit
+    # evaluation to grow by only `q`, while a non-convex one — which asks for exactly `q * α` —
+    # was refused that same growth outright.
+    αₙ = min(αₙ, q * α)
+    αₙ ≥ T(BACKTRACKING_GROW_MIN) * α || return α
+    αₙ
 end
 
 # The expansion phase of `solve_with_status` below: lengthen the accepted step `α` while
@@ -417,8 +438,13 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
             # ceiling on a direction whose natural scale is larger (issue #174). Only the first
             # trial is expanded — once the ladder has backtracked, the longer steps below have
             # already been rejected — and only when asked, `expand` being off by default.
+            # The expansion draws on the *same* `linesearch_max_iterations` budget as the ladder,
+            # so `trials` keeps meaning "merit evaluations this line search spent" and the bound
+            # `Options` documents keeps holding. The cap binds only for a budget of `nexpand + 1`
+            # or less; at the default of 60 against 3 it never does.
             if m.expand && i == 1
-                α, φₐ, n = backtracking_expand(f, sdc, φ₀, d₀, α, φₐ, n, m.q, m.nexpand)
+                budget = min(m.nexpand, config(ls).linesearch_max_iterations - n)
+                α, φₐ, n = backtracking_expand(f, sdc, φ₀, d₀, α, φₐ, n, m.q, budget)
             end
             oc = φₐ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR
             return LinesearchStatus{T}(α, oc, n, φ₀, d₀, φₐ, τ, αmin)

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -1,12 +1,4 @@
 using Printf
-@doc raw"""
-    const DEFAULT_ARMIJO_α₀
-
-The default starting value for ``\alpha`` used in [`Backtracking`](@ref).
-Its value is """ * """$(DEFAULT_ARMIJO_α₀).
-"""
-const DEFAULT_ARMIJO_α₀ = 1.0
-
 """
     const DEFAULT_ARMIJO_p
 
@@ -55,15 +47,53 @@ Its value is """ * """$(BACKTRACKING_SHRINK_MIN).
 const BACKTRACKING_SHRINK_MIN = 0.1
 
 @doc raw"""
+    const BACKTRACKING_GROW_MIN
+
+Lower bound on the factor by which the expansion phase of [`Backtracking`](@ref) lengthens an
+accepted step: unless the model minimiser lies at least
+``\mathrm{BACKTRACKING\_GROW\_MIN}\cdot\alpha``, the trial step is kept and no further merit
+evaluation is spent (see [`backtracking_extrapolation`](@ref)).
+Its value is """ * """$(BACKTRACKING_GROW_MIN).
+
+This is the counterpart of [`BACKTRACKING_SHRINK_MIN`](@ref) on the growing side, and it is what
+makes the expansion phase free for a well-scaled direction: a Newton or BFGS step is already at
+its model minimum, so the test fails and the search returns at once.
+"""
+const BACKTRACKING_GROW_MIN = 2.0
+
+@doc raw"""
+    const DEFAULT_BACKTRACKING_q
+
+The default *upper* bound on the factor by which the expansion phase of [`Backtracking`](@ref)
+lengthens the step in one round, i.e. the counterpart of ``p`` on the growing side.
+Its value is """ * """$(DEFAULT_BACKTRACKING_q).
+"""
+const DEFAULT_BACKTRACKING_q = 10.0
+
+"""
+    const DEFAULT_BACKTRACKING_NEXPAND
+
+The default cap on the number of expansion trials of [`Backtracking`](@ref); each one costs a
+merit evaluation. Its value is $(DEFAULT_BACKTRACKING_NEXPAND).
+"""
+const DEFAULT_BACKTRACKING_NEXPAND = 3
+
+@doc raw"""
     Backtracking <: LinesearchMethod
 
 # Keys
 
+The trial step ``\alpha`` is *not* a key: it is the argument of [`solve`](@ref), which is its only
+source. (A `Backtracking` used to carry an `α₀` field for it, which the algorithm never read — see
+issue #174.)
+
 The keys are:
-- `α₀`=""" * string(DEFAULT_ARMIJO_α₀) * raw""": the initial step size ``\alpha``. This is decreased iteratively by a factor ``p`` until the [`SufficientDecreaseCondition`](@ref) is satisfied.
 - `c₁`=""" * string(DEFAULT_WOLFE_c₁) * raw""": the constant ``c_1`` in the [`SufficientDecreaseCondition`](@ref) (Armijo condition). Also see [`DEFAULT_WOLFE_c₁`](@ref).
 - `c₂`=""" * string(DEFAULT_WOLFE_c₂) * raw""": the constant on whose basis the [`CurvatureCondition`](@ref) is tested. We should have ``c_2\in(c_1, 1).`` The closer this constant is to 1, the easier it is to satisfy the [`CurvatureCondition`](@ref).
 - `p`=""" * string(DEFAULT_ARMIJO_p) * raw""": an *upper bound* on the factor by which ``\alpha`` is decreased in every step until the stopping criterion is satisfied. The actual factor is chosen by interpolation and confined to ``[`` [`BACKTRACKING_SHRINK_MIN`](@ref) ``\cdot\alpha, p\alpha]``, so the trial sequence is never longer than the plain ``\alpha \gets p\alpha`` ladder.
+- `expand`=`false`: whether the search may *lengthen* the trial step (the expansion phase described below). Off by default, so a `Backtracking` is the classical one-sided algorithm unless it is asked for.
+- `q`=""" * string(DEFAULT_BACKTRACKING_q) * raw""": an *upper bound* on the factor by which ``\alpha`` is increased in one expansion round — the counterpart of ``p``. Only used when `expand` is set. See [`DEFAULT_BACKTRACKING_q`](@ref).
+- `nexpand`=""" * string(DEFAULT_BACKTRACKING_NEXPAND) * raw""": the cap on the number of expansion trials, each of which costs one merit evaluation. Only used when `expand` is set. See [`DEFAULT_BACKTRACKING_NEXPAND`](@ref).
 - `τ_ulps`=[`armijo_ulps`](@ref)`(T, c₁)` (""" * string(DEFAULT_ARMIJO_τ_ULPS) * raw""" in `Float64` and `Float32`, less in `Float16`): the round-off resolution of the merit, in units in the last place of ``\varphi(0)``. It slackens the [`SufficientDecreaseCondition`](@ref) (never past ``\varphi(0)``), fixes ``\alpha_\mathrm{min}``, and separates a genuine decrease from one within the noise. A value larger than [`armijo_ulps`](@ref)`(T, c₁)` is capped to it, since above that ``\tau`` would swamp the decrease the condition demands. See [`DEFAULT_ARMIJO_τ_ULPS`](@ref).
 
 # Implementation
@@ -97,7 +127,33 @@ improvable by any line search), whereas one that does vary contradicts ``d_0 < 0
 
 The [`CurvatureCondition`](@ref) is not used to terminate the iteration — it cannot be
 honoured by shrinking alone — it is only checked afterwards to emit a warning (see
-[`curvature_diagnostic`](@ref)).
+[`curvature_diagnostic`](@ref)). With `expand` set it *is* satisfied more often, because the
+expansion phase moves the accepted step toward the line minimiser, so the diagnostic fires less.
+
+## The expansion phase
+
+With `expand = true` and the *first* trial step accepted, the search may also lengthen it, by
+[`backtracking_extrapolation`](@ref), while each longer trial still satisfies the
+[`SufficientDecreaseCondition`](@ref) *and* strictly improves the merit; at most `nexpand` such
+trials are made and the best step seen is returned. A shrunken step is never expanded again:
+once the ladder has backtracked, the longer steps are already known to fail.
+
+This is what makes the search two-sided. A shrink-only search returns the trial step it was
+given whenever that step is acceptable, so on a direction whose natural scale is *larger* than
+the trial step it pins ``\alpha`` at that ceiling on every iteration and the outer solve crawls —
+by two orders of magnitude in the DFP case of issue #174, where the direction wanted
+``\alpha \approx 11`` throughout.
+
+The phase costs nothing where it can gain nothing. The model it extrapolates from is the same
+quadratic that [`backtracking_interpolation`](@ref) uses on the way down, built from
+``\varphi(0)``, ``\varphi'(0)`` and the merit at the trial step — all three already known — so
+the decision whether to expand at all is free, and a direction that is already scaled like a
+Newton step (which is at its model minimum at ``\alpha = 1``) fails the test and returns without
+a further merit evaluation. That matters because for the merit of a [`NonlinearSolver`](@ref) an
+evaluation is a full residual evaluation, the most expensive single operation of a solver step,
+which is also why the phase does not test the [`CurvatureCondition`](@ref) to decide when to stop
+growing: that would cost a full [`Jacobian`](@ref) per trial. Use [`StrongWolfe`](@ref), which
+brackets on the derivative, where curvature control is genuinely required.
 
 # Extended help
 
@@ -113,31 +169,41 @@ to ``\varphi(\alpha) \leq \varphi_0``, i.e. plain monotonicity, and such an acce
 `LINESEARCH_FLOOR` rather than as a decrease.
 """
 struct Backtracking{T} <: LinesearchMethod{T}
-    α₀::T
     c₁::T
     c₂::T
     p::T
+    q::T
     τ_ulps::T
+    expand::Bool
+    nexpand::Int
 
-    function Backtracking{T}(α₀::T, c₁::T, c₂::T, p::T, τ_ulps::T=armijo_ulps(T, c₁)) where {T}
+    function Backtracking{T}(c₁::T, c₂::T, p::T, q::T, τ_ulps::T=armijo_ulps(T, c₁),
+        expand::Bool=false, nexpand::Int=DEFAULT_BACKTRACKING_NEXPAND) where {T}
         @assert 0 < p < 1 "The shrinking parameter needs to satisfy 0 < p < 1, it is $(p)."
+        @assert q > 1 "The expansion parameter needs to satisfy q > 1, it is $(q)."
         @assert 0 < c₁ < c₂ < 1 "The Wolfe constants need to satisfy 0 < c₁ < c₂ < 1, they are c₁ = $(c₁), c₂ = $(c₂)."
         @assert τ_ulps ≥ 0 "The round-off resolution needs to be nonnegative, it is $(τ_ulps) ulps."
+        # `≥ 1` rather than `≥ 0`: `expand` is the one and only way to switch the phase off, so
+        # `nexpand = 0` would be a second, silent encoding of "disabled" that `show` and
+        # `isapprox` would then have to agree about.
+        @assert nexpand ≥ 1 "The expansion budget needs to be at least one trial, it is $(nexpand). Pass expand = false to switch the phase off."
         # Capped here rather than only in the keyword constructor, so that *every* path into a
         # `Backtracking{T}` — including `change_precision`, which converts a method built for a
         # different `T` — gets a resolution the element type can support. See `armijo_ulps`.
-        new{T}(α₀, c₁, c₂, p, min(τ_ulps, armijo_ulps(T, c₁)))
+        new{T}(c₁, c₂, p, q, min(τ_ulps, armijo_ulps(T, c₁)), expand, nexpand)
     end
 end
 
 function Backtracking(::Type{T}=Float64;
-    α₀=T(DEFAULT_ARMIJO_α₀),
     c₁=T(DEFAULT_WOLFE_c₁),
     c₂=T(DEFAULT_WOLFE_c₂),
     p=T(DEFAULT_ARMIJO_p),
-    τ_ulps=armijo_ulps(T, c₁)
+    q=T(DEFAULT_BACKTRACKING_q),
+    τ_ulps=armijo_ulps(T, c₁),
+    expand=false,
+    nexpand=DEFAULT_BACKTRACKING_NEXPAND
 ) where {T}
-    Backtracking{T}(α₀, c₁, c₂, p, τ_ulps)
+    Backtracking{T}(c₁, c₂, p, q, τ_ulps, expand, nexpand)
 end
 
 Backtracking(::Type{T}, ::SolverMethod) where {T} = Backtracking(T)
@@ -230,6 +296,66 @@ function backtracking_interpolation(φ₀::T, d₀::T, α::T, φα::T, αp::T, �
     clamp(αₙ, T(BACKTRACKING_SHRINK_MIN) * α, p * α)
 end
 
+@doc raw"""
+    backtracking_extrapolation(φ₀, d₀, α, φα, q)
+
+The next trial step of the expansion phase of [`Backtracking`](@ref), or `α` itself to say that
+the step should not be lengthened.
+
+`α`/`φα` is the step that was just *accepted*. The model is the same quadratic through
+``\varphi(0)``, ``\varphi'(0)`` and ``\varphi(\alpha)`` that [`backtracking_interpolation`](@ref)
+uses on the first backtrack, and its minimiser is
+
+```math
+\alpha^\star = \frac{-\varphi'(0)\,\alpha^2}{2\big(\varphi(\alpha) - \varphi(0) - \varphi'(0)\alpha\big)} ,
+```
+
+clamped from above to ``q\alpha``. A denominator that is negative or zero means the model is not
+convex — the merit fell at least as fast as its tangent, so it is still dropping steeply — and
+the step grows by the full factor ``q``. A denominator that is not *finite* is a different thing
+entirely, namely no model at all, and returns `α`.
+
+Everything the model needs has already been evaluated, so the decision costs no merit
+evaluation. That is what the lower bound [`BACKTRACKING_GROW_MIN`](@ref) is for: unless the
+model wants a step at least that multiple of ``\alpha``, `α` is returned unchanged and the
+search stops without spending one. A direction scaled like a Newton step has
+``\alpha^\star \approx \alpha`` at ``\alpha = 1`` and therefore pays nothing at all, and a merit
+sitting at its round-off floor (``\varphi(\alpha) \approx \varphi(0)``) gives
+``\alpha^\star \approx \alpha/2``, so the model declines to expand into rounding noise without
+needing a special case for it.
+"""
+function backtracking_extrapolation(φ₀::T, d₀::T, α::T, φα::T, q::T) where {T}
+    den = 2 * (φα - φ₀ - d₀ * α)
+    # A non-finite denominator is *not* the non-convex case: it means there is no model at all,
+    # so it must not fall through to the `q * α` branch, which would grow the step on the
+    # strength of a `NaN`. (`backtracking_interpolation` guards its model the same way.)
+    isfinite(den) || return α
+    αₙ = den > zero(T) ? -d₀ * α^2 / den : q * α
+    (isfinite(αₙ) && αₙ ≥ T(BACKTRACKING_GROW_MIN) * α) || return α
+    min(αₙ, q * α)
+end
+
+# The expansion phase of `solve_with_status` below: lengthen the accepted step `α` while
+# `backtracking_extrapolation` asks for it and each longer trial both satisfies the sufficient
+# decrease condition and strictly improves the merit, and return the best pair seen together with
+# the updated evaluation count. A rejected expansion therefore costs exactly one merit evaluation
+# and nothing else — the previous best is still what is returned.
+#
+# `n` is passed and returned rather than captured: a counter captured by this function and mutated
+# by its caller would be boxed, which makes the `trials` of the status built from it inferred-`Any`
+# (the same reason `_wolfe_zoom`'s caller passes its `n`).
+function backtracking_expand(f, sdc::SufficientDecreaseCondition{T}, φ₀::T, d₀::T, α::T, φα::T, n::Int, q::T, nexpand::Int) where {T}
+    for _ in 1:nexpand
+        αₙ = backtracking_extrapolation(φ₀, d₀, α, φα, q)
+        αₙ > α || break
+        φₙ = f(αₙ)
+        n += 1
+        (isfinite(φₙ) && φₙ < φα && sdc(αₙ, φₙ)) || break
+        α, φα = αₙ, φₙ
+    end
+    (α, φα, n)
+end
+
 """
     solve(ls::Linesearch{T,<:Backtracking}, α, params)
 
@@ -272,7 +398,7 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
     n = 0        # trial steps at which the merit was evaluated
     reachedαmin = false  # the ladder ran down to the αmin floor rather than out of budget
 
-    for _ in 1:config(ls).linesearch_max_iterations
+    for i in 1:config(ls).linesearch_max_iterations
         αₐ = α
         φₐ = f(α)
         n += 1
@@ -286,6 +412,14 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
         # The condition itself can never accept an increase (see `SufficientDecreaseCondition`),
         # so a `LINESEARCH_FLOOR` accept here is always a non-increasing step.
         if sdc(α, φₐ)
+            # The step may also be too *short*: a shrink-only search hands back whatever trial
+            # step it was given as soon as that step is acceptable, which pins α at the caller's
+            # ceiling on a direction whose natural scale is larger (issue #174). Only the first
+            # trial is expanded — once the ladder has backtracked, the longer steps below have
+            # already been rejected — and only when asked, `expand` being off by default.
+            if m.expand && i == 1
+                α, φₐ, n = backtracking_expand(f, sdc, φ₀, d₀, α, φₐ, n, m.q, m.nexpand)
+            end
             oc = φₐ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR
             return LinesearchStatus{T}(α, oc, n, φ₀, d₀, φₐ, τ, αmin)
         end
@@ -340,13 +474,16 @@ function curvature_diagnostic(status::LinesearchStatus{T}, ls::Linesearch{T,<:Ba
     nothing
 end
 
-Base.show(io::IO, ls::Backtracking) = print(io, "Backtracking with α₀ = $(ls.α₀) c₁ = $(ls.c₁), c₂ = $(ls.c₂), p = $(ls.p) and τ_ulps = $(ls.τ_ulps).")
+Base.show(io::IO, ls::Backtracking) = print(io, "Backtracking with c₁ = $(ls.c₁), c₂ = $(ls.c₂), p = $(ls.p) and τ_ulps = $(ls.τ_ulps)$(ls.expand ? ", expanding by at most q = $(ls.q) in at most $(ls.nexpand) trial(s)" : ", shrinking only").")
 
 function change_precision(::Type{T}, method::Backtracking) where {T}
     T ≠ eltype(method) || return method
-    Backtracking{T}(T(method.α₀), T(method.c₁), T(method.c₂), T(method.p), T(method.τ_ulps))
+    Backtracking{T}(T(method.c₁), T(method.c₂), T(method.p), T(method.q), T(method.τ_ulps), method.expand, method.nexpand)
 end
 
 function Base.isapprox(bt₁::Backtracking{T}, bt₂::Backtracking{T}; kwargs...) where {T}
-    isapprox(bt₁.α₀, bt₂.α₀; kwargs...) && isapprox(bt₁.c₁, bt₂.c₁; kwargs...) && isapprox(bt₁.c₂, bt₂.c₂; kwargs...) && isapprox(bt₁.p, bt₂.p; kwargs...) && isapprox(bt₁.τ_ulps, bt₂.τ_ulps; kwargs...)
+    # `expand` and `nexpand` are compared exactly: they select *which* algorithm runs and how many
+    # times, and neither is a quantity an approximate comparison means anything for.
+    bt₁.expand == bt₂.expand && bt₁.nexpand == bt₂.nexpand &&
+        isapprox(bt₁.c₁, bt₂.c₁; kwargs...) && isapprox(bt₁.c₂, bt₂.c₂; kwargs...) && isapprox(bt₁.p, bt₂.p; kwargs...) && isapprox(bt₁.q, bt₂.q; kwargs...) && isapprox(bt₁.τ_ulps, bt₂.τ_ulps; kwargs...)
 end

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -40,6 +40,8 @@ guarantees about the step, because there are two distinct kinds:
 - **Condition-satisfying, ``\\alpha``-relative** — [`Backtracking`](@ref),
   [`StrongWolfe`](@ref) and trivially [`Static`](@ref): "given the trial step ``\\alpha``,
   return a step satisfying a decrease condition". The result depends on the input ``\\alpha``.
+  [`Backtracking`](@ref) shrinks it only, and therefore returns it unchanged whenever it is
+  acceptable, unless its `expand` key is set; [`StrongWolfe`](@ref) brackets in both directions.
 - **Minimising, ``\\alpha``-independent** — [`Bisection`](@ref), [`Quadratic`](@ref) and
   [`BierlaireQuadratic`](@ref): "approximate the minimiser of ``\\varphi`` along the
   direction". The input ``\\alpha`` only seeds the bracketing (see issue #164), and no Wolfe

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -133,6 +133,19 @@ end
     @test_throws AssertionError Backtracking(; nexpand=0)
     @test Backtracking() isa Backtracking                       # defaults are valid
     @test !Backtracking().expand                                # ... and shrink-only
+
+    # `show` says which of the two algorithms the method is, and names the expansion budget only
+    # where it is read — the shrink-only default does not carry `q` and `nexpand` into its
+    # description of itself.
+    let shown = sprint(show, Backtracking())
+        @test occursin("shrinking only", shown)
+        @test !occursin("q = ", shown)
+    end
+    let shown = sprint(show, Backtracking(; expand=true, nexpand=2))
+        @test occursin("q = $(SimpleSolvers.DEFAULT_BACKTRACKING_q)", shown)
+        @test occursin("2 trial(s)", shown)
+        @test !occursin("shrinking only", shown)
+    end
 end
 
 @testset "$(rpad("Backtracking: non-descent and stationary anchors are reported, not searched", 80))" begin
@@ -260,11 +273,20 @@ end
 
     # A non-finite model must not propagate a NaN step into the search.
     @test backtracking_extrapolation(1.0, -2.0, 1.0, NaN, 10.0) == 1.0
+
+    # The gate is on the step that would actually be tried, not on the raw minimiser, so a q below
+    # BACKTRACKING_GROW_MIN buys nothing whichever branch the model takes: the convex one wants
+    # α★ = 11 but may only reach 1.5·α, and the non-convex one asks for exactly that.
+    @test backtracking_extrapolation(121.0, -22.0, 1.0, 100.0, 1.5) == 1.0
+    @test backtracking_extrapolation(1.0, -2.0, 1.0, -10.0, 1.5) == 1.0
+    # ... and at q = BACKTRACKING_GROW_MIN exactly, both do expand, by that factor.
+    @test backtracking_extrapolation(121.0, -22.0, 1.0, 100.0, 2.0) == 2.0
+    @test backtracking_extrapolation(1.0, -2.0, 1.0, -10.0, 2.0) == 2.0
 end
 
 @testset "$(rpad("Backtracking expansion phase (issue #174)", 80))" begin
     quadratic(αmin) = LinesearchProblem{Float64}((α, _) -> (α - αmin)^2, (α, _) -> 2(α - αmin))
-    run(prob, m) = solve_with_status(Linesearch(prob, m; verbosity=0), 1.0)
+    search(prob, m) = solve_with_status(Linesearch(prob, m; verbosity=0), 1.0)
 
     shrink = Backtracking()
     grow = Backtracking(; expand=true)
@@ -274,7 +296,7 @@ end
     # ceiling it was given, at every outer iteration. That is what cost DFP two orders of
     # magnitude in the issue.
     for αmin in (11.0, 100.0)
-        st = run(quadratic(αmin), shrink)
+        st = search(quadratic(αmin), shrink)
         @test steplength(st) == 1.0
         @test trials(st) == 1
     end
@@ -283,7 +305,7 @@ end
     # merit evaluations. Landing within a factor BACKTRACKING_GROW_MIN of the minimiser is the
     # whole point: it is the *scale* that was wrong, not the last digit.
     for αmin in (11.0, 100.0)
-        st = run(quadratic(αmin), grow)
+        st = search(quadratic(αmin), grow)
         @test issufficient(st)
         @test αmin / SimpleSolvers.BACKTRACKING_GROW_MIN ≤ steplength(st) ≤ αmin
         @test 1 < trials(st) ≤ 1 + grow.nexpand
@@ -292,43 +314,66 @@ end
     # And it costs nothing where it can gain nothing: a direction already scaled like a Newton
     # step is at its model minimum, so the phase returns after the one trial the shrink-only
     # search would have made. This is why the model is extrapolated rather than α simply grown.
-    stw = run(quadratic(1.0), grow)
+    stw = search(quadratic(1.0), grow)
     @test steplength(stw) == 1.0
-    @test trials(stw) == trials(run(quadratic(1.0), shrink)) == 1
+    @test trials(stw) == trials(search(quadratic(1.0), shrink)) == 1
 
     # A shrunken step is never expanded again: the longer steps have already been rejected.
     # φ(α) = 1 - 2α + 1000α² needs several backtracks from α = 1, and `expand` must not change
     # what that returns.
     overshoot = LinesearchProblem{Float64}((α, _) -> 1.0 - 2α + 1000α^2, (α, _) -> -2.0 + 2000α)
-    @test steplength(run(overshoot, grow)) == steplength(run(overshoot, shrink))
-    @test trials(run(overshoot, grow)) == trials(run(overshoot, shrink))
+    @test steplength(search(overshoot, grow)) == steplength(search(overshoot, shrink))
+    @test trials(search(overshoot, grow)) == trials(search(overshoot, shrink))
 
     # The merit's round-off floor is not expanded into, and stays reported as a floor.
     noise = LinesearchProblem{Float64}((α, _) -> α > 0 ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
-    @test outcome(run(noise, grow)) == outcome(run(noise, shrink)) == LINESEARCH_FLOOR
+    @test outcome(search(noise, grow)) == outcome(search(noise, shrink)) == LINESEARCH_FLOOR
+
+    # `noise` never accepts, so it cannot exercise the one case where the two meet: a *first*
+    # trial accepted at the floor, with `expand` set. A merit that is flat enough for the demanded
+    # decrease c₁α|φ'(0)| to fall below τ accepts α = 1 while decreasing by less than τ, and there
+    # the model gives α★ ≈ α/2 — so the phase declines to grow, the outcome stays a floor, and the
+    # shrink-only search is matched trial for trial.
+    let τ = armijo_tolerance(1.0, Backtracking().τ_ulps)
+        flat = LinesearchProblem{Float64}((α, _) -> α > 0 ? 1.0 - τ / 2 : 1.0, (α, _) -> -1e-13)
+        stf = search(flat, grow)
+        @test outcome(stf) == LINESEARCH_FLOOR
+        @test steplength(stf) == 1.0
+        @test trials(stf) == trials(search(flat, shrink)) == 1
+    end
 
     # Contract item 5: the cost does not depend on the scale of the merit, and neither does the
     # step — the model is built from φ₀, φ'(0) and φ(α), which all scale together.
     scaled(s) = LinesearchProblem{Float64}((α, _) -> s * (α - 11.0)^2, (α, _) -> s * 2(α - 11.0))
     for s in (1e-8, 1.0, 1e8)
-        @test steplength(run(scaled(s), grow)) == steplength(run(scaled(1.0), grow))
-        @test trials(run(scaled(s), grow)) == trials(run(scaled(1.0), grow))
+        @test steplength(search(scaled(s), grow)) == steplength(search(scaled(1.0), grow))
+        @test trials(search(scaled(s), grow)) == trials(search(scaled(1.0), grow))
     end
 
     # Every trial is counted, expansions included.
     n = Ref(0)
     counted = LinesearchProblem{Float64}((α, _) -> (n[] += 1; (α - 11.0)^2), (α, _) -> 2(α - 11.0))
-    st = run(counted, grow)
+    st = search(counted, grow)
     @test n[] == trials(st) + 1   # + the α = 0 anchor
 
     # `nexpand` is a hard cap on the extra evaluations, whatever the merit does.
-    @test trials(run(quadratic(1e10), Backtracking(; expand=true, nexpand=1))) == 2
+    @test trials(search(quadratic(1e10), Backtracking(; expand=true, nexpand=1))) == 2
+
+    # ... and it caps the phase from *within* `linesearch_max_iterations`, not beside it, so the
+    # whole search still spends at most the budget `Options` documents. A merit whose scale is far
+    # above the trial step would take every one of `nexpand`'s trials; a budget of one leaves it
+    # none, and a budget of two leaves it exactly one.
+    for (budget, expected) in ((1, 1), (2, 2), (3, 3))
+        st = solve_with_status(Linesearch(quadratic(1e10), grow; verbosity=0,
+                linesearch_max_iterations=budget), 1.0)
+        @test trials(st) == expected ≤ budget
+    end
 
     # The expansion never returns a step worse than the one the shrink-only search accepted: a
     # trial that fails sufficient decrease or does not improve the merit costs one evaluation and
     # the previous best is kept. φ(α) = (α-11)² for α ≤ 5 and a cliff above it.
     cliff = LinesearchProblem{Float64}((α, _) -> α > 5 ? 1e6 : (α - 11.0)^2, (α, _) -> 2(α - 11.0))
-    stc = run(cliff, grow)
+    stc = search(cliff, grow)
     @test steplength(stc) == 1.0
     @test stc.φ == 100.0
     @test trials(stc) == 2   # the one rejected expansion, and nothing more
@@ -965,6 +1010,20 @@ end
         @test change_precision(T, grow) ≈ Backtracking(T; expand=true, nexpand=2)
         @test !(change_precision(T, grow) ≈ Backtracking(T; nexpand=2))
         @test !(change_precision(T, grow) ≈ Backtracking(T; expand=true, nexpand=3))
+
+        # ... and the phase *runs* in the new precision, not merely survives conversion into it:
+        # `BACKTRACKING_GROW_MIN` and `q` are converted with the method, so a merit whose scale is
+        # an order of magnitude above the trial step is reached in Float16 exactly as in Float64,
+        # while the shrink-only search stays pinned at the caller's ceiling.
+        let prob = LinesearchProblem{T}((α, _) -> (α - T(11))^2, (α, _) -> 2 * (α - T(11))),
+            expander = Backtracking(T; expand=true)
+
+            st = solve_with_status(Linesearch(prob, expander; verbosity=0), one(T))
+            @test issufficient(st)
+            @test T(11) / T(SimpleSolvers.BACKTRACKING_GROW_MIN) ≤ steplength(st) ≤ T(11)
+            @test 1 < trials(st) ≤ 1 + expander.nexpand
+            @test steplength(solve_with_status(Linesearch(prob, Backtracking(T); verbosity=0), one(T))) == one(T)
+        end
     end
 end
 

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -9,7 +9,7 @@ using SimpleSolvers: change_precision, bisection, bracket_root, triple_point_fin
 using SimpleSolvers: CurvatureCondition, SufficientDecreaseCondition
 using SimpleSolvers: issufficient, isfloor
 using SimpleSolvers: steplength, outcome, trials, armijo_tolerance, armijo_ulps, backtracking_αmin,
-    backtracking_interpolation, with_config, problem, method, config
+    backtracking_interpolation, backtracking_extrapolation, with_config, problem, method, config
 
 include("lowered_code.jl")
 
@@ -127,7 +127,12 @@ end
     @test_throws AssertionError Backtracking(; p=0.0)
     @test_throws AssertionError Backtracking(; c₁=0.5, c₂=0.1)  # c₁ < c₂ violated
     @test_throws AssertionError Backtracking(; c₁=-1e-4)        # c₁ > 0 violated
+    @test_throws AssertionError Backtracking(; q=1.0)           # q > 1 violated
+    # `expand` is the only way to switch the expansion phase off, so `nexpand = 0` — a second,
+    # silent encoding of "disabled" — is rejected rather than accepted as a synonym.
+    @test_throws AssertionError Backtracking(; nexpand=0)
     @test Backtracking() isa Backtracking                       # defaults are valid
+    @test !Backtracking().expand                                # ... and shrink-only
 end
 
 @testset "$(rpad("Backtracking: non-descent and stationary anchors are reported, not searched", 80))" begin
@@ -229,6 +234,104 @@ end
     @test trials(st) < 10
     @test n[] == trials(st) + 1
     @test steplength(st) ≤ 0.5
+end
+
+@testset "$(rpad("backtracking_extrapolation", 80))" begin
+    # φ(α) = (α - 11)², anchored at α = 0: φ₀ = 121, φ'(0) = -22, φ(1) = 100. The quadratic
+    # model through those three values has its minimiser at the true one, α★ = 11.
+    @test backtracking_extrapolation(121.0, -22.0, 1.0, 100.0, 100.0) == 11.0
+    @test backtracking_extrapolation(121.0, -22.0, 1.0, 100.0, 10.0) == 10.0   # clamped to q·α
+
+    # A well-scaled direction: φ(α) = (α - 1)² has α★ = α = 1, so the step is returned unchanged
+    # and the caller stops without spending a merit evaluation. This is the zero-cost gate.
+    @test backtracking_extrapolation(1.0, -2.0, 1.0, 0.0, 10.0) == 1.0
+
+    # ... and so is a model minimiser that is longer but not by the factor BACKTRACKING_GROW_MIN.
+    # φ(α) = (α - 1.5)²: α★ = 1.5 < 2·1.
+    @test backtracking_extrapolation(2.25, -3.0, 1.0, 0.25, 10.0) == 1.0
+
+    # A non-convex model — the merit fell at least as fast as its tangent, so it is still
+    # dropping steeply — grows by the full factor q.
+    @test backtracking_extrapolation(1.0, -2.0, 1.0, -10.0, 10.0) == 10.0
+
+    # A merit at its round-off floor (φ(α) = φ₀) gives α★ = α/2 and is therefore *not* expanded:
+    # the model declines to grow into rounding noise without needing a special case.
+    @test backtracking_extrapolation(1.0, -2.0, 1.0, 1.0, 10.0) == 1.0
+
+    # A non-finite model must not propagate a NaN step into the search.
+    @test backtracking_extrapolation(1.0, -2.0, 1.0, NaN, 10.0) == 1.0
+end
+
+@testset "$(rpad("Backtracking expansion phase (issue #174)", 80))" begin
+    quadratic(αmin) = LinesearchProblem{Float64}((α, _) -> (α - αmin)^2, (α, _) -> 2(α - αmin))
+    run(prob, m) = solve_with_status(Linesearch(prob, m; verbosity=0), 1.0)
+
+    shrink = Backtracking()
+    grow = Backtracking(; expand=true)
+
+    # The defect: a direction whose natural scale is larger than the trial step. A shrink-only
+    # search accepts the trial step — it does satisfy sufficient decrease — and hands back the
+    # ceiling it was given, at every outer iteration. That is what cost DFP two orders of
+    # magnitude in the issue.
+    for αmin in (11.0, 100.0)
+        st = run(quadratic(αmin), shrink)
+        @test steplength(st) == 1.0
+        @test trials(st) == 1
+    end
+
+    # With the expansion phase the step reaches that scale instead, in at most `nexpand` further
+    # merit evaluations. Landing within a factor BACKTRACKING_GROW_MIN of the minimiser is the
+    # whole point: it is the *scale* that was wrong, not the last digit.
+    for αmin in (11.0, 100.0)
+        st = run(quadratic(αmin), grow)
+        @test issufficient(st)
+        @test αmin / SimpleSolvers.BACKTRACKING_GROW_MIN ≤ steplength(st) ≤ αmin
+        @test 1 < trials(st) ≤ 1 + grow.nexpand
+    end
+
+    # And it costs nothing where it can gain nothing: a direction already scaled like a Newton
+    # step is at its model minimum, so the phase returns after the one trial the shrink-only
+    # search would have made. This is why the model is extrapolated rather than α simply grown.
+    stw = run(quadratic(1.0), grow)
+    @test steplength(stw) == 1.0
+    @test trials(stw) == trials(run(quadratic(1.0), shrink)) == 1
+
+    # A shrunken step is never expanded again: the longer steps have already been rejected.
+    # φ(α) = 1 - 2α + 1000α² needs several backtracks from α = 1, and `expand` must not change
+    # what that returns.
+    overshoot = LinesearchProblem{Float64}((α, _) -> 1.0 - 2α + 1000α^2, (α, _) -> -2.0 + 2000α)
+    @test steplength(run(overshoot, grow)) == steplength(run(overshoot, shrink))
+    @test trials(run(overshoot, grow)) == trials(run(overshoot, shrink))
+
+    # The merit's round-off floor is not expanded into, and stays reported as a floor.
+    noise = LinesearchProblem{Float64}((α, _) -> α > 0 ? nextfloat(1.0) : 1.0, (α, _) -> -2.0)
+    @test outcome(run(noise, grow)) == outcome(run(noise, shrink)) == LINESEARCH_FLOOR
+
+    # Contract item 5: the cost does not depend on the scale of the merit, and neither does the
+    # step — the model is built from φ₀, φ'(0) and φ(α), which all scale together.
+    scaled(s) = LinesearchProblem{Float64}((α, _) -> s * (α - 11.0)^2, (α, _) -> s * 2(α - 11.0))
+    for s in (1e-8, 1.0, 1e8)
+        @test steplength(run(scaled(s), grow)) == steplength(run(scaled(1.0), grow))
+        @test trials(run(scaled(s), grow)) == trials(run(scaled(1.0), grow))
+    end
+
+    # Every trial is counted, expansions included.
+    n = Ref(0)
+    counted = LinesearchProblem{Float64}((α, _) -> (n[] += 1; (α - 11.0)^2), (α, _) -> 2(α - 11.0))
+    st = run(counted, grow)
+    @test n[] == trials(st) + 1   # + the α = 0 anchor
+
+    # `nexpand` is a hard cap on the extra evaluations, whatever the merit does.
+    @test trials(run(quadratic(1e10), Backtracking(; expand=true, nexpand=1))) == 2
+
+    # The expansion never returns a step worse than the one the shrink-only search accepted: a
+    # trial that fails sufficient decrease or does not improve the merit costs one evaluation and
+    # the previous best is kept. φ(α) = (α-11)² for α ≤ 5 and a cliff above it.
+    cliff = LinesearchProblem{Float64}((α, _) -> α > 5 ? 1e6 : (α - 11.0)^2, (α, _) -> 2(α - 11.0))
+    stc = run(cliff, grow)
+    @test steplength(stc) == 1.0
+    @test stc.φ == 100.0
+    @test trials(stc) == 2   # the one rejected expansion, and nothing more
 end
 
 @testset "$(rpad("SufficientDecreaseCondition round-off allowance", 80))" begin
@@ -808,7 +911,7 @@ end
             ("minimiser at α < 0", (α, _) -> (α + one_T)^2, (α, _) -> 2 * (α + one_T)),
             ("slope contradicts values", (α, _) -> one_T + α, (α, _) -> -2one_T),
         )
-        for m in (Static(T), Backtracking(T), StrongWolfe(T), Bisection(T), Quadratic(T), BierlaireQuadratic(T))
+        for m in (Static(T), Backtracking(T), Backtracking(T; expand=true), StrongWolfe(T), Bisection(T), Quadratic(T), BierlaireQuadratic(T))
             for (nm, f, d) in pathological
                 ls = Linesearch(LinesearchProblem{T}(f, d), m; verbosity=0)
                 st = @test_nowarn solve_with_status(ls, one_T)
@@ -852,6 +955,16 @@ end
         @test change_precision(T, Backtracking()).τ_ulps == Backtracking(T).τ_ulps
         @test Backtracking(T; τ_ulps=T(4)).τ_ulps ≤ armijo_ulps(T)
         @test Backtracking(T; τ_ulps=zero(T)).τ_ulps == 0   # opting out still works
+
+        # The expansion keys survive a precision change too — `expand` and `nexpand` unconverted,
+        # `q` in the new element type — and `isapprox` compares them.
+        grow = Backtracking(; expand=true, nexpand=2)
+        @test change_precision(T, grow).expand
+        @test change_precision(T, grow).nexpand == 2
+        @test change_precision(T, grow).q == T(SimpleSolvers.DEFAULT_BACKTRACKING_q)
+        @test change_precision(T, grow) ≈ Backtracking(T; expand=true, nexpand=2)
+        @test !(change_precision(T, grow) ≈ Backtracking(T; nexpand=2))
+        @test !(change_precision(T, grow) ≈ Backtracking(T; expand=true, nexpand=3))
     end
 end
 
@@ -1125,6 +1238,7 @@ end
     # the session was started. The byte counts that motivated them follow, guarded: they are the
     # end-to-end statement but say nothing under `--check-bounds=yes` (see `AS_A_CALLER_COMPILES_IT`).
     for f in (solve, solve_with_status, SimpleSolvers._bierlaire_fit, SimpleSolvers._wolfe_zoom,
+        SimpleSolvers.backtracking_expand,
         bisection, SimpleSolvers._bisection_core, SimpleSolvers._triple_point_core)
         @test !has_boxed_capture(f)
     end
@@ -1148,7 +1262,7 @@ end
         x .= 1.0
         @allocated solve!(x, s, state)
     end
-    for ls in (Static(), Backtracking(), Bisection(), Quadratic(), BierlaireQuadratic())
+    for ls in (Static(), Backtracking(), Backtracking(; expand=true), Bisection(), Quadratic(), BierlaireQuadratic())
         @test solve_allocations(ls) == 0 skip = !AS_A_CALLER_COMPILES_IT
     end
 

--- a/test/lowered_code.jl
+++ b/test/lowered_code.jl
@@ -47,10 +47,18 @@ Whether any message `f()` emits contains `pattern`.
 Used to pin a reporter's *verbosity gate*, which is otherwise silent when a future edit gets it
 wrong. Preferred over `@test_logs` here because it asks whether one specific message is present, and
 so is not upset by unrelated messages the same solve may emit at the same verbosity.
+
+`f` runs at a verbosity high enough to trigger the reporter under test, and at that verbosity a
+converged solve also writes its `NonlinearSolverStatus` to `stdout` (see `print_status`) — which is
+not a log record, so the `TestLogger` does not intercept it and it lands in the test output. That is
+by design for a *user* at `verbosity = 2` and noise in a test suite, so `stdout` is swallowed here
+too. Only the log stream is inspected either way.
 """
 function logged_any(f, pattern)
     logger = Test.TestLogger()
-    Base.CoreLogging.with_logger(f, logger)
+    redirect_stdout(devnull) do
+        Base.CoreLogging.with_logger(f, logger)
+    end
     any(r -> occursin(pattern, string(r.message)), logger.logs)
 end
 

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -181,6 +181,10 @@ for T ∈ (Float64, Float32)
     for (Solver, kwarguments, tolfac) in (
         (NewtonSolver, (linesearch=Static(T),), 2),
         (NewtonSolver, (linesearch=Backtracking(T),), 2),
+        # The expansion phase of issue #174 lengthens a step rather than only shrinking it, so it
+        # has to be pinned end-to-end and not just at the line search: a `NewtonSolver` asked for
+        # it must still land on a root, to the same tolerance as the shrink-only default.
+        (NewtonSolver, (linesearch=Backtracking(T; expand=true),), 2),
         (NewtonSolver, (linesearch=Bisection(T),), 2),
         (NewtonSolver, (linesearch=Quadratic(T),), 32),
         # These rows briefly carried `tolfac = 64`, when folding the quadratic searches into
@@ -1163,7 +1167,7 @@ end
     # `Jacobian` — so a message in any of their bodies is re-inferred and re-codegen'd once per
     # problem a solver is built for. Every one of them therefore delegates to a `@noinline` reporter
     # taking nothing but numbers and the `Options`. See `report_linesearch_status` for why, and
-    # `test/logging_code.jl` for the check.
+    # `has_logging_code` in `test/lowered_code.jl` for the check.
     for f in (SimpleSolvers.report_dogleg_singular, SimpleSolvers.report_dogleg_nan,
         SimpleSolvers.report_dogleg_underflow, SimpleSolvers.report_nan_direction,
         SimpleSolvers.report_static_refactorize,


### PR DESCRIPTION
Closes #174, both halves of it.

## Problem 1: `α₀` was inert

It was stored, documented as *"the initial step size α"*, printed by `show`, compared by `isapprox` and converted by `change_precision` — and never read by `solve` or `solve_with_status`. The trial step was, and remains, the `α` argument, so `Backtracking(; α₀ = 10.0)` configured nothing.

The field is removed, along with `DEFAULT_ARMIJO_α₀` and the positional `Backtracking{T}(α₀, c₁, c₂, p[, τ_ulps])` form. **Breaking**, but it changes no behaviour: nothing read the field, and the only internal caller — `solver_step!` — already passed `one(T)` explicitly.

## Problem 2: the search could not lengthen a step

A shrink-only search returns the trial step it was given whenever that step is acceptable, so on a direction whose natural scale is *larger* it pins `α` at the caller's ceiling on every iteration. On the `St(20,3)²` SVD problem of GeometricOptimizers that cost a DFP direction — which wants `α ≈ 11` throughout — **49 679** iterations against `Bisection`'s **134**.

`Backtracking` gained an expansion phase behind a new **`expand` key, `false` by default**: with it set, an accepted *first* trial step is lengthened while each longer trial still satisfies sufficient decrease and strictly improves the merit, capped by `nexpand` and by the per-round growth factor `q`. A shrunken step is never expanded again — the longer steps below it have already been rejected.

### Why the model rather than geometric growth

The step it grows to comes from a new `backtracking_extrapolation`, built on the *same* quadratic model that `backtracking_interpolation` uses on the way down:

```
den = 2(φ(α) − φ₀ − d₀·α)      # > 0 ⟺ convex
α★  = −d₀·α² / den
```

All three inputs are already in hand when a step is accepted, so **deciding whether to expand at all costs no merit evaluation**. That is the point: for the merit of a `NonlinearSolver` an evaluation is a full residual evaluation, the most expensive single operation of a solver step, and the geometric `α ← qα` that #174 suggests would charge every well-scaled Newton step one of those forever. A direction already scaled like a Newton step has `α★ ≈ α` at `α = 1`, fails the `BACKTRACKING_GROW_MIN` test and returns immediately.

Two properties fall out rather than being special-cased:

- **Scale invariance** (line-search contract item 5): `φ₀`, `d₀` and `φ(α)` scale together, so `α★` is unchanged when `φ` is multiplied by a constant.
- **A round-off floor self-guards**: there `φ(α) ≈ φ₀`, so `den ≈ −2d₀α > 0` and `α★ ≈ α/2 < α` — the model declines to expand into rounding noise on its own.

The phase deliberately does *not* consult the curvature condition to decide when to stop growing, which would cost a full Jacobian per trial; `StrongWolfe` remains the method for that.

## Measured

Iterations to convergence on `test/optimizer_convergence/svd_optim.jl` of GeometricOptimizers, seed 1234:

| method + retraction | `Backtracking` | `expand = true` | `Bisection` |
|---|---|---|---|
| `_DFP` + Geodesic | 49 679 | **830** | 134 |
| `_DFP` + Cayley | 29 081 | **1 237** | 96 |
| `_BFGS` + Geodesic | 113 | 93 | 143 |
| `_BFGS` + Cayley | 136 | 118 | 93 |

The `Backtracking` column reproduces 0.10.1's numbers exactly, which is the check that the default path is untouched. The well-scaled `_BFGS` rows are slightly *better* rather than harmed. `_DFP` trails `Bisection` on iteration count but leads on wall clock (0.2 s against 0.5 s for Geodesic): a `Bisection` iteration spends of the order of 580 merit evaluations against `Backtracking`'s 25.

On the defaults, from a sweep on the same problem: `nexpand = 1` is too few (`_DFP` does not converge within 60 000 iterations) and `2`+ all work, hence `3`. `q` is a plateau over 4–100 rather than a cliff — `q = 100` reaches 594/398 on the two `_DFP` rows — and `10` is the conservative point on it rather than the best on this one problem.

## Verification

- The whole 0.10.1 test suite passes **unedited**: iteration counts, `trials` counts and the zero-allocation assertions. Also under `--check-bounds=yes`.
- New tests cover the extrapolation unit-wise, the expansion end-to-end, the zero-cost gate (`trials == 1` on a well-scaled merit even with `expand` set), the `nexpand` cap, scale invariance, the floor self-guard, and that a shrunken step is not expanded. `Backtracking(T; expand=true)` was added to the "contract holds for every method" and zero-allocation loops.
- Docs build clean, with a new "Lengthening the step" section carrying a runnable contrast of the two settings.
- GeometricIntegrators' Runge-Kutta suite passes (128 assertions) with **bit-identical** `Gauss(1)`…`Gauss(4)` trajectories. Its runtime moved 93.7 s → 97.4 s, within noise for a suite that is ~97 % compilation.

## Note for downstream

Version bumped to **0.11.0** for the breaking removal. Both GeometricIntegrators and GeometricOptimizers pin `SimpleSolvers = "0.10"`, so each needs a `[compat]` bump to pick this up.

## Review round (c8df1d2)

**The expansion trials now come out of the budget that bounds them.** `Options` documents `linesearch_max_iterations` as bounding *"the **inner**, one-dimensional line search taken within a single solver step"*, and termination case 4 of the `Backtracking` docstring says the search stops when that budget is spent — but the phase spent its `nexpand` trials beside that budget rather than inside it, so an accepted first trial could report `1 + nexpand` evaluations against a bound of 1. `solve_with_status` now passes `min(nexpand, linesearch_max_iterations - n)`. The cap binds only for a budget of `nexpand + 1` or less, so at the defaults — 60 against 3 — it never does and the `expand = true` column above stands. (Caught by Copilot; the first draft of the fix documented `nexpand` as a second, independent budget, which papers over the violation rather than honouring it.)

**`backtracking_extrapolation` gates on the clamped step, not the raw minimiser.** The two agree for every `q ≥ BACKTRACKING_GROW_MIN`, hence for the default and for every number above. Below it they disagree in a way that had no defence: a convex model passed the gate on an `α★` it was then not allowed to reach and bought a growth by `q` alone, while a non-convex model — which asks for exactly `q·α` — was refused the same growth outright.

**The docstrings now say what `expand` asks of the merit.** The phase is the one place a line search leaves the `[0, α]` the caller offered, out to `q^nexpand·α` — a thousand times the trial step on the defaults. A trial whose merit is not finite is rejected at the cost of that one evaluation, but a merit that *throws* outside its domain is the caller's to guard, which is one more reason the phase is opt-in.

### New tests

- the gate at `q = 1.5` and at `q = 2` exactly, on both branches of the model;
- the budget cap, at `linesearch_max_iterations` of 1, 2 and 3;
- `show` both ways — the rewritten method had no assertion at all;
- the expansion *running* in `Float32` and `Float16`, rather than merely surviving `change_precision` into them;
- a first trial accepted **at** the round-off floor meeting `expand`, where the model gives `α★ ≈ α/2` and declines to grow (the existing `noise` problem never accepts at the first trial, so it could not reach this);
- `Backtracking(T; expand = true)` as a row of the `NewtonSolver` convergence matrix, so the phase is pinned end-to-end and not only at the line search.

### Also

The suite printed two solver statuses. `logged_any` runs a solve at `verbosity = 2` to pin a reporter's gate, and at that verbosity `print_status` writes the converged status to **stdout** — not a log record, so the `TestLogger` never intercepted it and it landed in the test output. Right for a user, noise in a suite, so the helper swallows stdout; only the log stream was ever inspected. The suite is silent again.

The claim that the 0.10.1 suite *"passes unedited"* is replaced by the accurate and stronger one: no expectation was adjusted, and every test edit is either a new case or an addition to a loop that already ran over every method.

Re-verified: full suite green (Line Searches 1375/1375, Nonlinear Solvers 2809/2809) and silent, green under `--check-bounds=yes`, docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

