### PR TITLE
Docs: state the general p₂ in the fixed-point bracketer's docstring

### DIFF
--- a/src/bracketing/bracket_minimum.jl
+++ b/src/bracketing/bracket_minimum.jl
@@ -214,7 +214,7 @@ Find a bracket while keeping the left side (i.e. `x`) fixed.
 
 The algorithm is similar to [`bracket_minimum`](@ref) (also based on [`DEFAULT_BRACKETING_s`](@ref) and [`DEFAULT_BRACKETING_k`](@ref)) with the difference that for the latter the left side is also moving.
 
-The function `bracket_minimum_with_fixed_point` is used as a starting point for [`Quadratic`](@ref) (adapted from [kelley1995iterative](@cite)): that line search fits the polynomial centred at the bracket's left endpoint ``a``,
+The function `bracket_minimum_with_fixed_point` is used as a starting point for [`Quadratic`](@ref) (adapted from [kelley1995iterative](@cite)): that line search fits the polynomial centred at the bracket's left endpoint ``a`` (which may differ from the input `x` after the bracketer’s initial direction flip),
 ```math
 p(\alpha) = f(a) + f'(a)(\alpha - a) + p_2(\alpha - a)^2,
 ```

--- a/src/bracketing/bracket_minimum.jl
+++ b/src/bracketing/bracket_minimum.jl
@@ -214,11 +214,15 @@ Find a bracket while keeping the left side (i.e. `x`) fixed.
 
 The algorithm is similar to [`bracket_minimum`](@ref) (also based on [`DEFAULT_BRACKETING_s`](@ref) and [`DEFAULT_BRACKETING_k`](@ref)) with the difference that for the latter the left side is also moving.
 
-The function `bracket_minimum_with_fixed_point` is used as a starting point for [`Quadratic`](@ref) (adapted from [kelley1995iterative](@cite)), as the coefficient ``p_2`` of the fitted polynomial is:
+The function `bracket_minimum_with_fixed_point` is used as a starting point for [`Quadratic`](@ref) (adapted from [kelley1995iterative](@cite)): that line search fits the polynomial centred at the bracket's left endpoint ``a``,
 ```math
-p_2 = \frac{f(b) - f(a) - f'(a)b}{b^2},
+p(\alpha) = f(a) + f'(a)(\alpha - a) + p_2(\alpha - a)^2,
 ```
-where ``b = \mathtt{bracket\_minimum\_with\_fixed\_point}(a)``. The right end `b` is
+so interpolating ``f`` at the right endpoint ``b`` fixes the coefficient ``p_2`` as
+```math
+p_2 = \frac{f(b) - f(a) - f'(a)(b - a)}{(b - a)^2},
+```
+where ``(a, b)`` is the bracket returned by ``\mathtt{bracket\_minimum\_with\_fixed\_point}``. The right end `b` is
 grown outward (with the left end `a` held fixed) until `f` stops decreasing, i.e.
 until the *turning point* `f(b) ≥ f(b_\mathrm{prev})` is reached, so that a minimum
 is bracketed in `(a, b)`. (The earlier variant compared against the fixed anchor


### PR DESCRIPTION
Follow-up from the review of #156.

`bracket_minimum_with_fixed_point`'s docstring quoted the coefficient that `Quadratic` derives from the returned bracket as

```math
p_2 = \frac{f(b) - f(a) - f'(a)b}{b^2}
```

which is the special case `a = 0`. The bracketer keeps its *caller's* left endpoint fixed, and after the first round that endpoint is the previous iterate `αₜ`, not zero (`src/linesearch/quadratic.jl:133`) — so a reader applying the quoted formula to a later round gets the wrong curvature.

The fit is centred at `a` (`quadratic.jl:110-111`), so the docstring now states the polynomial being interpolated and the general coefficient it fixes:

```math
p(\alpha) = f(a) + f'(a)(\alpha - a) + p_2(\alpha - a)^2
```
```math
p_2 = \frac{f(b) - f(a) - f'(a)(b - a)}{(b - a)^2}
```

That is what the code computes as `denom = 2(y₁ - y₀ - d₀(b - a))` at `quadratic.jl:127`, and it reduces to the old expression when `a = 0`.

Also corrected `b = bracket_minimum_with_fixed_point(a)` to name the bracket `(a, b)`: the routine returns the pair (along with the endpoint merits), and it may flip direction, so the caller's `a` is not always the one that comes back.

Docstring only — no behaviour change, no test changes. `docs/src/linesearch/quadratic.md` is already consistent: its second iteration (line 315) uses the general `(b-a)` form, and the first (line 278) is the `a = 0` step of that worked example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)