### PR TITLE
Let a NonlinearProblem be solved without assembling a solver by hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ linear side, `solve(prob, method, α, params, config)` on the line-search side.
 
 ### Added
 
-- `NewtonSolver(x, nlp::NonlinearProblem, y = similar(x))` and the same form for `PicardSolver` and
+- `NewtonSolver(x, nlp::NonlinearProblem, y = zero(x))` and the same form for `PicardSolver` and
   `DogLegSolver`, hence also `NonlinearSolver(method, x, nlp)`. The residual prototype `y` only
-  supplies a size and a type — its values are never read — so it defaults to `similar(x)`, which is
-  what a square system needs, and every system here is square because the Jacobian gets factorized.
-  A Jacobian stored in the problem takes precedence over autodiff, exactly as the `DF!` keyword
-  does.
+  supplies a size and a type — nothing computed from it survives — so it defaults to `zero(x)`,
+  which is what a square system needs, and every system here is square because the Jacobian gets
+  factorized. (`zero` and not `similar`: `alloc_j` broadcasts over `y`, so an uninitialized
+  prototype throws an `UndefRefError` for an element type whose `similar` leaves undefined
+  references, such as `BigFloat`.) A Jacobian stored in the problem takes precedence over autodiff,
+  exactly as the `DF!` keyword does.
 - `solve!(x, prob, method, args...; kwargs...)`, which builds the solver and overwrites `x` with the
   solution, and `solve(x₀, prob, method, args...; kwargs...)`, which returns the solution as a new
   array and leaves `x₀` alone — `solve!`'s signature minus the bang. The trailing positional
@@ -40,41 +42,6 @@ factorization cache, the line-search buffers), so this is the convenience path a
 loop: that should still build one `NonlinearSolver` and reuse it. The docstrings say so.
 
 ### Changed
-
-The three `(x, F, y)` constructors are now one-line delegations to their `NonlinearProblem`
-counterparts — the assembly recipe they each carried a copy of exists once per solver now. No
-behaviour change: `NonlinearProblem(F, DF!, x, y)` stores `J = DF!`, so the resulting
-`resolve_jacobian` call is the one they made before.
-
-### Added
-
-Convenience entry points for solving a `NonlinearProblem`, [issue
-#159](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/159). `NonlinearProblem` was exported but
-was not usable as an argument anywhere: no solver constructor accepted one, so a hand-built problem
-forced the seven-argument low-level constructor, with the linear problem, the linear solver, the
-line search and the cache all supplied by the caller. The `NewtonSolver` docstring had advertised
-the missing capability — *"can be called with a `NonlinearProblem` or with a `Callable`"* — since
-before it existed.
-
-- `NewtonSolver(x, nlp::NonlinearProblem, y = similar(x))` and the same form for `PicardSolver` and
-  `DogLegSolver`, hence also `NonlinearSolver(method, x, nlp)`. The residual prototype `y` only
-  supplies a size and a type — its values are never read — so it defaults to `similar(x)`, which is
-  what a square system needs, and every system here is square because the Jacobian gets factorized.
-  A Jacobian stored in the problem takes precedence over autodiff, exactly as the `DF!` keyword
-  does.
-- `solve!(x, prob, method, args...; kwargs...)`, which builds the solver and overwrites `x` with the
-  solution, and `solve(x₀, prob, method, args...; kwargs...)`, which returns the solution as a new
-  array and leaves `x₀` alone — `solve!`'s signature minus the bang. The trailing positional
-  arguments go through to the solver-level `solve!`, so they are the problem's `params`, optionally
-  preceded by a `NonlinearSolverState`; the keywords are the constructor's plus `Options`'.
-- `solve_with_status!(x, s)` and `solve_with_status!(x, prob, method, params; kwargs...)`, returning
-  the `NonlinearSolverStatus` instead of the solution. A wrapper discards the solver it built, so
-  `status(s, state)` — which needs both — is otherwise out of reach; this builds the state itself.
-  The `!` is honest here, unlike in the line search's `solve_with_status`, whose `α` is a number.
-
-Each wrapper call constructs a solver (a Jacobian with its ForwardDiff configuration, a
-factorization cache, the line-search buffers), so this is the convenience path and not the one for a
-loop: that should still build one `NonlinearSolver` and reuse it. The docstrings say so.
 
 The three `(x, F, y)` constructors are now one-line delegations to their `NonlinearProblem`
 counterparts — the assembly recipe they each carried a copy of exists once per solver now. No

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,41 @@ counterparts — the assembly recipe they each carried a copy of exists once per
 behaviour change: `NonlinearProblem(F, DF!, x, y)` stores `J = DF!`, so the resulting
 `resolve_jacobian` call is the one they made before.
 
+### Added
+
+Convenience entry points for solving a `NonlinearProblem`, [issue
+#159](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/159). `NonlinearProblem` was exported but
+was not usable as an argument anywhere: no solver constructor accepted one, so a hand-built problem
+forced the seven-argument low-level constructor, with the linear problem, the linear solver, the
+line search and the cache all supplied by the caller. The `NewtonSolver` docstring had advertised
+the missing capability — *"can be called with a `NonlinearProblem` or with a `Callable`"* — since
+before it existed.
+
+- `NewtonSolver(x, nlp::NonlinearProblem, y = similar(x))` and the same form for `PicardSolver` and
+  `DogLegSolver`, hence also `NonlinearSolver(method, x, nlp)`. The residual prototype `y` only
+  supplies a size and a type — its values are never read — so it defaults to `similar(x)`, which is
+  what a square system needs, and every system here is square because the Jacobian gets factorized.
+  A Jacobian stored in the problem takes precedence over autodiff, exactly as the `DF!` keyword
+  does.
+- `solve!(x, prob, method, args...; kwargs...)`, which builds the solver and overwrites `x` with the
+  solution, and `solve(x₀, prob, method, args...; kwargs...)`, which returns the solution as a new
+  array and leaves `x₀` alone — `solve!`'s signature minus the bang. The trailing positional
+  arguments go through to the solver-level `solve!`, so they are the problem's `params`, optionally
+  preceded by a `NonlinearSolverState`; the keywords are the constructor's plus `Options`'.
+- `solve_with_status!(x, s)` and `solve_with_status!(x, prob, method, params; kwargs...)`, returning
+  the `NonlinearSolverStatus` instead of the solution. A wrapper discards the solver it built, so
+  `status(s, state)` — which needs both — is otherwise out of reach; this builds the state itself.
+  The `!` is honest here, unlike in the line search's `solve_with_status`, whose `α` is a number.
+
+Each wrapper call constructs a solver (a Jacobian with its ForwardDiff configuration, a
+factorization cache, the line-search buffers), so this is the convenience path and not the one for a
+loop: that should still build one `NonlinearSolver` and reuse it. The docstrings say so.
+
+The three `(x, F, y)` constructors are now one-line delegations to their `NonlinearProblem`
+counterparts — the assembly recipe they each carried a copy of exists once per solver now. No
+behaviour change: `NonlinearProblem(F, DF!, x, y)` stores `J = DF!`, so the resulting
+`resolve_jacobian` call is the one they made before.
+
 ## [0.10.1]
 
 Compile-time and allocation fixes. No behaviour change: the same messages, at the same `verbosity`
@@ -488,6 +523,7 @@ signature are not enumerated here.)
   different `refactorize` default). There is now a single `NewtonSolver` type
   (`NonlinearSolver{T,Newton}`); build a quasi-Newton solver with
   `NewtonSolver(…; refactorize=n)` (or via `NonlinearSolver(QuasiNewton(n), …)`).
+  ([issue #149](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/149))
 - The error-swallowing fallbacks `initialize!(x...)`, the 1-arg
   `solver_step!(::NonlinearSolver)`, and the generic two-arg `Gradient` functor;
   unsupported calls now raise a proper `MethodError`.
@@ -508,6 +544,7 @@ signature are not enumerated here.)
   struct with `Newton(refactorize=1)` (mirroring `DogLeg`). `QuasiNewton` is kept
   as a convenience constructor `QuasiNewton(refactorize=5) = Newton(refactorize)`.
   `Newton{true}`/`Newton{false}` no longer parse.
+  ([issue #149](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/149))
 - The default line search of `NewtonSolver(x, F, y; …)` changed from `Backtracking`
   to `StrongWolfe` (the only line search that genuinely enforces the strong curvature
   condition). Pass `linesearch=Backtracking(T)` to restore the previous behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to SimpleSolvers.jl are documented here.
 
+## [0.11.0]
+
+Convenience entry points for solving a `NonlinearProblem`, [issue
+#159](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/159).
+
+### The gap
+
+`NonlinearProblem` was exported but was not usable as an argument anywhere: no solver constructor
+accepted one, so a hand-built problem forced the seven-argument low-level constructor, with the
+linear problem, the linear solver, the line search and the cache all supplied by the caller. The
+`NewtonSolver` docstring had advertised the missing capability — *"can be called with a
+`NonlinearProblem` or with a `Callable`"* — since before it existed. Nor was there a `solve`/`solve!`
+taking a problem and a method, which both of the other subsystems have: `solve(lu, ls)` on the
+linear side, `solve(prob, method, α, params, config)` on the line-search side.
+
+### Added
+
+- `NewtonSolver(x, nlp::NonlinearProblem, y = similar(x))` and the same form for `PicardSolver` and
+  `DogLegSolver`, hence also `NonlinearSolver(method, x, nlp)`. The residual prototype `y` only
+  supplies a size and a type — its values are never read — so it defaults to `similar(x)`, which is
+  what a square system needs, and every system here is square because the Jacobian gets factorized.
+  A Jacobian stored in the problem takes precedence over autodiff, exactly as the `DF!` keyword
+  does.
+- `solve!(x, prob, method, args...; kwargs...)`, which builds the solver and overwrites `x` with the
+  solution, and `solve(x₀, prob, method, args...; kwargs...)`, which returns the solution as a new
+  array and leaves `x₀` alone — `solve!`'s signature minus the bang. The trailing positional
+  arguments go through to the solver-level `solve!`, so they are the problem's `params`, optionally
+  preceded by a `NonlinearSolverState`; the keywords are the constructor's plus `Options`'.
+- `solve_with_status!(x, s)` and `solve_with_status!(x, prob, method, params; kwargs...)`, returning
+  the `NonlinearSolverStatus` instead of the solution. A wrapper discards the solver it built, so
+  `status(s, state)` — which needs both — is otherwise out of reach; this builds the state itself.
+  The `!` is honest here, unlike in the line search's `solve_with_status`, whose `α` is a number.
+
+Each wrapper call constructs a solver (a Jacobian with its ForwardDiff configuration, a
+factorization cache, the line-search buffers), so this is the convenience path and not the one for a
+loop: that should still build one `NonlinearSolver` and reuse it. The docstrings say so.
+
+### Changed
+
+The three `(x, F, y)` constructors are now one-line delegations to their `NonlinearProblem`
+counterparts — the assembly recipe they each carried a copy of exists once per solver now. No
+behaviour change: `NonlinearProblem(F, DF!, x, y)` stores `J = DF!`, so the resulting
+`resolve_jacobian` call is the one they made before.
+
 ## [0.10.1]
 
 Compile-time and allocation fixes. No behaviour change: the same messages, at the same `verbosity`

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleSolvers"
 uuid = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Michael Kraus"]
 
 [deps]

--- a/src/SimpleSolvers.jl
+++ b/src/SimpleSolvers.jl
@@ -116,6 +116,10 @@ include("linesearch/wolfe.jl")
 export NonlinearProblem, NonlinearSolver, NonlinearSolverException, NonlinearSolverState,
     NewtonSolver, assess_convergence
 
+# The mutating counterpart of the line-search `solve_with_status`: it overwrites `x`, hence the
+# `!`. `solve!` and `solve` are exported above.
+export solve_with_status!
+
 # As above: the type is exported, `isconverged`/`isstalled`/`status` are not. `status` in
 # particular would be hostile to export — a downstream package that does `using SimpleSolvers`
 # and defines its own `status` gets a method-definition error, not a shadowing warning.

--- a/src/nonlinear/dogleg_solver.jl
+++ b/src/nonlinear/dogleg_solver.jl
@@ -312,7 +312,7 @@ function DogLegSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; (
 end
 
 """
-    DogLegSolver(x, nlp::NonlinearProblem, y = similar(x))
+    DogLegSolver(x, nlp::NonlinearProblem, y = zero(x))
 
 Build a [`DogLegSolver`](@ref) for the [`NonlinearProblem`](@ref) `nlp` with the initial
 guess `x`. See [`NewtonSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref)
@@ -325,7 +325,7 @@ from the trust-region radius.
 - `refactorize`
 - `options_kwargs`: see [`Options`](@ref).
 """
-function DogLegSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=similar(x); linear_solver_method=LU(), jacobian=missing, refactorize=1, options_kwargs...) where {T}
+function DogLegSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=zero(x); linear_solver_method=LU(), jacobian=missing, refactorize=1, options_kwargs...) where {T}
     config = Options(T; options_kwargs...)
     jacobian = resolve_jacobian(nlp.F, nlp.J, jacobian, x, y)
     cache = DogLegCache(x, y)

--- a/src/nonlinear/dogleg_solver.jl
+++ b/src/nonlinear/dogleg_solver.jl
@@ -307,10 +307,27 @@ function DogLegSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch:
     DogLegSolver(x, nlp, ls, linearsolver, with_config(linesearch, config), cache, config; jacobian=jacobian, refactorize=refactorize)
 end
 
-function DogLegSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; linear_solver_method=LU(), (DF!)=missing, jacobian=missing, refactorize=1, options_kwargs...) where {T}
+function DogLegSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; (DF!)=missing, kwargs...) where {T}
+    DogLegSolver(x, NonlinearProblem(F, DF!, x, y), y; kwargs...)
+end
+
+"""
+    DogLegSolver(x, nlp::NonlinearProblem, y = similar(x))
+
+Build a [`DogLegSolver`](@ref) for the [`NonlinearProblem`](@ref) `nlp` with the initial
+guess `x`. See [`NewtonSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref)
+for the rôle of `y`; as above, no `linesearch` keyword is accepted — the step length comes
+from the trust-region radius.
+
+# Keywords
+- `linear_solver_method`
+- `jacobian`: see [`resolve_jacobian`](@ref),
+- `refactorize`
+- `options_kwargs`: see [`Options`](@ref).
+"""
+function DogLegSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=similar(x); linear_solver_method=LU(), jacobian=missing, refactorize=1, options_kwargs...) where {T}
     config = Options(T; options_kwargs...)
-    nlp = NonlinearProblem(F, DF!, x, y)
-    jacobian = resolve_jacobian(F, DF!, jacobian, x, y)
+    jacobian = resolve_jacobian(nlp.F, nlp.J, jacobian, x, y)
     cache = DogLegCache(x, y)
     linearproblem = LinearProblem(alloc_j(x, y))
     linearsolver = LinearSolver(linear_solver_method, y)

--- a/src/nonlinear/newton_solver.jl
+++ b/src/nonlinear/newton_solver.jl
@@ -58,7 +58,8 @@ A `const` derived from [`NonlinearSolver`](@ref) as `NewtonSolver{T} = Nonlinear
 
 The `NewtonSolver` can be called with a [`NonlinearProblem`](@ref) or with a `Callable`.
 
-See [`NewtonSolver(::AbstractVector{T}, ::Callable, ::AbstractVector{T}) where {T}`](@ref).
+See [`NewtonSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref)
+and [`NewtonSolver(::AbstractVector{T}, ::Callable, ::AbstractVector{T}) where {T}`](@ref).
 
 ```jldoctest; setup = :(using SimpleSolvers)
 F(y, x, params) = y .= sin.(x) ^ 2
@@ -111,6 +112,55 @@ function NewtonSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch:
 end
 
 """
+    NewtonSolver(x, nlp::NonlinearProblem, y = similar(x))
+
+Build a [`NewtonSolver`](@ref) for the [`NonlinearProblem`](@ref) `nlp` with the initial
+guess `x`, assembling the [`Jacobian`](@ref), the [`LinearProblem`](@ref), the
+[`LinearSolver`](@ref), the [`Linesearch`](@ref) and the [`NonlinearSolverCache`](@ref).
+
+`y` only supplies the size and type of the residual ``F(x)``; its values are never read.
+It defaults to `similar(x)`, which is what a square system needs — and every system here is
+square, since the [`LinearSolver`](@ref) factorizes the Jacobian.
+
+The Jacobian stored in `nlp` (if any) takes precedence over autodiff, exactly as the `DF!`
+keyword of [`NewtonSolver(::AbstractVector{T}, ::Callable, ::AbstractVector{T}) where {T}`](@ref)
+does — see [`resolve_jacobian`](@ref).
+
+# Keywords
+- `linear_solver_method`
+- `linesearch`
+- `jacobian`
+- `refactorize`
+- `options_kwargs`: see [`Options`](@ref)
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers)
+F(y, x, params) = y .= sin.(x) .^ 2
+x = ones(3)
+nlp = NonlinearProblem(F, x)
+
+NewtonSolver(x, nlp) isa NewtonSolver
+
+# output
+
+true
+```
+"""
+function NewtonSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=similar(x); linear_solver_method=LU(), linesearch=Backtracking(T), jacobian=missing, refactorize=1, options_kwargs...) where {T}
+    # The `Options` are built here, once, and shared by the solver *and* its line search, so
+    # that `NewtonSolver(…; verbosity = 0)` silences the line search too and the inner ladder
+    # is bounded by `linesearch_max_iterations` from the same place.
+    config = Options(T; options_kwargs...)
+    jacobian = resolve_jacobian(nlp.F, nlp.J, jacobian, x, y)
+    cache = NonlinearSolverCache(x, y)
+    linearproblem = LinearProblem(alloc_j(x, y))
+    linearsolver = LinearSolver(linear_solver_method, y)
+    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), linesearch, config)
+    NewtonSolver(x, nlp, linearproblem, linearsolver, ls, cache, config; jacobian=jacobian, refactorize=refactorize)
+end
+
+"""
     NewtonSolver(x, F, y)
 
 # Keywords
@@ -120,19 +170,13 @@ end
 - `jacobian`
 - `refactorize`
 - `options_kwargs`: see [`Options`](@ref)
+
+The `Callable` `F` (and the optional `DF!`) are wrapped in a [`NonlinearProblem`](@ref), so
+this is [`NewtonSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref)
+with the problem built for the caller.
 """
-function NewtonSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; linear_solver_method=LU(), (DF!)=missing, linesearch=Backtracking(T), jacobian=missing, refactorize=1, options_kwargs...) where {T}
-    # The `Options` are built here, once, and shared by the solver *and* its line search, so
-    # that `NewtonSolver(…; verbosity = 0)` silences the line search too and the inner ladder
-    # is bounded by `linesearch_max_iterations` from the same place.
-    config = Options(T; options_kwargs...)
-    nlp = NonlinearProblem(F, DF!, x, y)
-    jacobian = resolve_jacobian(F, DF!, jacobian, x, y)
-    cache = NonlinearSolverCache(x, y)
-    linearproblem = LinearProblem(alloc_j(x, y))
-    linearsolver = LinearSolver(linear_solver_method, y)
-    ls = Linesearch(linesearch_problem(nlp, jacobian, cache), linesearch, config)
-    NewtonSolver(x, nlp, linearproblem, linearsolver, ls, cache, config; jacobian=jacobian, refactorize=refactorize)
+function NewtonSolver(x::AbstractVector{T}, F::Callable, y::AbstractVector{T}; (DF!)=missing, kwargs...) where {T}
+    NewtonSolver(x, NonlinearProblem(F, DF!, x, y), y; kwargs...)
 end
 
 function NewtonSolver(x::AT, y::AT; F=missing, kwargs...) where {T,AT<:AbstractVector{T}}

--- a/src/nonlinear/newton_solver.jl
+++ b/src/nonlinear/newton_solver.jl
@@ -112,15 +112,25 @@ function NewtonSolver(x::AT, nlp::NLST, ls::LST, linearsolver::LSoT, linesearch:
 end
 
 """
-    NewtonSolver(x, nlp::NonlinearProblem, y = similar(x))
+    NewtonSolver(x, nlp::NonlinearProblem, y = zero(x))
 
 Build a [`NewtonSolver`](@ref) for the [`NonlinearProblem`](@ref) `nlp` with the initial
 guess `x`, assembling the [`Jacobian`](@ref), the [`LinearProblem`](@ref), the
 [`LinearSolver`](@ref), the [`Linesearch`](@ref) and the [`NonlinearSolverCache`](@ref).
 
-`y` only supplies the size and type of the residual ``F(x)``; its values are never read.
-It defaults to `similar(x)`, which is what a square system needs — and every system here is
-square, since the [`LinearSolver`](@ref) factorizes the Jacobian.
+`y` is a *prototype* for the residual ``F(x)``: it supplies a size and an element type, and
+nothing that is computed from it survives (`alloc_j` turns it into a `NaN` matrix and the
+cache stores `zero(y)`). It is not, however, left alone — [`JacobianAutodiff`](@ref) keeps it
+as the buffer ForwardDiff writes the residual into, so a caller-supplied `y` is overwritten on
+every Jacobian evaluation. It defaults to `zero(x)`, which is what a square system needs — and
+every system here is square, since the [`LinearSolver`](@ref) factorizes the Jacobian.
+
+!!! info
+    The default is `zero(x)` rather than `similar(x)` because `alloc_j` broadcasts over `y`:
+    for an element type whose `similar` leaves undefined references (`BigFloat`, say) an
+    uninitialized prototype throws an `UndefRefError`. It also assumes `zero(x)` has the same
+    type as `x`, which [`NonlinearSolverCache`](@ref) requires; for an `x` where it does not —
+    a `SubArray`, whose `zero` is an `Array` — pass `y` explicitly.
 
 The Jacobian stored in `nlp` (if any) takes precedence over autodiff, exactly as the `DF!`
 keyword of [`NewtonSolver(::AbstractVector{T}, ::Callable, ::AbstractVector{T}) where {T}`](@ref)
@@ -147,7 +157,7 @@ NewtonSolver(x, nlp) isa NewtonSolver
 true
 ```
 """
-function NewtonSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=similar(x); linear_solver_method=LU(), linesearch=Backtracking(T), jacobian=missing, refactorize=1, options_kwargs...) where {T}
+function NewtonSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=zero(x); linear_solver_method=LU(), linesearch=Backtracking(T), jacobian=missing, refactorize=1, options_kwargs...) where {T}
     # The `Options` are built here, once, and shared by the solver *and* its line search, so
     # that `NewtonSolver(…; verbosity = 0)` silences the line search too and the inner ladder
     # is bounded by `linesearch_max_iterations` from the same place.

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -322,8 +322,25 @@ starting from `x` and overwriting it with the solution (which is returned).
 The remaining positional arguments are passed on to
 [`solve!(::AbstractArray, ::NonlinearSolver, ::NonlinearSolverState, params)`](@ref), so they are
 either nothing at all, the `params` of the problem, or a [`NonlinearSolverState`](@ref) followed by
-`params`. The keyword arguments are those of the solver constructors (`linesearch`, `jacobian`,
-`linear_solver_method`, `refactorize`) together with the [`Options`](@ref) keywords.
+`params`.
+
+The keyword arguments are the [`Options`](@ref) keywords together with whatever the constructor
+selected by `method` accepts — which is *not* the same set for all four methods:
+
+| `method` | constructor keywords |
+|:---|:---|
+| [`Newton`](@ref), [`QuasiNewton`](@ref) | `linesearch`, `jacobian`, `linear_solver_method` |
+| [`DogLeg`](@ref) | `jacobian`, `linear_solver_method` |
+| [`Picard`](@ref) | `jacobian` |
+
+`Picard` and `DogLeg` consult no line search, so they reject a `linesearch` keyword rather than
+ignoring it (it falls through to [`Options`](@ref) and raises a `MethodError` there) — see
+[`PicardSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref).
+
+`refactorize` is deliberately absent from that table: it belongs to the `method`, as `Newton(5)`
+(equivalently [`QuasiNewton`](@ref)) or `DogLeg(5)`. Passing it as a keyword does work for those
+two — it is forwarded after `method.refactorize` and, being the rightmost occurrence, silently
+wins — but `Picard` has no Jacobian to refactorize and errors on it. Configure it through `method`.
 
 !!! info
     This is the convenience path: every call *builds a solver* — a Jacobian (with its ForwardDiff
@@ -397,6 +414,13 @@ This is how the outcome of a solve is obtained without holding on to a
 [`NonlinearSolverState`](@ref): the state is built here and handed to [`status`](@ref) afterwards.
 The `!` is part of the name because `x` *is* modified, unlike in the line-search
 [`solve_with_status`](@ref), whose `α` is a number.
+
+!!! info
+    The predicates that read the returned status — [`isconverged`](@ref) and
+    [`isstalled`](@ref) — are **not** exported, for the same reason the line-search predicates
+    are not: they are generic names a package doing `using SimpleSolvers` may well want for
+    itself. Reach them as `SimpleSolvers.isconverged(st)`, or import them explicitly with
+    `using SimpleSolvers: isconverged`.
 
 # Examples
 

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -312,3 +312,111 @@ true
 status(s::NonlinearSolver, state::NonlinearSolverState) = NonlinearSolverStatus(state, config(s))
 
 solve!(x::AbstractArray, s::NonlinearSolver, params=NullParameters()) = solve!(x, s, NonlinearSolverState(x, value(cache(s))), params)
+
+"""
+    solve!(x, prob, method, args...; kwargs...)
+
+Solve the [`NonlinearProblem`](@ref) `prob` with the [`NonlinearSolverMethod`](@ref) `method`,
+starting from `x` and overwriting it with the solution (which is returned).
+
+The remaining positional arguments are passed on to
+[`solve!(::AbstractArray, ::NonlinearSolver, ::NonlinearSolverState, params)`](@ref), so they are
+either nothing at all, the `params` of the problem, or a [`NonlinearSolverState`](@ref) followed by
+`params`. The keyword arguments are those of the solver constructors (`linesearch`, `jacobian`,
+`linear_solver_method`, `refactorize`) together with the [`Options`](@ref) keywords.
+
+!!! info
+    This is the convenience path: every call *builds a solver* — a Jacobian (with its ForwardDiff
+    configuration), a factorization cache and the line-search buffers. Code that solves repeatedly
+    should construct one [`NonlinearSolver`](@ref) and call
+    [`solve!(::AbstractArray, ::NonlinearSolver, ::NonlinearSolverState, params)`](@ref) on it
+    instead.
+
+`solve!` returns the solution, not a status; use [`solve_with_status!`](@ref) if the outcome of the
+solve is needed.
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers)
+julia> F(y, x, params) = y .= x .^ 2 .- 2;
+
+julia> prob = NonlinearProblem(F, zeros(1));
+
+julia> x = [1.0];
+
+julia> solve!(x, prob, Newton(); verbosity = 0)
+1-element Vector{Float64}:
+ 1.4142135623730951
+```
+"""
+function solve!(x::AbstractVector, prob::NonlinearProblem, method::NonlinearSolverMethod, args...; kwargs...)
+    solve!(x, NonlinearSolver(method, x, prob; kwargs...), args...)
+end
+
+"""
+    solve(x, prob, method, args...; kwargs...)
+
+Solve the [`NonlinearProblem`](@ref) `prob` with the [`NonlinearSolverMethod`](@ref) `method`,
+starting from the initial guess `x`, and return the solution as a *new* array — `x` itself is left
+untouched. This is [`solve!(::AbstractVector, ::NonlinearProblem, ::NonlinearSolverMethod)`](@ref)
+on a copy, and takes the same arguments; the note on solver construction there applies here too.
+
+The initial guess has to be passed because a `NonlinearProblem` stores neither the solution nor the
+residual, so nothing else determines the size and type of the array to allocate.
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers)
+julia> F(y, x, params) = y .= x .^ 2 .- 2;
+
+julia> prob = NonlinearProblem(F, zeros(1));
+
+julia> x₀ = [1.0];
+
+julia> solve(x₀, prob, Newton(); verbosity = 0)
+1-element Vector{Float64}:
+ 1.4142135623730951
+
+julia> x₀
+1-element Vector{Float64}:
+ 1.0
+```
+"""
+function solve(x::AbstractVector, prob::NonlinearProblem, method::NonlinearSolverMethod, args...; kwargs...)
+    solve!(copy(x), prob, method, args...; kwargs...)
+end
+
+"""
+    solve_with_status!(x, s, params=NullParameters())
+    solve_with_status!(x, prob, method, params=NullParameters(); kwargs...)
+
+Solve as [`solve!`](@ref) does — `x` is overwritten with the solution — but return the
+[`NonlinearSolverStatus`](@ref) instead of `x`.
+
+This is how the outcome of a solve is obtained without holding on to a
+[`NonlinearSolverState`](@ref): the state is built here and handed to [`status`](@ref) afterwards.
+The `!` is part of the name because `x` *is* modified, unlike in the line-search
+[`solve_with_status`](@ref), whose `α` is a number.
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers; using SimpleSolvers: isconverged)
+julia> F(y, x, params) = y .= x .^ 2 .- 2;
+
+julia> prob = NonlinearProblem(F, zeros(1));
+
+julia> x = [1.0];
+
+julia> isconverged(solve_with_status!(x, prob, Newton(); verbosity = 0))
+true
+```
+"""
+function solve_with_status!(x::AbstractArray, s::NonlinearSolver, params=NullParameters())
+    state = NonlinearSolverState(x, value(cache(s)))
+    solve!(x, s, state, params)
+    status(s, state)
+end
+
+function solve_with_status!(x::AbstractVector, prob::NonlinearProblem, method::NonlinearSolverMethod, params=NullParameters(); kwargs...)
+    solve_with_status!(x, NonlinearSolver(method, x, prob; kwargs...), params)
+end

--- a/src/nonlinear/picard_solver.jl
+++ b/src/nonlinear/picard_solver.jl
@@ -59,7 +59,7 @@ function PicardSolver(x::AT, F::Callable, y::AT; (DF!)=missing, kwargs...) where
 end
 
 """
-    PicardSolver(x, nlp::NonlinearProblem, y = similar(x))
+    PicardSolver(x, nlp::NonlinearProblem, y = zero(x))
 
 Build a [`PicardSolver`](@ref) for the [`NonlinearProblem`](@ref) `nlp` with the initial
 guess `x`. See [`NewtonSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref)
@@ -69,7 +69,7 @@ for the rôle of `y`; as above, no `linesearch` keyword is accepted.
 - `jacobian`: see [`resolve_jacobian`](@ref),
 - `options_kwargs`: see [`Options`](@ref).
 """
-function PicardSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=similar(x); jacobian=missing, options_kwargs...) where {T}
+function PicardSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=zero(x); jacobian=missing, options_kwargs...) where {T}
     config = Options(T; options_kwargs...)
     jacobian = resolve_jacobian(nlp.F, nlp.J, jacobian, x, y)
     cache = NonlinearSolverCache(x, y)

--- a/src/nonlinear/picard_solver.jl
+++ b/src/nonlinear/picard_solver.jl
@@ -54,10 +54,24 @@ solve!(x, s, state)
  0.0
 ```
 """
-function PicardSolver(x::AT, F::Callable, y::AT; (DF!)=missing, jacobian=missing, options_kwargs...) where {T,AT<:AbstractVector{T}}
+function PicardSolver(x::AT, F::Callable, y::AT; (DF!)=missing, kwargs...) where {T,AT<:AbstractVector{T}}
+    PicardSolver(x, NonlinearProblem(F, DF!, x, y), y; kwargs...)
+end
+
+"""
+    PicardSolver(x, nlp::NonlinearProblem, y = similar(x))
+
+Build a [`PicardSolver`](@ref) for the [`NonlinearProblem`](@ref) `nlp` with the initial
+guess `x`. See [`NewtonSolver(::AbstractVector{T}, ::NonlinearProblem, ::AbstractVector{T}) where {T}`](@ref)
+for the rôle of `y`; as above, no `linesearch` keyword is accepted.
+
+# Keywords
+- `jacobian`: see [`resolve_jacobian`](@ref),
+- `options_kwargs`: see [`Options`](@ref).
+"""
+function PicardSolver(x::AbstractVector{T}, nlp::NonlinearProblem, y::AbstractVector{T}=similar(x); jacobian=missing, options_kwargs...) where {T}
     config = Options(T; options_kwargs...)
-    nlp = NonlinearProblem(F, DF!, x, y)
-    jacobian = resolve_jacobian(F, DF!, jacobian, x, y)
+    jacobian = resolve_jacobian(nlp.F, nlp.J, jacobian, x, y)
     cache = NonlinearSolverCache(x, y)
     # The Picard `solver_step!` never consults a line search; the (structurally
     # mandatory) `linesearch` field is filled with a trivial `Static` step.  A

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -266,6 +266,80 @@ for T ∈ (Float64, Float32)
 end
 
 
+# test the convenience wrappers of issue #159: the same solves as the loop above, but with the
+# solver assembled by `solve!`/`solve`/`solve_with_status!` from a `NonlinearProblem` instead of
+# by the caller.
+for T ∈ (Float64, Float32)
+    for (solver_method, kwarguments, tolfac) in (
+        (Newton(), (linesearch=Static(T),), 2),
+        (QuasiNewton(), (linesearch=Static(T),), 2),
+        (Picard(), (), 8),
+        (DogLeg(), (), 1)
+    )
+
+        @testset "Testing solve!/solve/solve_with_status! with method = $(solver_method) & $(kwarguments) & $(T)" begin
+            isroot(_x) = ≈(_x, T(root₁); atol=tolfac * eps(T)) || ≈(_x, T(root₂); atol=tolfac * eps(T)) || ≈(_x, T(root₃); atol=tolfac * eps(T)) || ≈(_x, T(root₄); atol=tolfac * eps(T))
+
+            x = T.(copy(x₀))
+            y = F(x)
+            prob = NonlinearProblem(F!, x, y)
+
+            # `solve!` overwrites its first argument and returns it
+            xs = T.(copy(x₀))
+            @test solve!(xs, prob, solver_method; verbosity=0, kwarguments...) === xs
+            @test all(isroot, xs)
+
+            # `solve` returns a new array and leaves the initial guess untouched
+            xi = T.(copy(x₀))
+            xn = solve(xi, prob, solver_method; verbosity=0, kwarguments...)
+            @test xn !== xi
+            @test xi == T.(x₀)
+            @test all(isroot, xn)
+
+            # `solve_with_status!` reports the outcome of the solve
+            xt = T.(copy(x₀))
+            st = solve_with_status!(xt, prob, solver_method; verbosity=0, kwarguments...)
+            @test st isa NonlinearSolverStatus
+            @test isconverged(st)
+            @test all(isroot, xt)
+
+            # a problem carrying its own Jacobian takes the `JacobianFunction` path
+            probJ = NonlinearProblem(F!, J!, x, y)
+            xj = T.(copy(x₀))
+            solve!(xj, probJ, solver_method; verbosity=0, kwarguments...)
+            @test all(isroot, xj)
+        end
+    end
+end
+
+@testset "The solve! wrapper forwards params, a state and solver keywords" begin
+    Fp!(y, x, params) = y .= x .^ 2 .- params.a
+    prob = NonlinearProblem(Fp!, zeros(2))
+
+    # `params` is forwarded to the problem
+    x = ones(2)
+    solve!(x, prob, Newton(), (a=3.0,); verbosity=0)
+    @test x ≈ [sqrt(3.0), sqrt(3.0)]
+
+    # so is a state supplied by the caller, which is how the iteration count is obtained
+    state = NonlinearSolverState(zeros(2))
+    x .= 1
+    solve!(x, prob, Newton(), state, (a=3.0,); verbosity=0)
+    @test iteration_number(state) > 0
+    @test x ≈ [sqrt(3.0), sqrt(3.0)]
+
+    # solver keywords reach the constructor: a single iteration cannot converge, and the
+    # methods that consult no line search still reject a `linesearch` keyword (as their
+    # constructors do — see "PicardSolver rejects a linesearch keyword" below)
+    x .= 1
+    st = solve_with_status!(x, prob, Newton(), (a=3.0,); max_iterations=1, verbosity=0)
+    @test !isconverged(st)
+
+    @test_throws MethodError solve!(ones(2), prob, Picard(), (a=3.0,); linesearch=Static(1.0), verbosity=0)
+    @test_throws MethodError solve!(ones(2), prob, DogLeg(), (a=3.0,); linesearch=Static(1.0), verbosity=0)
+end
+
+
 # test regularization
 for T ∈ (Float64, Float32)
     for (solver_method, kwarguments) in (

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -303,11 +303,19 @@ for T ∈ (Float64, Float32)
             @test isconverged(st)
             @test all(isroot, xt)
 
-            # a problem carrying its own Jacobian takes the `JacobianFunction` path
+            # a problem carrying its own Jacobian takes the `JacobianFunction` path — asserted on
+            # the constructed solver, since the root alone would not distinguish it from autodiff
             probJ = NonlinearProblem(F!, J!, x, y)
+            @test SimpleSolvers.jacobian(NonlinearSolver(solver_method, T.(copy(x₀)), probJ; verbosity=0, kwarguments...)) isa JacobianFunction
             xj = T.(copy(x₀))
             solve!(xj, probJ, solver_method; verbosity=0, kwarguments...)
             @test all(isroot, xj)
+
+            # the solver-taking form of `solve_with_status!`, which the problem-taking one calls
+            xw = T.(copy(x₀))
+            sw = NonlinearSolver(solver_method, xw, prob; verbosity=0, kwarguments...)
+            @test isconverged(solve_with_status!(xw, sw))
+            @test all(isroot, xw)
         end
     end
 end
@@ -337,6 +345,26 @@ end
 
     @test_throws MethodError solve!(ones(2), prob, Picard(), (a=3.0,); linesearch=Static(1.0), verbosity=0)
     @test_throws MethodError solve!(ones(2), prob, DogLeg(), (a=3.0,); linesearch=Static(1.0), verbosity=0)
+end
+
+# The default residual prototype is `zero(x)` and not `similar(x)`: `alloc_j` broadcasts over it
+# (`_nan(T) .* y * x'`), so an uninitialized prototype throws an `UndefRefError` for any element
+# type whose `similar` leaves undefined references.  `BigFloat` is one.
+@testset "The default residual prototype works for element types with undef-leaving similar" begin
+    Fb!(y, x, params) = y .= x .^ 2 .- 2
+    xb = BigFloat.(ones(2))
+    prob = NonlinearProblem(Fb!, xb)
+
+    @test NewtonSolver(xb, prob) isa NonlinearSolver
+    @test PicardSolver(xb, prob) isa NonlinearSolver
+    @test DogLegSolver(xb, prob) isa NonlinearSolver
+
+    # …and a solve goes through.  `static=false` is needed only because the default `LU()` caches
+    # a small matrix as an `MMatrix`, and StaticArrays cannot `setindex!` a non-isbits eltype —
+    # a pre-existing limitation of the linear solver, unrelated to the residual prototype.
+    xs = BigFloat.(ones(2))
+    solve!(xs, prob, Newton(); linear_solver_method=LU(static=false), verbosity=0)
+    @test xs ≈ [sqrt(BigFloat(2)), sqrt(BigFloat(2))]
 end
 
 

--- a/test/smoke_tests.jl
+++ b/test/smoke_tests.jl
@@ -152,6 +152,19 @@ end
 
     @test NonlinearSolver(Newton(), xvec, yr; F=F_vec!) isa NonlinearSolver
 
+    # the `NonlinearProblem` forms, with and without the residual prototype
+    nlprob = NonlinearProblem(F_vec!, xvec, yr)
+    @test NewtonSolver(xvec, nlprob, yr) isa NonlinearSolver
+    @test NewtonSolver(xvec, nlprob) isa NonlinearSolver
+    @test PicardSolver(xvec, nlprob) isa NonlinearSolver
+    @test DogLegSolver(xvec, nlprob) isa NonlinearSolver
+    @test NonlinearSolver(Newton(), xvec, nlprob) isa NonlinearSolver
+
+    # and the wrappers that build such a solver themselves
+    @test solve!(copy(xvec), nlprob, Newton(); verbosity=0) isa AbstractVector
+    @test solve(xvec, nlprob, Newton(); verbosity=0) isa AbstractVector
+    @test solve_with_status!(copy(xvec), nlprob, Newton(); verbosity=0) isa NonlinearSolverStatus
+
     ns = NewtonSolver(xvec, yr; F=F_vec!, verbosity=0)
     nstate = SolverState(ns)
     @test status(ns, nstate) isa NonlinearSolverStatus


### PR DESCRIPTION
Closes #159.

## The gap

`NonlinearProblem` is exported but is not usable as an argument anywhere: no solver constructor accepts one, so a hand-built problem forces the seven-argument low-level constructor, with the linear problem, the linear solver, the line search and the cache all supplied by the caller. The `NewtonSolver` docstring has advertised the missing capability — *"can be called with a `NonlinearProblem` or with a `Callable`"* — since before it existed. Nor is there a `solve`/`solve!` taking a problem and a method, which both of the other subsystems have: `solve(lu, ls)` on the linear side, `solve(prob, method, α, params, config)` on the line-search side.

## Constructors

`NewtonSolver(x, nlp::NonlinearProblem, y = zero(x))` and the same form for `PicardSolver` and `DogLegSolver`, hence also `NonlinearSolver(method, x, nlp)`. A Jacobian stored in the problem takes precedence over autodiff, exactly as the `DF!` keyword does.

The residual prototype `y` supplies a size and an element type, and nothing computed from it survives — `alloc_j` turns it into a `NaN` matrix, the cache stores `zero(y)`. It is not left alone, though: `JacobianAutodiff` keeps it as the buffer ForwardDiff writes the residual into, so a caller-supplied prototype is overwritten on every Jacobian evaluation. It defaults to `zero(x)`, which is what a square system needs, and every system here is square because the Jacobian gets factorized.

`zero` and not `similar`: `alloc_j` is `_nan(T) .* y * x'`, which *broadcasts over* `y`. For IEEE floats an uninitialized prototype is harmless (`NaN * garbage == NaN`), but for an element type whose `similar` leaves undefined references it throws — `NewtonSolver(BigFloat.(ones(2)), nlp)` was an `UndefRefError`. The default also assumes `zero(x)` shares `x`'s type, which `NonlinearSolverCache` requires; a `SubArray`, whose `zero` is an `Array`, has to pass `y` explicitly. Both are documented.

## Wrappers

```julia
solve!(x, prob, method, args...; kwargs...)              # → x, overwritten
solve(x₀, prob, method, args...; kwargs...)              # → new array, x₀ untouched
solve_with_status!(x, s::NonlinearSolver, params)        # → NonlinearSolverStatus
solve_with_status!(x, prob, method, params; kwargs...)   # → NonlinearSolverStatus
```

`solve` is `solve!`'s signature minus the bang, which is what the bang should mean. The initial guess has to be passed because a `NonlinearProblem` stores neither the solution nor the residual, so nothing else determines the size and type of the array to allocate. The trailing positional arguments go through to the solver-level `solve!`, so they are the problem's `params`, optionally preceded by a `NonlinearSolverState`.

The keywords are `Options`' plus whatever the constructor selected by `method` accepts, which is not one set for all four: `Newton`/`QuasiNewton` take `linesearch`, `jacobian` and `linear_solver_method`, `DogLeg` drops `linesearch`, `Picard` takes only `jacobian`. The methods that consult no line search reject a `linesearch` keyword rather than ignoring it — it falls through to `Options` and raises a `MethodError` there. `refactorize` belongs to the `method` (`Newton(5)`, `QuasiNewton()`, `DogLeg(5)`) and not to the keywords; passing it as a keyword happens to work for `Newton` and `DogLeg`, where it is forwarded after `method.refactorize` and silently wins as the rightmost occurrence, and errors for `Picard`. The docstring carries the table.

`solve_with_status!` exists because a wrapper discards the solver it built, which puts `status(s, state)` — needing both — out of reach; it builds the state itself. The `!` is honest here, unlike in the line search's `solve_with_status`, whose `α` is a number. It is the one new export; the predicates that read what it returns, `isconverged` and `isstalled`, stay unexported in line with the policy at the top of `SimpleSolvers.jl` (generic names a downstream `using SimpleSolvers` may want for itself), and the docstring says how to reach them.

Each wrapper call constructs a solver (a Jacobian with its ForwardDiff configuration, a factorization cache, the line-search buffers), so this is the convenience path and not the one for a loop: that should still build one `NonlinearSolver` and reuse it. The docstrings say so.

## Deduplication

The three `(x, F, y)` constructors are now one-line delegations to their `NonlinearProblem` counterparts — the assembly recipe they each carried a copy of exists once per solver now. No behaviour change: `NonlinearProblem(F, DF!, x, y)` stores `J = DF!`, so the resulting `resolve_jacobian` call is the one they made before.

## Verification

- Full suite passes, including Aqua's ambiguity check (the new `NonlinearProblem` and `Callable` signatures are disjoint types — `Base.Callable` is `Union{Function,Type}` — so no ambiguity is possible).
- `doctest(SimpleSolvers)` passes, and the new doctests were confirmed to be exercised by breaking one expected value and seeing the failure.
- A full `docs/make.jl` build succeeds, which is what validates the method-signature `@ref`s.
- `test/nonlinear_solver_tests.jl` under `--check-bounds=yes`: no failures.

New tests run all four methods over `Float64` and `Float32`: `solve!` returns the array it overwrote, `solve` leaves its argument untouched, `solve_with_status!` reports convergence in both its forms, a problem carrying its own Jacobian is asserted to take the `JacobianFunction` path on the constructed solver (the root alone would not distinguish it from autodiff), and `params`, a caller's state and `max_iterations` all survive the extra hop while `Picard` and `DogLeg` still reject a `linesearch` keyword through it. A `BigFloat` testset locks in the `zero(x)` prototype.

> [!NOTE]
> That `BigFloat` test needs `linear_solver_method=LU(static=false)`. The default `LU()` caches a matrix with leading dimension ≤ `N_STATIC_THRESHOLD` as an `MMatrix`, and StaticArrays cannot `setindex!` a non-isbits eltype, so a small extended-precision Newton solve fails with the default linear solver method. That is pre-existing and unrelated to this PR — flagging it rather than fixing it here.

> [!NOTE]
> Based on `main`, so the `## [0.11.0]` CHANGELOG section and the version bump here will conflict textually with #175, which creates the same section for the expansion phase. The code changes are disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
