### PR TITLE
Report a solve whose iterate moves while its residual goes nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,9 @@ now says.
   reference is monotone — the best residual so far — so an iteration that undoes the previous
   one's progress does not reset the clock.
 - **The report is unconditional.** A solve that spends its whole budget without converging and
-  without progressing over at least half of it now says so, naming the residual it achieved, the
+  without progressing over at least half of it — and over at least `F_STALL_REPORT_MINIMUM`
+  iterations, below which the proportion is not evidence of anything — now says so, naming the
+  residual it achieved, the
   tolerance it was asked for, how many iterations it went without improving, and that the iterate
   did *not* freeze — which is what distinguishes a floor of the problem from the round-off floor
   `max_stalls` reports. It replaces the bare iteration count rather than adding to it, and, like

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to SimpleSolvers.jl are documented here.
 
 ## [0.11.0]
 
-Two independent changes. **Breaking**: `Backtracking` loses its `α₀` key and its positional
+Three independent changes. **Breaking**: `Backtracking` loses its `α₀` key and its positional
 constructor, and gains an opt-in expansion phase. Additive: a `NonlinearProblem` can be solved
-without assembling a solver by hand.
+without assembling a solver by hand, and a `NonlinearSolver` reports — and, on request, stops —
+a solve that is *not progressing*, the case
+[issue #173](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/173) found next to the
+`max_stalls` machinery of 0.10.0.
 
 ### Convenience entry points for solving a `NonlinearProblem`
 
@@ -134,6 +137,54 @@ default line search still shrinks only. GeometricIntegrators' Runge-Kutta suite
 passes (128 assertions) with bit-identical trajectories for `Gauss(1)`…`Gauss(4)`. To fix an
 under-scaled direction, ask for it:
 `NewtonSolver(x, F, y; linesearch = Backtracking(T; expand = true))`.
+
+### Solves that get nowhere
+
+`max_stalls` (0.10.0) catches a solve whose **iterate has frozen**: the step has fallen below the
+round-off level of `x` while the residual is not small, so no progress is possible along the
+current direction. Issue #173 reports the case next to it — the iterate keeps moving perfectly
+normally while the residual sits on a floor far above the requested tolerance. No existing
+criterion can fire, by construction: `iterate_settled` is false because the step is not small,
+`residual_small` is false because the residual is not either, and `stalled_step` needs both. Such
+a solve spends `max_iterations` in full and reports `"Solver took 1000 iterations."`, which names
+a symptom and no cause.
+
+The floor there was set by the *problem* — an under-parameterised network ansatz, whose
+approximation error put `‖F‖` at 2e-6, six orders of magnitude above the tolerance the solver was
+asked for. That is not round-off, so no `eps(T)`-scaled tolerance can bound it, and the remedy is
+one level up from the solver: raise `f_abstol` above the achievable residual, or improve the
+approximation until its floor lies below the tolerance you need. Which is exactly what the report
+now says.
+
+- `SimpleSolvers.record_progress!` keeps, per solve, the residual as of the last iteration that
+  counted as *progress* and the iteration at which that was, so
+  `SimpleSolvers.iterations_since_progress` measures how long the residual has been going
+  nowhere. It is called once per iteration from `solve!`, next to `record_stall!`, and the
+  reference is monotone — the best residual so far — so an iteration that undoes the previous
+  one's progress does not reset the clock.
+- **The report is unconditional.** A solve that spends its whole budget without converging and
+  without progressing over at least half of it now says so, naming the residual it achieved, the
+  tolerance it was asked for, how many iterations it went without improving, and that the iterate
+  did *not* freeze — which is what distinguishes a floor of the problem from the round-off floor
+  `max_stalls` reports. It replaces the bare iteration count rather than adding to it, and, like
+  the stagnation message, is gated on `verbosity ≥ 1` and capped with `maxlog`. The bare count
+  gained a `maxlog` too: it had none, so a time-stepping caller got one per step.
+- **The stopping criterion is opt-in**, through two new `Options` fields: `f_stall_window`
+  (default `0`, disabled) gives up after that many iterations without progress, and
+  `f_stall_factor` (default `0.5`) is the drop that counts as progress. `SimpleSolvers.no_progress`
+  is the predicate, gated on `!residual_small` exactly as `stalled_step` is, so giving up and
+  converging remain mutually exclusive; `SimpleSolvers.isnotprogressing` reads it off the status.
+
+The asymmetry is deliberate. The threshold is a policy, not a test: an iteration converging
+linearly with rate ρ improves by ρ^W over a window W, so a window of 50 at the default factor
+abandons every ρ > 0.986, and a `PicardSolver` on a stiff problem is slower than that. There is no
+value that is right for every problem — so the *diagnosis*, which is consulted only about a solve
+that has already spent its budget and therefore decides nothing, is free; while the *stopping*,
+which can cut short a solve that would have succeeded, is the caller's to ask for. Set it once the
+report has told you the floor is real.
+
+Behaviour at default options is unchanged except for what is printed: no solve stops earlier than
+it did, and `f_stall_window = 0` makes `no_progress` constant `false`.
 
 ## [0.10.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,11 +157,14 @@ approximation until its floor lies below the tolerance you need. Which is exactl
 now says.
 
 - `SimpleSolvers.record_progress!` keeps, per solve, the residual as of the last iteration that
-  counted as *progress* and the iteration at which that was, so
+  counted as *progress* and the number of iterations since, so
   `SimpleSolvers.iterations_since_progress` measures how long the residual has been going
-  nowhere. It is called once per iteration from `solve!`, next to `record_stall!`, and the
-  reference is monotone — the best residual so far — so an iteration that undoes the previous
-  one's progress does not reset the clock.
+  nowhere. The reference is monotone — the best residual so far — so an iteration that undoes the
+  previous one's progress does not reset the clock. Like `record_stall!` it is an increment
+  rather than a predicate, so it owns its counter: an iteration that never records leaves it at
+  zero, exactly as `stall_number` does. `SimpleSolvers.record_iteration!` is the one function
+  that takes both measurements, from a single `residuals` call, and `solve!` calls it once per
+  iteration.
 - **The report is unconditional.** A solve that spends its whole budget without converging and
   without progressing over at least half of it — and over at least `F_STALL_REPORT_MINIMUM`
   iterations, below which the proportion is not evidence of anything — now says so, naming the
@@ -170,7 +173,9 @@ now says.
   did *not* freeze — which is what distinguishes a floor of the problem from the round-off floor
   `max_stalls` reports. It replaces the bare iteration count rather than adding to it, and, like
   the stagnation message, is gated on `verbosity ≥ 1` and capped with `maxlog`. The bare count
-  gained a `maxlog` too: it had none, so a time-stepping caller got one per step.
+  gained a `maxlog` too: it had none, so a time-stepping caller got one per step — and it is now
+  also replaced by the *stagnation* message, which had been added alongside it since 0.10.0. The
+  three are mutually exclusive, most specific first.
 - **The stopping criterion is opt-in**, through two new `Options` fields: `f_stall_window`
   (default `0`, disabled) gives up after that many iterations without progress, and
   `f_stall_factor` (default `0.5`) is the drop that counts as progress. `SimpleSolvers.no_progress`

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -267,16 +267,20 @@ default of the `f_stall_factor` field of [`Options`](@ref). Its value is """ *
 halved".
 
 [`record_progress!`](@ref) keeps the residual ``r^f_a`` of the last iteration that counted as
-progress, together with the iteration at which it happened, so that
-[`iterations_since_progress`](@ref) measures how long the residual has been going nowhere. That
-one number is used twice: unconditionally by [`nonlinear_solver_warnings`](@ref) to explain a
-solve that spent its whole budget, and — only when `f_stall_window > 0` — as the stopping
-criterion [`no_progress`](@ref).
+progress, and counts the iterations since, so that [`iterations_since_progress`](@ref) measures
+how long the residual has been going nowhere. That one number is used twice: unconditionally by
+[`nonlinear_solver_warnings`](@ref) to explain a solve that spent its whole budget, and — only
+when `f_stall_window > 0` — as the stopping criterion [`no_progress`](@ref).
 
 A factor closer to one (say `0.999`, i.e. "any improvement of a tenth of a percent counts") makes
 the measurement *more permissive*: a residual creeping down that slowly keeps resetting the clock,
 so only one that is essentially flat is ever reported. A smaller factor demands a steeper descent
 of an iteration before it counts as progress, and so reports sooner.
+
+Only ``0 < f_{\mathrm{stall\,factor}} \le 1`` is meaningful. Nothing asserts it — `Options`
+validates none of its fields — but a factor above one would make a residual that *grew* count as
+progress and so let the reference climb, which is exactly the monotonicity
+[`record_progress!`](@ref) relies on to be immune to a residual that jumps around.
 
 See [`F_STALL_WINDOW`](@ref).
 """
@@ -319,10 +323,16 @@ The fewest iterations without progress that [`spent_without_progress`](@ref) wil
 value is """ * """$(F_STALL_REPORT_MINIMUM)""" * raw""".
 
 Unlike `f_stall_window` this is not configurable, because it is not a policy: it is the point
-below which the *proportion* that predicate measures is not evidence of anything. A solve that
-converges in four iterations without halving its residual on the last two has not stagnated, it
-has finished — and at two iterations the proportion is satisfied by a single one, which is the
-normal last step of a solve that converged on its successive-change criterion.
+below which the *proportion* that predicate measures is not evidence of anything. At two
+iterations the proportion is satisfied by a single one, and a solve that gets nowhere for four
+iterations has not shown you anything a solve that got somewhere on the fifth would not.
+
+It is the *second* of the two guards [`spent_without_progress`](@ref) carries. The first is
+[`isconverged`](@ref) — a residual that stopped improving because it was already small enough is
+success, not stagnation, and that is what excuses the short solve which converged on its
+successive-change criterion without halving its residual on the last step. This minimum then
+covers the solve that has *not* converged and is merely too short for the proportion to mean
+anything.
 
 This bounds only what is *said* about a solve, never what is done with it — the stopping
 criterion is `f_stall_window` alone (see [`no_progress`](@ref)).

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -312,6 +312,23 @@ iterations then turns a full budget into a prompt answer.
 """
 const F_STALL_WINDOW::Int = 0
 
+@doc raw"""
+    const F_STALL_REPORT_MINIMUM
+
+The fewest iterations without progress that [`spent_without_progress`](@ref) will report on. Its
+value is """ * """$(F_STALL_REPORT_MINIMUM)""" * raw""".
+
+Unlike `f_stall_window` this is not configurable, because it is not a policy: it is the point
+below which the *proportion* that predicate measures is not evidence of anything. A solve that
+converges in four iterations without halving its residual on the last two has not stagnated, it
+has finished — and at two iterations the proportion is satisfied by a single one, which is the
+normal last step of a solve that converged on its successive-change criterion.
+
+This bounds only what is *said* about a solve, never what is done with it — the stopping
+criterion is `f_stall_window` alone (see [`no_progress`](@ref)).
+"""
+const F_STALL_REPORT_MINIMUM::Int = 10
+
 """
     Options
 

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -258,6 +258,60 @@ Set `max_stalls = typemax(Int)` to restore the previous behaviour of running all
 """
 const MAX_STALLS::Int = 2
 
+@doc raw"""
+    const F_STALL_FACTOR
+
+The factor by which the residual has to drop for an iteration to count as *progress*; the
+default of the `f_stall_factor` field of [`Options`](@ref). Its value is """ *
+                        """$(F_STALL_FACTOR)""" * raw""", i.e. progress means "the residual
+halved".
+
+[`record_progress!`](@ref) keeps the residual ``r^f_a`` of the last iteration that counted as
+progress, together with the iteration at which it happened, so that
+[`iterations_since_progress`](@ref) measures how long the residual has been going nowhere. That
+one number is used twice: unconditionally by [`nonlinear_solver_warnings`](@ref) to explain a
+solve that spent its whole budget, and — only when `f_stall_window > 0` — as the stopping
+criterion [`no_progress`](@ref).
+
+A factor closer to one (say `0.999`, i.e. "any improvement of a tenth of a percent counts") makes
+the measurement *more permissive*: a residual creeping down that slowly keeps resetting the clock,
+so only one that is essentially flat is ever reported. A smaller factor demands a steeper descent
+of an iteration before it counts as progress, and so reports sooner.
+
+See [`F_STALL_WINDOW`](@ref).
+"""
+const F_STALL_FACTOR = 0.5
+
+@doc raw"""
+    const F_STALL_WINDOW
+
+The default number of iterations without progress after which a [`NonlinearSolver`](@ref) gives
+up; the default of the `f_stall_window` field of [`Options`](@ref). Its value is """ *
+                        """$(F_STALL_WINDOW)""" * raw""", which **disables** the criterion (see
+[`no_progress`](@ref)).
+
+This is the counterpart of `max_stalls` for a solve whose iterate keeps *moving*: the residual
+sits on a floor far above the requested tolerance while the step is nowhere near the round-off
+level of ``x``, so neither [`stalled_step`](@ref) nor either convergence branch can fire and the
+iteration spends `max_iterations` in full. That floor is typically set by the problem itself — a
+model, discretisation or ansatz error that ``F`` cannot resolve — rather than by round-off, so
+no ``\mathrm{eps}(T)``-scaled tolerance can bound it.
+
+It is off by default because the threshold is a *policy*, not a test, and a wrong one gives up on
+a healthy solve. An iteration converging linearly with rate ``\rho`` improves by ``\rho^W`` over a
+window ``W``: at `f_stall_factor = 0.5` and `f_stall_window = 50` every ``\rho > 2^{-1/50}
+\approx 0.986`` is abandoned, and a [`PicardSolver`](@ref) on a stiff problem is slower than that.
+There is no value that is right for every problem, which is why the *diagnosis* is unconditional
+(a solve that spent its budget without progressing says so, see
+[`nonlinear_solver_warnings`](@ref)) and only the *stopping* is opt-in: the report costs a solve
+that has already failed nothing, whereas the criterion can cost a solve that would have
+succeeded everything.
+
+So set it once you have seen the report and know the floor is real — a window of a few tens of
+iterations then turns a full budget into a prompt answer.
+"""
+const F_STALL_WINDOW::Int = 0
+
 """
     Options
 
@@ -275,6 +329,7 @@ Options()
                 f_reltol = 1.4901161193847656e-8
                 f_suctol = 4.440892098500626e-16
                 f_mindec = 0.0001
+          f_stall_factor = 0.5
           f_abstol_break = Inf
        allow_f_increases = true
           min_iterations = 0
@@ -282,6 +337,7 @@ Options()
          warn_iterations = 1000
 linesearch_max_iterations = 60
               max_stalls = 2
+          f_stall_window = 0
               show_trace = false
              store_trace = false
           extended_trace = false
@@ -341,6 +397,17 @@ linesearch_max_iterations = 60
     looser. If the stagnation warning reports an achieved `rfₐ` near your `f_abstol`, raise
     `f_abstol` above it — an order of magnitude of headroom is usual.
 
+    A residual floor need not come from round-off at all. A model, discretisation or ansatz
+    error — an approximation `F` is built on and cannot resolve — puts a floor on ``\\|F(x)\\|``
+    that may sit many orders of magnitude *above* the round-off level, and that no
+    ``\\mathrm{eps}(T)``-scaled tolerance can bound. Such a solve looks different from a stalled
+    one: the iterate keeps moving normally, so nothing stops the iteration and it spends
+    `max_iterations` in full. It is reported by [`nonlinear_solver_warnings`](@ref) as having
+    made no progress, and `f_stall_window` (see [`F_STALL_WINDOW`](@ref)) bounds its cost once
+    you know the floor is there. The remedy is the same, one level up: raise `f_abstol` above
+    the achieved `rfₐ`, or improve the approximation until its floor lies below the tolerance
+    you need.
+
 !!! info
     Also see [`meets_stopping_criteria`](@ref).
 """
@@ -352,6 +419,7 @@ struct Options{T}
     f_reltol::T
     f_suctol::T
     f_mindec::T
+    f_stall_factor::T
     f_abstol_break::T
     allow_f_increases::Bool
     min_iterations::Int
@@ -359,6 +427,7 @@ struct Options{T}
     warn_iterations::Int
     linesearch_max_iterations::Int
     max_stalls::Int
+    f_stall_window::Int
     show_trace::Bool
     store_trace::Bool
     extended_trace::Bool
@@ -381,6 +450,7 @@ function Options(T=Float64;
     f_reltol::Real=(√(eps(T))),
     f_suctol::Real=default_tolerance(T),
     f_mindec::Real=minimum_decrease_threshold(T),
+    f_stall_factor::Real=T(F_STALL_FACTOR),
     f_abstol_break::Real=T(Inf),
     allow_f_increases::Bool=ALLOW_F_INCREASES,
     min_iterations::Integer=MIN_ITERATIONS,
@@ -388,6 +458,7 @@ function Options(T=Float64;
     warn_iterations::Integer=WARN_ITERATIONS,
     linesearch_max_iterations::Integer=linesearch_iterations(T),
     max_stalls::Integer=MAX_STALLS,
+    f_stall_window::Integer=F_STALL_WINDOW,
     show_trace::Bool=SHOW_TRACE,
     store_trace::Bool=STORE_TRACE,
     extended_trace::Bool=EXTENDED_TRACE,
@@ -411,6 +482,7 @@ function Options(T=Float64;
             f_reltol,
             f_suctol,
             f_mindec,
+            f_stall_factor,
             f_abstol_break)...,
         allow_f_increases,
         min_iterations,
@@ -418,6 +490,7 @@ function Options(T=Float64;
         warn_iterations,
         linesearch_max_iterations,
         max_stalls,
+        f_stall_window,
         show_trace,
         store_trace,
         extended_trace,
@@ -470,3 +543,19 @@ The number of consecutive stalled steps after which a [`NonlinearSolver`](@ref) 
 [`MAX_STALLS`](@ref) and [`stalled_step`](@ref).
 """
 max_stalls(o::Options) = o.max_stalls
+
+"""
+    f_stall_factor(o::Options)
+
+The factor by which the residual has to drop for an iteration to count as progress. See
+[`F_STALL_FACTOR`](@ref) and [`record_progress!`](@ref).
+"""
+f_stall_factor(o::Options) = o.f_stall_factor
+
+"""
+    f_stall_window(o::Options)
+
+The number of iterations without progress after which a [`NonlinearSolver`](@ref) gives up
+(`0` disables the criterion). See [`F_STALL_WINDOW`](@ref) and [`no_progress`](@ref).
+"""
+f_stall_window(o::Options) = o.f_stall_window

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -273,6 +273,7 @@ function solve!(x::AbstractArray, s::NonlinearSolver, state::NonlinearSolverStat
         solver_step!(x, s, state, params)
         update!(state, x, value!(value(cache(s)), nonlinearproblem(s), x, params))
         record_stall!(state, config(s))
+        record_progress!(state, config(s))
     end
 
     status = NonlinearSolverStatus(state, config(s))

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -272,8 +272,7 @@ function solve!(x::AbstractArray, s::NonlinearSolver, state::NonlinearSolverStat
         increase_iteration_number!(state)
         solver_step!(x, s, state, params)
         update!(state, x, value!(value(cache(s)), nonlinearproblem(s), x, params))
-        record_stall!(state, config(s))
-        record_progress!(state, config(s))
+        record_iteration!(state, config(s))
     end
 
     status = NonlinearSolverStatus(state, config(s))

--- a/src/nonlinear/nonlinear_solver_state.jl
+++ b/src/nonlinear/nonlinear_solver_state.jl
@@ -10,7 +10,7 @@ The `NonlinearSolverState` to be used together with a [`NonlinearSolver`](@ref).
 
 ```jldoctest; setup = :(using SimpleSolvers)
 julia> state = NonlinearSolverState(zeros(3))
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], NaN, 0, false)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], NaN, 0, false, NaN, 0)
 ```
 """
 mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T}} <: AbstractSolverState
@@ -31,6 +31,10 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
                      # merit cannot be decreased; OR-ed into the verdict of the next
                      # `record_stall!`, which clears it again
 
+    rf_ref::T        # the residual as of the last iteration that counted as progress, and the
+    iter_ref::Int    # iteration at which that was; maintained by `record_progress!`, read as
+                     # `iterations_since_progress` by the report and by `no_progress`
+
     function NonlinearSolverState(X::AbstractVector{T}, Y::AbstractVector{T}=X) where {T}
         x = zero(X)
         x̄ = zero(X)
@@ -42,7 +46,7 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
         y .= T(NaN)
         ȳ .= T(NaN)
 
-        new{T,typeof(x),typeof(y)}(0, x, x̄, y, ȳ, T(NaN), 0, false)
+        new{T,typeof(x),typeof(y)}(0, x, x̄, y, ȳ, T(NaN), 0, false, T(NaN), 0)
     end
 end
 
@@ -93,6 +97,10 @@ function initialize!(state::NonlinearSolverState{T}, x::AbstractVector{T}, y::Ab
     state.ȳ .= T(NaN)
     state.stalls = 0
     state.stallflag = false
+    # The initial residual is also the first progress reference: a solve is measured against
+    # where it started, so `iterations_since_progress` counts from iteration 0.
+    state.rf_ref = state.r₀
+    state.iter_ref = 0
 end
 
 """
@@ -103,6 +111,53 @@ Return the number of *consecutive* stalled steps recorded in
 [`iteration_number`](@ref).
 """
 stall_number(state::NonlinearSolverState) = state.stalls
+
+@doc raw"""
+    iterations_since_progress(state)
+
+Return the number of iterations since the residual last dropped by `config.f_stall_factor`, as
+recorded in `state::`[`NonlinearSolverState`](@ref) by [`record_progress!`](@ref). Zero on a
+freshly initialized state.
+
+This measures the failure mode [`stall_number`](@ref) cannot see. A stalled step is one that did
+not move the iterate; here the iterate moves perfectly normally — by far more than the round-off
+level of ``x`` — while the residual descends towards a floor above the requested tolerance, so
+neither [`stalled_step`](@ref) nor either branch of [`assess_convergence`](@ref) can fire and the
+solve spends `max_iterations` in full. [`nonlinear_solver_warnings`](@ref) reports it, and
+[`no_progress`](@ref) stops it when the caller has opted in with `f_stall_window`.
+"""
+iterations_since_progress(state::NonlinearSolverState) = iteration_number(state) - state.iter_ref
+
+@doc raw"""
+    record_progress!(state, config)
+
+Update the progress reference of `state::`[`NonlinearSolverState`](@ref): when the residual has
+dropped to `config.f_stall_factor` times the residual of the last iteration that counted as
+progress, that becomes the new reference and the count returned by
+[`iterations_since_progress`](@ref) restarts. Returns that count.
+
+The reference is therefore monotonically non-increasing — it is the best residual so far, at the
+granularity of the factor — which is what makes the measurement immune to a residual that jumps
+around: an iteration that undoes the progress of the previous one does not reset the clock. See
+[`F_STALL_FACTOR`](@ref) for the choice of granularity.
+
+Like [`record_stall!`](@ref), this must be called *exactly once per iteration* — [`solve!`](@ref)
+does so right after [`update!`](@ref) — because it is a per-iteration measurement rather than a
+predicate. That is why it lives here and not in [`NonlinearSolverStatus`](@ref), which is pure
+and is built more than once per iteration. A hand-rolled iteration that drives
+[`solver_step!`](@ref) directly and never calls it keeps the count at zero and behaves exactly as
+before.
+"""
+function record_progress!(state::NonlinearSolverState, config::Options)
+    rfₐ = l2norm(value(state))
+    # `NaN ≤ x` is false, so a not-yet-initialized reference never counts as progress; it is set
+    # by `initialize!` before the first iteration in every solve that goes through `solve!`.
+    if rfₐ ≤ config.f_stall_factor * state.rf_ref
+        state.rf_ref = rfₐ
+        state.iter_ref = iteration_number(state)
+    end
+    iterations_since_progress(state)
+end
 
 """
     flag_stall!(state)
@@ -160,10 +215,10 @@ julia> y = zero(x); f(y, x, NullParameters())
  0.06120871905481365
 
 julia> state = NonlinearSolverState(x)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN], [NaN], [NaN], [NaN], NaN, 0, false)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN], [NaN], [NaN], [NaN], NaN, 0, false, NaN, 0)
 
 julia> update!(state, x, y)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.25], [NaN], [0.06120871905481365], [NaN], NaN, 0, false)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.25], [NaN], [0.06120871905481365], [NaN], NaN, 0, false, NaN, 0)
 
 julia> x = ones(1) / 2
 1-element Vector{Float64}:
@@ -174,7 +229,7 @@ julia> f(y, x, NullParameters())
  0.0
 
 julia> update!(state, x, y)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.5], [0.25], [0.0], [0.06120871905481365], NaN, 0, false)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.5], [0.25], [0.0], [0.06120871905481365], NaN, 0, false, NaN, 0)
 ```
 
 The [`NonlinearSolverState`](@ref) stores the previous solution, the previous value, the current solution and the current value.

--- a/src/nonlinear/nonlinear_solver_state.jl
+++ b/src/nonlinear/nonlinear_solver_state.jl
@@ -31,9 +31,13 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
                      # merit cannot be decreased; OR-ed into the verdict of the next
                      # `record_stall!`, which clears it again
 
-    rf_ref::T        # the residual as of the last iteration that counted as progress, and the
-    iter_ref::Int    # iteration at which that was; maintained by `record_progress!`, read as
-                     # `iterations_since_progress` by the report and by `no_progress`
+    rf_ref::T                  # the residual as of the last iteration that counted as progress,
+    iters_since_progress::Int  # and the number of iterations since; both maintained by
+                               # `record_progress!`, the latter read as
+                               # `iterations_since_progress` by the report and by `no_progress`.
+                               # The counter is *owned* rather than derived from `iterations` so
+                               # that, exactly like `stalls`, it stays at zero for an iteration
+                               # that never records.
 
     function NonlinearSolverState(X::AbstractVector{T}, Y::AbstractVector{T}=X) where {T}
         x = zero(X)
@@ -100,7 +104,7 @@ function initialize!(state::NonlinearSolverState{T}, x::AbstractVector{T}, y::Ab
     # The initial residual is also the first progress reference: a solve is measured against
     # where it started, so `iterations_since_progress` counts from iteration 0.
     state.rf_ref = state.r₀
-    state.iter_ref = 0
+    state.iters_since_progress = 0
 end
 
 """
@@ -126,37 +130,46 @@ neither [`stalled_step`](@ref) nor either branch of [`assess_convergence`](@ref)
 solve spends `max_iterations` in full. [`nonlinear_solver_warnings`](@ref) reports it, and
 [`no_progress`](@ref) stops it when the caller has opted in with `f_stall_window`.
 """
-iterations_since_progress(state::NonlinearSolverState) = iteration_number(state) - state.iter_ref
+iterations_since_progress(state::NonlinearSolverState) = state.iters_since_progress
 
 @doc raw"""
     record_progress!(state, config)
+    record_progress!(state, config, rfₐ)
 
 Update the progress reference of `state::`[`NonlinearSolverState`](@ref): when the residual has
 dropped to `config.f_stall_factor` times the residual of the last iteration that counted as
 progress, that becomes the new reference and the count returned by
-[`iterations_since_progress`](@ref) restarts. Returns that count.
+[`iterations_since_progress`](@ref) restarts; otherwise the count advances by one. Returns that
+count. The three-argument form takes a residual `rfₐ` the caller has already computed; the
+two-argument form computes it from `value(state)`.
 
 The reference is therefore monotonically non-increasing — it is the best residual so far, at the
 granularity of the factor — which is what makes the measurement immune to a residual that jumps
 around: an iteration that undoes the progress of the previous one does not reset the clock. See
 [`F_STALL_FACTOR`](@ref) for the choice of granularity.
 
-Like [`record_stall!`](@ref), this must be called *exactly once per iteration* — [`solve!`](@ref)
-does so right after [`update!`](@ref) — because it is a per-iteration measurement rather than a
-predicate. That is why it lives here and not in [`NonlinearSolverStatus`](@ref), which is pure
-and is built more than once per iteration. A hand-rolled iteration that drives
-[`solver_step!`](@ref) directly and never calls it keeps the count at zero and behaves exactly as
-before.
+Like [`record_stall!`](@ref), this is a per-iteration measurement rather than a predicate, so it
+must be called exactly once per iteration; [`record_iteration!`](@ref) is what does so, and
+carries that contract. That is why the counter lives here and not in
+[`NonlinearSolverStatus`](@ref), which is pure and is built more than once per iteration. Because
+the count is a field rather than a difference of iteration numbers, a hand-rolled iteration that
+drives [`solver_step!`](@ref) directly and never records keeps it at zero and behaves exactly as
+before — the same guarantee [`stall_number`](@ref) gives.
 """
 function record_progress!(state::NonlinearSolverState, config::Options)
-    rfₐ = l2norm(value(state))
+    record_progress!(state, config, l2norm(value(state)))
+end
+
+function record_progress!(state::NonlinearSolverState, config::Options, rfₐ::Number)
     # `NaN ≤ x` is false, so a not-yet-initialized reference never counts as progress; it is set
     # by `initialize!` before the first iteration in every solve that goes through `solve!`.
     if rfₐ ≤ config.f_stall_factor * state.rf_ref
         state.rf_ref = rfₐ
-        state.iter_ref = iteration_number(state)
+        state.iters_since_progress = 0
+    else
+        state.iters_since_progress += 1
     end
-    iterations_since_progress(state)
+    state.iters_since_progress
 end
 
 """

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -222,21 +222,28 @@ end
 
 """
     record_stall!(state, config)
+    record_stall!(state, config, rxₛ, rfₐ)
 
 Update the consecutive-stall counter of `state::`[`NonlinearSolverState`](@ref): increment it
 when the last step [`stalled_step`](@ref) *or* the line search flagged a stall (see
 [`flag_stall!`](@ref)), and reset it to zero otherwise. The flag is cleared either way.
-Returns the new count (see [`stall_number`](@ref)).
+Returns the new count (see [`stall_number`](@ref)). The four-argument form takes residuals the
+caller has already computed; the two-argument form computes them from the state.
 
-This must be called *exactly once per iteration* — [`solve!`](@ref) does so right after
-[`update!`](@ref). That is why the counter is not maintained inside
-[`assess_convergence`](@ref) or [`NonlinearSolverStatus`](@ref): those are pure and are
-evaluated more than once per iteration, so incrementing there would double-count. A
-hand-rolled iteration that drives [`solver_step!`](@ref) directly and never calls
-`record_stall!` simply keeps the count at zero and behaves exactly as before.
+This is a per-iteration measurement rather than a predicate, so it must be called exactly once
+per iteration; [`record_iteration!`](@ref) is what does so, and carries that contract. That is
+why the counter is not maintained inside [`assess_convergence`](@ref) or
+[`NonlinearSolverStatus`](@ref): those are pure and are evaluated more than once per iteration,
+so incrementing there would double-count. A hand-rolled iteration that drives
+[`solver_step!`](@ref) directly and never records simply keeps the count at zero and behaves
+exactly as before.
 """
 function record_stall!(state::NonlinearSolverState, config::Options)
     rxₛ, rfₐ, _ = residuals(state)
+    record_stall!(state, config, rxₛ, rfₐ)
+end
+
+function record_stall!(state::NonlinearSolverState, config::Options, rxₛ::Number, rfₐ::Number)
     flagged = state.stallflag
     state.stallflag = false
     # The line-search flag substitutes for `iterate_settled` (it is the same news, one
@@ -245,6 +252,29 @@ function record_stall!(state::NonlinearSolverState, config::Options)
     # gate is what makes stagnation and convergence mutually exclusive (see `isstalled`).
     stalled = (flagged || iterate_settled(rxₛ, config, state)) && !residual_small(rfₐ, config, state)
     state.stalls = stalled ? state.stalls + 1 : 0
+end
+
+"""
+    record_iteration!(state, config)
+
+Take the two per-iteration measurements of `state::`[`NonlinearSolverState`](@ref) — the
+consecutive-stall counter ([`record_stall!`](@ref)) and the progress reference
+([`record_progress!`](@ref)) — from a single evaluation of [`residuals`](@ref).
+
+This is the one function carrying the "exactly once per iteration" contract that both counters
+depend on: [`solve!`](@ref) calls it right after [`update!`](@ref), and nothing else does. Both
+counters are increments rather than predicates, so calling it twice would double-count and
+never calling it leaves both at zero, which is exactly how a hand-rolled iteration that drives
+[`solver_step!`](@ref) directly behaves.
+
+Sharing the residuals is why it exists at all: the two recordings need `rxₛ` and `rfₐ` between
+them, and computing them once here rather than once in each keeps a per-iteration norm off the
+hot loop.
+"""
+function record_iteration!(state::NonlinearSolverState, config::Options)
+    rxₛ, rfₐ, _ = residuals(state)
+    record_stall!(state, config, rxₛ, rfₐ)
+    record_progress!(state, config, rfₐ)
 end
 
 function NonlinearSolverStatus(state::NonlinearSolverState{T}, config::Options{T}) where {T}
@@ -332,23 +362,26 @@ isnotprogressing(status::NonlinearSolverStatus) = status.not_progressing
 """
     spent_without_progress(status)
 
-Check whether the iteration spent at least *half* of its iterations, and at least
-[`F_STALL_REPORT_MINIMUM`](@ref) of them, without the residual dropping by
+Check whether the iteration failed to converge and spent at least *half* of its iterations, and
+at least [`F_STALL_REPORT_MINIMUM`](@ref) of them, without the residual dropping by
 `config.f_stall_factor` — the diagnosis [`nonlinear_solver_warnings`](@ref) reports when a solve
 has used its whole budget, and the condition under which the no-progress line is shown by `show`.
 
-This is unconditional, unlike [`isnotprogressing`](@ref), and it can afford to be because it is
-only ever used to *describe* a solve, never to decide one: [`nonlinear_solver_warnings`](@ref)
-consults it about a solve that has already spent `max_iterations` without converging, and `show`
-about one it has been handed to print. A threshold that would be reckless as a stopping criterion
-(see [`F_STALL_WINDOW`](@ref)) is harmless as an explanation — which is why the two exist
-separately.
+This is not gated on any option, unlike [`isnotprogressing`](@ref), and it can afford not to be
+because it is only ever used to *describe* a solve, never to decide one:
+[`nonlinear_solver_warnings`](@ref) consults it about a solve that has already spent
+`max_iterations`, and `show` about one it has been handed to print. A threshold that would be
+reckless as a stopping criterion (see [`F_STALL_WINDOW`](@ref)) is harmless as an explanation —
+which is why the two exist separately.
 
-The absolute minimum is what makes it safe in `show`, which has no `Options` and so cannot check
-the budget the way the warning does. Without it the proportion alone is satisfied by a *two*-
-iteration solve whose last step did not halve the residual — the normal last step of one that
-converged on its successive-change criterion — and a healthy solve would start explaining itself.
-With it, no such solve comes close: a `Gauss(2)` Lotka-Volterra run converges in two to four
+Both guards are here rather than at the call sites because `show` has no `Options` and so cannot
+apply them itself, and it is the caller most exposed to a false positive. [`isconverged`](@ref)
+is the primary one: a residual that stopped improving *because it was already small enough* is
+success, and a solve held to a large `min_iterations` would otherwise spend most of its
+iterations on a converged plateau and start explaining itself. The absolute minimum is the
+backstop for a solve that has *not* converged and is simply short — without it the proportion
+alone is satisfied by a *two*-iteration solve whose last step did not halve the residual. With
+both, no healthy solve comes close: a `Gauss(2)` Lotka-Volterra run converges in two to four
 iterations with at most one of them unproductive.
 
 A long healthy solve does not reach it either, for the separate reason that its residual keeps
@@ -356,6 +389,7 @@ halving: an iteration converging linearly with rate ``\\rho`` halves every ``-1/
 iterations, 69 of them even at ``\\rho = 0.99``.
 """
 spent_without_progress(status::NonlinearSolverStatus) =
+    !isconverged(status) &&
     status.iterations_since_progress ≥ F_STALL_REPORT_MINIMUM &&
     2 * status.iterations_since_progress ≥ status.iterations
 
@@ -429,7 +463,7 @@ end
 function no_progress_reason(status::NonlinearSolverStatus, config::Options)
     isnotprogressing(status) ?
     "gave up after $(status.iterations) iterations: the residual rfₐ = $(status.rfₐ) did not improve by the factor f_stall_factor = $(config.f_stall_factor) in the last $(status.iterations_since_progress) of them, which is the f_stall_window = $(config.f_stall_window) you asked it to give up after" :
-    "spent its full budget of max_iterations = $(config.max_iterations) iterations without converging: the residual rfₐ = $(status.rfₐ) did not improve by the factor f_stall_factor = $(config.f_stall_factor) in the last $(status.iterations_since_progress) of them, so the iteration is making no useful progress and a larger budget is unlikely to change that. Set f_stall_window to stop at that point instead of spending the whole budget"
+    "spent its full budget of max_iterations = $(config.max_iterations) iterations without converging: the residual rfₐ = $(status.rfₐ) did not improve by the factor f_stall_factor = $(config.f_stall_factor) in the last $(status.iterations_since_progress) of them, so either it is on a floor this problem imposes — in which case a larger budget will not help — or it is converging far too slowly for the budget it was given. Set f_stall_window to stop at that point instead of spending the whole budget"
 end
 
 """
@@ -451,16 +485,21 @@ residual is going nowhere), which in turn replaces the bare iteration count — 
 names a symptom and no cause, and was the only thing a non-progressing solve used to report.
 """
 function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Options)
-    # Stagnation is the more specific diagnosis and is reported below, so it suppresses this one.
-    # Otherwise: either the caller opted into `f_stall_window` and it fired, or the solve spent its
-    # whole budget without converging and `spent_without_progress` says why.
-    noprogress = !isstalled(status, config) &&
+    # Stagnation is the more specific diagnosis and is reported below, so it suppresses the
+    # no-progress one. Otherwise: either the caller opted into `f_stall_window` and it fired, or the
+    # solve spent its whole budget and `spent_without_progress` says what on. (That predicate
+    # carries its own `!isconverged` gate, so it is not repeated here.)
+    stagnated = isstalled(status, config)
+    noprogress = !stagnated &&
                  (isnotprogressing(status) ||
-                  (status.iterations ≥ config.max_iterations && !isconverged(status) && spent_without_progress(status)))
+                  (status.iterations ≥ config.max_iterations && spent_without_progress(status)))
 
+    # The bare count names a symptom and no cause, so either of the two diagnoses below replaces it
+    # rather than joining it — the mutual exclusivity the docstring promises.
     # `maxlog` for the same reason the messages below have one: a caller that drives `solve!` in a
     # loop would otherwise get this once per step for as long as the problem stays unattainable.
-    (config.warn_iterations > 0 && status.iterations ≥ config.warn_iterations && !noprogress) &&
+    (config.warn_iterations > 0 && status.iterations ≥ config.warn_iterations &&
+     !noprogress && !stagnated) &&
         (@warn "Solver took $(status.iterations) iterations." maxlog = 3)
     # Same shape as the stagnation message: say what the solve achieved, what was asked of it, and
     # how to make the request attainable. The distinguishing news is that the iterate is *not*
@@ -477,7 +516,7 @@ function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Option
     # step for as long as the problem stays unattainable, which is the message flood this
     # replaced. Note that `maxlog` is keyed on the source location and so is process-global, not
     # per solve; see `linesearch_warnings`.
-    (isstalled(status, config) && config.verbosity ≥ 1) &&
+    (stagnated && config.verbosity ≥ 1) &&
         (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖). If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this." maxlog = 3)
     (status.f_increased && !config.allow_f_increases) && (@warn "The function increased and the solver stopped!")
     (status.rfₐ > config.f_abstol_break) && (@warn "The residual rfₐ has reached the maximally allowed value $(config.f_abstol_break)!")

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -258,8 +258,9 @@ function NonlinearSolverStatus(state::NonlinearSolverState{T}, config::Options{T
 end
 
 # The stall and no-progress lines are appended only when they are relevant, so the printout of a
-# fresh status — and of a healthy solve, whose residual improves right up to the last iteration —
-# is unchanged.
+# fresh status is unchanged. `spent_without_progress` rather than its proportion alone is what
+# keeps a *healthy* solve's printout unchanged too: this is the one caller that cannot check the
+# budget, having no `Options` — see `F_STALL_REPORT_MINIMUM`.
 Base.show(io::IO, status::NonlinearSolverStatus) = print(io,
     (@sprintf "i=%4i" status.iterations), ",\n",
     (@sprintf "rxₛ=%4e" status.rxₛ), ",\n",
@@ -331,22 +332,32 @@ isnotprogressing(status::NonlinearSolverStatus) = status.not_progressing
 """
     spent_without_progress(status)
 
-Check whether the iteration spent at least *half* of its iterations without the residual dropping
-by `config.f_stall_factor` — the diagnosis [`nonlinear_solver_warnings`](@ref) reports when a
-solve has used its whole budget, and the condition under which the no-progress line is shown by
-`show`.
+Check whether the iteration spent at least *half* of its iterations, and at least
+[`F_STALL_REPORT_MINIMUM`](@ref) of them, without the residual dropping by
+`config.f_stall_factor` — the diagnosis [`nonlinear_solver_warnings`](@ref) reports when a solve
+has used its whole budget, and the condition under which the no-progress line is shown by `show`.
 
 This is unconditional, unlike [`isnotprogressing`](@ref), and it can afford to be because it is
 only ever used to *describe* a solve, never to decide one: [`nonlinear_solver_warnings`](@ref)
 consults it about a solve that has already spent `max_iterations` without converging, and `show`
-about one it has been handed to print. A threshold that would be reckless as
-a stopping criterion (see [`F_STALL_WINDOW`](@ref)) is harmless as an explanation — which is why
-the two exist separately. A healthy solve never reaches it: an iteration converging linearly with
-rate ``\\rho`` halves its residual every ``-1/\\log_2\\rho`` iterations, 69 of them even at
-``\\rho = 0.99``, and it stops long before the budget in any case.
+about one it has been handed to print. A threshold that would be reckless as a stopping criterion
+(see [`F_STALL_WINDOW`](@ref)) is harmless as an explanation — which is why the two exist
+separately.
+
+The absolute minimum is what makes it safe in `show`, which has no `Options` and so cannot check
+the budget the way the warning does. Without it the proportion alone is satisfied by a *two*-
+iteration solve whose last step did not halve the residual — the normal last step of one that
+converged on its successive-change criterion — and a healthy solve would start explaining itself.
+With it, no such solve comes close: a `Gauss(2)` Lotka-Volterra run converges in two to four
+iterations with at most one of them unproductive.
+
+A long healthy solve does not reach it either, for the separate reason that its residual keeps
+halving: an iteration converging linearly with rate ``\\rho`` halves every ``-1/\\log_2\\rho``
+iterations, 69 of them even at ``\\rho = 0.99``.
 """
 spent_without_progress(status::NonlinearSolverStatus) =
-    status.iterations > 0 && 2 * status.iterations_since_progress ≥ status.iterations
+    status.iterations_since_progress ≥ F_STALL_REPORT_MINIMUM &&
+    2 * status.iterations_since_progress ≥ status.iterations
 
 """
     meets_stopping_criteria(state, config)

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -9,6 +9,7 @@ Stores absolute and successive residuals for `x` and `f`. It is used as a diagno
 # Keys
 - `iterations`: number of iterations
 - `stalls`: number of *consecutive* stalled steps, see [`stalled_step`](@ref) and [`isstalled`](@ref),
+- `iterations_since_progress`: iterations since the residual last dropped by `f_stall_factor`, see [`iterations_since_progress`](@ref),
 - `rxₛ`: successive residual in `x`,
 - `rfₐ`: absolute residual in `f`,
 - `rfₛ`: successive residual in `f`,
@@ -16,6 +17,7 @@ Stores absolute and successive residuals for `x` and `f`. It is used as a diagno
 - `f_converged::Bool`
 - `f_increased::Bool`
 - `stalled::Bool`: the *last* step stalled, see [`stalled_step`](@ref)
+- `not_progressing::Bool`: the iteration is not getting anywhere, see [`no_progress`](@ref)
 
 # Examples
 
@@ -37,6 +39,7 @@ rfₛ= NaN
 struct NonlinearSolverStatus{T}
     iterations::Int
     stalls::Int
+    iterations_since_progress::Int
 
     rxₛ::T
     rfₐ::T
@@ -46,6 +49,7 @@ struct NonlinearSolverStatus{T}
     f_converged::Bool
     f_increased::Bool
     stalled::Bool
+    not_progressing::Bool
 end
 
 @doc raw"""
@@ -187,6 +191,35 @@ function stalled_step(rxₛ::Number, rfₐ::Number, config::Options, state::Nonl
     iterate_settled(rxₛ, config, state) && !residual_small(rfₐ, config, state)
 end
 
+@doc raw"""
+    no_progress(rfₐ, config, state)
+
+Return `true` when the iteration has spent `config.f_stall_window` iterations without the
+residual dropping by `config.f_stall_factor` (see [`iterations_since_progress`](@ref)) while the
+residual is **not** small (see [`residual_small`](@ref)). Always `false` at the default
+`f_stall_window = 0`, which disables the criterion — see [`F_STALL_WINDOW`](@ref) for why it is
+opt-in.
+
+This is the sibling of [`stalled_step`](@ref) for a solve whose iterate has *not* frozen. Both
+end an iteration that cannot reach the requested tolerance, and they cover disjoint cases:
+`stalled_step` fires when the step has dropped below the round-off level of ``x``, so that the
+merit cannot be reduced *along the current direction*; `no_progress` fires when the steps are
+perfectly healthy and the residual is descending — just towards a floor above the tolerance,
+slowly enough that the remaining budget cannot get there. Their thresholds differ by orders of
+magnitude for the same reason: two consecutive stalled steps are conclusive because the second
+one had a fresh [`Jacobian`](@ref), whereas no number of *moving* steps is conclusive about a
+rate, which is why one is a default and the other a policy the caller sets.
+
+The `!residual_small` gate is the same one [`stalled_step`](@ref) carries, and it is what keeps
+giving up and converging mutually exclusive: a residual that has stopped improving *because it
+is already small enough* is success, and [`assess_convergence`](@ref) says so.
+"""
+function no_progress(rfₐ::Number, config::Options, state::NonlinearSolverState)
+    config.f_stall_window > 0 &&
+        iterations_since_progress(state) ≥ config.f_stall_window &&
+        !residual_small(rfₐ, config, state)
+end
+
 """
     record_stall!(state, config)
 
@@ -217,17 +250,23 @@ end
 function NonlinearSolverStatus(state::NonlinearSolverState{T}, config::Options{T}) where {T}
     rxₛ, rfₐ, rfₛ = residuals(state)
     x_converged, f_converged, f_increased, stalled = assess_convergence(rxₛ, rfₐ, rfₛ, config, state)
-    NonlinearSolverStatus{T}(iteration_number(state), stall_number(state), rxₛ, rfₐ, rfₛ, x_converged, f_converged, f_increased, stalled)
+    # `no_progress` is evaluated here rather than in `assess_convergence` because it is not a
+    # convergence question: it reads a measurement taken once per iteration by `record_progress!`
+    # instead of the residuals of the current step.
+    NonlinearSolverStatus{T}(iteration_number(state), stall_number(state), iterations_since_progress(state),
+        rxₛ, rfₐ, rfₛ, x_converged, f_converged, f_increased, stalled, no_progress(rfₐ, config, state))
 end
 
-# The stall line is appended only when it is relevant, so the printout of a fresh status is
-# unchanged.
+# The stall and no-progress lines are appended only when they are relevant, so the printout of a
+# fresh status — and of a healthy solve, whose residual improves right up to the last iteration —
+# is unchanged.
 Base.show(io::IO, status::NonlinearSolverStatus) = print(io,
     (@sprintf "i=%4i" status.iterations), ",\n",
     (@sprintf "rxₛ=%4e" status.rxₛ), ",\n",
     (@sprintf "rfₐ=%4e" status.rfₐ), ",\n",
     (@sprintf "rfₛ=%4e" status.rfₛ),
-    status.stalls > 0 ? ",\n" * (@sprintf "stalls=%4i" status.stalls) : "")
+    status.stalls > 0 ? ",\n" * (@sprintf "stalls=%4i" status.stalls) : "",
+    spent_without_progress(status) ? ",\n" * (@sprintf "no progress for=%4i" status.iterations_since_progress) : "")
 
 @doc raw"""
     print_status(status, config)
@@ -274,6 +313,42 @@ and consider raising `f_abstol` above it, since the tolerance you asked for is n
 isstalled(status::NonlinearSolverStatus, config::Options) = status.stalls ≥ config.max_stalls
 
 """
+    isnotprogressing(status)
+
+Check whether the iteration has been given up on for lack of *progress*: `config.f_stall_window`
+iterations without the residual dropping by `config.f_stall_factor`, see [`no_progress`](@ref).
+Always `false` at the default `f_stall_window = 0`.
+
+Mutually exclusive with [`isconverged`](@ref), for the same reason [`isstalled`](@ref) is: the
+criterion requires the residual *not* to be small, whereas both convergence branches require that
+it is.
+
+As with [`isstalled`](@ref), whether this counts as failure is the caller's decision: the solve
+reached `status.rfₐ` and could not do better within the window it was given.
+"""
+isnotprogressing(status::NonlinearSolverStatus) = status.not_progressing
+
+"""
+    spent_without_progress(status)
+
+Check whether the iteration spent at least *half* of its iterations without the residual dropping
+by `config.f_stall_factor` — the diagnosis [`nonlinear_solver_warnings`](@ref) reports when a
+solve has used its whole budget, and the condition under which the no-progress line is shown by
+`show`.
+
+This is unconditional, unlike [`isnotprogressing`](@ref), and it can afford to be because it is
+only ever used to *describe* a solve, never to decide one: [`nonlinear_solver_warnings`](@ref)
+consults it about a solve that has already spent `max_iterations` without converging, and `show`
+about one it has been handed to print. A threshold that would be reckless as
+a stopping criterion (see [`F_STALL_WINDOW`](@ref)) is harmless as an explanation — which is why
+the two exist separately. A healthy solve never reaches it: an iteration converging linearly with
+rate ``\\rho`` halves its residual every ``-1/\\log_2\\rho`` iterations, 69 of them even at
+``\\rho = 0.99``, and it stops long before the budget in any case.
+"""
+spent_without_progress(status::NonlinearSolverStatus) =
+    status.iterations > 0 && 2 * status.iterations_since_progress ≥ status.iterations
+
+"""
     meets_stopping_criteria(state, config)
 
 Determines whether the iteration stops based on the current [`NonlinearSolverState`](@ref).
@@ -284,6 +359,7 @@ Determines whether the iteration stops based on the current [`NonlinearSolverSta
 The function `meets_stopping_criteria` returns `true` if one of the following is satisfied:
 - the `status::`[`NonlinearSolverStatus`](@ref) is converged (checked with [`isconverged`](@ref)) and `state.iterations ≥ config.min_iterations`,
 - the `status` has *stagnated* (checked with [`isstalled`](@ref), i.e. `config.max_stalls` consecutive steps that did not move the iterate while the residual is not small) and `state.iterations ≥ config.min_iterations`,
+- the `status` is making no *progress* (checked with [`isnotprogressing`](@ref), i.e. `config.f_stall_window` iterations without the residual dropping by `config.f_stall_factor` while it is not small) and `state.iterations ≥ config.min_iterations`; this is opt-in and never fires at the default `f_stall_window = 0`,
 - `status.f_increased` and `config.allow_f_increases = false` (i.e. `f` increased even though we do not allow it),
 - `state.iterations ≥ config.max_iterations`,
 - `status.rfₐ > config.f_abstol_break` (by default `Inf`). In theory this returns `true` if the residual gets too big.
@@ -328,10 +404,21 @@ function meets_stopping_criteria(state::NonlinearSolverState, config::Options)
 
     (isconverged(status) && state.iterations ≥ config.min_iterations) ||
         (isstalled(status, config) && state.iterations ≥ config.min_iterations) ||
+        (isnotprogressing(status) && state.iterations ≥ config.min_iterations) ||
         (status.f_increased && !config.allow_f_increases) ||
         state.iterations ≥ config.max_iterations ||
         status.rfₐ > config.f_abstol_break ||
         (havenan(status) && state.iterations ≥ 1)
+end
+
+# The two wordings of the no-progress message: the opt-in `f_stall_window` gave up, or the whole
+# budget was spent and this explains what it was spent on. Called from *inside* the `@warn` message
+# so that the string is built only for a message that is actually shown; see
+# `linesearch_exhausted_reason`, which is factored out for the same reason.
+function no_progress_reason(status::NonlinearSolverStatus, config::Options)
+    isnotprogressing(status) ?
+    "gave up after $(status.iterations) iterations: the residual rfₐ = $(status.rfₐ) did not improve by the factor f_stall_factor = $(config.f_stall_factor) in the last $(status.iterations_since_progress) of them, which is the f_stall_window = $(config.f_stall_window) you asked it to give up after" :
+    "spent its full budget of max_iterations = $(config.max_iterations) iterations without converging: the residual rfₐ = $(status.rfₐ) did not improve by the factor f_stall_factor = $(config.f_stall_factor) in the last $(status.iterations_since_progress) of them, so the iteration is making no useful progress and a larger budget is unlikely to change that. Set f_stall_window to stop at that point instead of spending the whole budget"
 end
 
 """
@@ -339,15 +426,37 @@ end
 
 Report a [`NonlinearSolverStatus`](@ref) at the end of a [`solve!`](@ref): the iteration count
 if it reached `warn_iterations`, *stagnation* at the residual floor (see [`isstalled`](@ref)
-and [`stalled_step`](@ref)), a disallowed residual increase, a residual beyond
+and [`stalled_step`](@ref)), a lack of *progress* (see [`spent_without_progress`](@ref) and
+[`isnotprogressing`](@ref)), a disallowed residual increase, a residual beyond
 `f_abstol_break`, and `NaN`s. Compare this to [`linesearch_warnings`](@ref), which does the
 same for the inner line search, and to [`print_status`](@ref).
 
 All messages except the iteration count and the two hard-failure ones are gated on
 `config.verbosity ≥ 1`.
+
+The three "this solve did not do what you asked" messages are mutually exclusive, most specific
+first: stagnation (the iterate froze) wins over lack of progress (the iterate moves but the
+residual is going nowhere), which in turn replaces the bare iteration count — which on its own
+names a symptom and no cause, and was the only thing a non-progressing solve used to report.
 """
 function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Options)
-    (config.warn_iterations > 0 && status.iterations ≥ config.warn_iterations) && (@warn "Solver took $(status.iterations) iterations.")
+    # Stagnation is the more specific diagnosis and is reported below, so it suppresses this one.
+    # Otherwise: either the caller opted into `f_stall_window` and it fired, or the solve spent its
+    # whole budget without converging and `spent_without_progress` says why.
+    noprogress = !isstalled(status, config) &&
+                 (isnotprogressing(status) ||
+                  (status.iterations ≥ config.max_iterations && !isconverged(status) && spent_without_progress(status)))
+
+    # `maxlog` for the same reason the messages below have one: a caller that drives `solve!` in a
+    # loop would otherwise get this once per step for as long as the problem stays unattainable.
+    (config.warn_iterations > 0 && status.iterations ≥ config.warn_iterations && !noprogress) &&
+        (@warn "Solver took $(status.iterations) iterations." maxlog = 3)
+    # Same shape as the stagnation message: say what the solve achieved, what was asked of it, and
+    # how to make the request attainable. The distinguishing news is that the iterate is *not*
+    # stuck — the steps are healthy and the residual is simply not heading for the tolerance —
+    # which points at the problem rather than at the solver or the precision.
+    (noprogress && config.verbosity ≥ 1) &&
+        (@warn "Nonlinear solver $(no_progress_reason(status, config)). The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖).$(status.stalled ? "" : " The iterate has not frozen (the last step was rxₛ = $(status.rxₛ)), so this is not the round-off floor of x that stagnation detection reports; a residual that is not heading for the tolerance while the steps are healthy usually means a floor of the problem itself — a model, discretisation or ansatz error that F cannot resolve, and that no eps-scaled tolerance can bound.") If rfₐ is accurate enough for you, raise f_abstol above it; otherwise improve the approximation F is built on until its floor lies below the tolerance you need. Set verbosity = 0 to silence this." maxlog = 3)
     # A stagnated solve is not an error, but it did not achieve what was asked of it, so say
     # what it *did* achieve and how to make the request attainable. This replaces the former
     # pair of misleading messages (a line-search warning per iteration plus "Solver took 1000

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -4,9 +4,10 @@ using SimpleSolvers: NonlinearSolverState, assess_convergence, residuals, update
 using SimpleSolvers: meets_stopping_criteria, nonlinear_solver_warnings, NonlinearSolverStatus
 using SimpleSolvers: linesearch_problem, cache, jacobianmatrix, solution, value, direction, direction!, NullParameters
 using SimpleSolvers: trust_radius, DOGLEG_Δ_INITIAL
-using SimpleSolvers: isconverged, isstalled, status
+using SimpleSolvers: isconverged, isstalled, isnotprogressing, spent_without_progress, status
 using SimpleSolvers: config, linesearch, stall_number, record_stall!, flag_stall!,
     stalled_step, residual_small, iterate_settled, initial_residual
+using SimpleSolvers: iterations_since_progress, record_progress!, no_progress
 using SimpleSolvers: compute_new_iterate!, increase_iteration_number!, Bisection, Quadratic,
     StrongWolfe, Backtracking, steplength, solve_with_status
 using Test
@@ -900,10 +901,12 @@ end
         x0 = ics(T)
         solver = PicardSolver(x0, F, copy(x0))
 
-        # PicardSolver runs out of iterations on this problem (expected); assert the
-        # "Solver took … iterations." warning is emitted rather than letting it leak
-        # to the test log.
-        @test_logs (:warn, r"Solver took \d+ iterations\.") match_mode = :any solve!(x0, solver)
+        # PicardSolver runs out of iterations on this problem (expected); assert the warning is
+        # emitted rather than letting it leak to the test log. The fixed-point map is locally
+        # expanding here, so the residual safeguard damps α to nothing and the residual sits at
+        # 10.4 for all 1000 iterations — a solve that makes no progress, which is what is now
+        # reported instead of the bare "Solver took … iterations." (see `spent_without_progress`).
+        @test_logs (:warn, r"spent its full budget .* did not improve") match_mode = :any solve!(x0, solver)
         @test_throws AssertionError @assert ≈(x0, _root; atol=tol(T))
 
         x0 = ics(T)
@@ -1017,6 +1020,122 @@ end
     update!(state2, [9.0], [0.0])             # residual small ⇒ success, not stagnation
     flag_stall!(state2)
     @test record_stall!(state2, config₀) == 0
+end
+
+@testset "$(rpad("progress predicates and the no-progress counter", 80))" begin
+    config₀ = Options(Float64; f_abstol=1e-10, f_reltol=0.0, f_stall_window=3)
+
+    state = NonlinearSolverState([1.0])
+    initialize!(state, [1.0], [1.0])          # r₀ = 1 is the first progress reference
+    @test iterations_since_progress(state) == 0
+
+    # an iteration that does not reduce the residual by `f_stall_factor` does not reset the clock
+    for i in 1:3
+        state.iterations = i
+        update!(state, [Float64(i)], [0.9])   # a 10 % improvement is not progress at 0.5
+        @test record_progress!(state, config₀) == i
+    end
+
+    # ... and one that does resets it, from where it happened
+    state.iterations = 4
+    update!(state, [4.0], [0.4])
+    @test record_progress!(state, config₀) == 0
+    state.iterations = 5
+    update!(state, [5.0], [0.4])
+    @test record_progress!(state, config₀) == 1
+
+    # the reference is the *best* residual so far, so undoing progress does not reset the clock
+    state.iterations = 6
+    update!(state, [6.0], [0.8])              # worse than the 0.4 reference
+    @test record_progress!(state, config₀) == 2
+    state.iterations = 7
+    update!(state, [7.0], [0.8])
+    @test record_progress!(state, config₀) == 3
+
+    # the criterion fires once the window is full, and only while the residual is not small
+    _, rfₐ, _ = residuals(state)
+    @test iterations_since_progress(state) == config₀.f_stall_window
+    @test !residual_small(rfₐ, config₀, state)
+    @test no_progress(rfₐ, config₀, state)
+    @test !no_progress(rfₐ, Options(Float64; f_abstol=1e10, f_stall_window=3), state)  # residual small
+    @test !no_progress(rfₐ, Options(Float64; f_abstol=1e-10, f_reltol=0.0), state)     # window disabled
+
+    # the report threshold is independent of the window: half the iterations without progress
+    status₁ = NonlinearSolverStatus(state, config₀)
+    @test status₁.iterations_since_progress == 3
+    @test status₁.iterations == 7
+    @test !spent_without_progress(status₁)    # 3 of 7
+    state.iterations = 8                      # ⇒ 4 of 8
+    @test spent_without_progress(NonlinearSolverStatus(state, config₀))
+
+    # a freshly initialized state is neither, so a fresh status prints unchanged
+    fresh = NonlinearSolverState([1.0])
+    @test !spent_without_progress(NonlinearSolverStatus(fresh, config₀))
+end
+
+@testset "$(rpad("a solve that moves but gets nowhere is reported, and can be stopped", 80))" begin
+    # The gap in the stall machinery reported in issue #173: the iterate keeps moving normally
+    # while the residual sits on a floor far above the requested tolerance. Here the floor is the
+    # whole residual — `F` is constant, so no step can reduce it — while the Picard step
+    # `d = -F` moves the iterate by 1e-3 every iteration, which is twelve orders of magnitude
+    # above the round-off level of `x`. By construction neither convergence branch nor
+    # `stalled_step` can fire, so nothing used to end this solve or explain it.
+    Ffloor(y, x, params) = y .= 1e-3
+
+    x = [0.0]
+    s = PicardSolver(x, Ffloor, zero(x); verbosity=0)
+    state = SolverState(s)
+    @test_logs solve!(x, s, state)                      # verbosity = 0 silences it completely
+    st = status(s, state)
+
+    @test !isconverged(st)
+    @test !isstalled(st, config(s))                     # the iterate never froze ...
+    @test stall_number(state) == 0                      # ... so nothing was ever counted
+    @test iteration_number(state) == config(s).max_iterations
+    @test iterations_since_progress(state) == config(s).max_iterations
+    @test spent_without_progress(st)
+    @test !isnotprogressing(st)                         # the criterion is off by default
+    @test st.rfₐ ≈ 1e-3
+
+    # at the default verbosity the report names the residual and the missing progress, in place
+    # of the bare "Solver took … iterations." that used to be the only signal
+    x2 = [0.0]
+    s2 = PicardSolver(x2, Ffloor, zero(x2))
+    @test_logs (:warn, r"spent its full budget .* did not improve by the factor") match_mode = :any solve!(x2, s2, SolverState(s2))
+
+    # `f_stall_window` turns the report into a stopping criterion
+    x3 = [0.0]
+    s3 = PicardSolver(x3, Ffloor, zero(x3); f_stall_window=20, verbosity=0)
+    state3 = SolverState(s3)
+    @test_logs solve!(x3, s3, state3)                   # ... including when it stops the solve
+    st3 = status(s3, state3)
+
+    @test isnotprogressing(st3)
+    @test !isconverged(st3)                             # giving up is not converging
+    @test iteration_number(state3) == 20
+    @test iteration_number(state3) < config(s3).max_iterations
+
+    x4 = [0.0]
+    s4 = PicardSolver(x4, Ffloor, zero(x4); f_stall_window=20)
+    @test_logs (:warn, r"gave up after 20 iterations") match_mode = :any solve!(x4, s4, SolverState(s4))
+
+    # A slow but healthy solve must survive the same window: this one contracts by 0.9 per
+    # iteration and needs 316 of them, far more than the window, but it halves its residual every
+    # seven — which is what `f_stall_factor` measures and `max_iterations` alone cannot tell
+    # apart. This is why the window is opt-in; see `F_STALL_WINDOW`.
+    Fslow(y, x, params) = y .= (1 - 0.9) .* (x .- 1.0)
+
+    x5 = [0.0]
+    s5 = PicardSolver(x5, Fslow, zero(x5); f_stall_window=20)
+    state5 = SolverState(s5)
+    @test_logs solve!(x5, s5, state5)                   # converges, quietly
+    st5 = status(s5, state5)
+
+    @test isconverged(st5)
+    @test !isnotprogressing(st5)
+    @test !spent_without_progress(st5)
+    @test iteration_number(state5) > 20                 # ... despite taking far longer than the window
+    @test x5[1] ≈ 1.0
 end
 
 @testset "$(rpad("pre-step convergence check and the merit-evaluation canary", 80))" begin

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -974,6 +974,19 @@ end
     s2 = NewtonSolver(x2, Ffloor, zero(x2); f_abstol=1e-20, f_reltol=0.0)
     @test_logs (:warn, r"stagnated") match_mode = :any solve!(x2, s2, SolverState(s2))
 
+    # ... and it *replaces* the bare iteration count rather than joining it. This solve stagnates
+    # after three iterations, so it only reaches `warn_iterations` when that is set below them;
+    # the two messages would otherwise never be seen together and the mutual exclusivity
+    # `nonlinear_solver_warnings` promises would go untested.
+    x4 = [1.0]
+    s4 = NewtonSolver(x4, Ffloor, zero(x4); f_abstol=1e-20, f_reltol=0.0, warn_iterations=1)
+    logs, _ = Test.collect_test_logs() do
+        solve!(x4, s4, SolverState(s4))
+    end
+    messages = [string(record.message) for record in logs]
+    @test any(m -> occursin("stagnated", m), messages)
+    @test !any(m -> occursin("Solver took", m), messages)
+
     # raising `f_abstol` above the floor makes the very same problem converge, quietly
     x3 = [1.0]
     s3 = NewtonSolver(x3, Ffloor, zero(x3); f_abstol=1e-6, f_reltol=0.0)
@@ -1066,28 +1079,110 @@ end
     @test status₁.iterations_since_progress == 3
     @test status₁.iterations == 7
     @test !spent_without_progress(status₁)    # 3 of 7: neither half nor enough
-    state.iterations = 6                      # ⇒ 2 of 6
-    @test !spent_without_progress(NonlinearSolverStatus(state, config₀))
-    state.iterations = 8                      # ⇒ 4 of 8: half, but too few to mean anything
+
+    # a fourth unproductive iteration makes it half — and still too few to mean anything
+    state.iterations = 8
+    update!(state, [8.0], [0.8])
+    @test record_progress!(state, config₀) == 4
     @test 2 * iterations_since_progress(state) ≥ iteration_number(state)
     @test !spent_without_progress(NonlinearSolverStatus(state, config₀))
-    state.iterations = 4 + SimpleSolvers.F_STALL_REPORT_MINIMUM   # iter_ref is 4
+
+    # ... and enough of them satisfies both
+    while iterations_since_progress(state) < SimpleSolvers.F_STALL_REPORT_MINIMUM
+        state.iterations += 1
+        update!(state, [Float64(state.iterations)], [0.8])
+        @test record_progress!(state, config₀) == iterations_since_progress(state)
+    end
+    @test 2 * iterations_since_progress(state) ≥ iteration_number(state)
     @test spent_without_progress(NonlinearSolverStatus(state, config₀))
 
-    # ... which is what keeps a *healthy* short solve from explaining itself: two iterations of
-    # which the last did not halve the residual satisfies the proportion on its own
+    # the proportion is the independent half of the threshold: the *same* run of unproductive
+    # iterations, after a long productive stretch, is a solve that got somewhere and is not
+    # reported for the tail it ended on
+    long = NonlinearSolverState([1.0])
+    initialize!(long, [1.0], [1.0])
+    for i in 1:30                             # thirty iterations, every one of them progress
+        long.iterations = i
+        update!(long, [Float64(i)], [0.5^i])
+        @test record_progress!(long, config₀) == 0
+    end
+    for i in 31:(30+SimpleSolvers.F_STALL_REPORT_MINIMUM)
+        long.iterations = i
+        update!(long, [Float64(i)], [0.5^30])
+        record_progress!(long, config₀)
+    end
+    @test iterations_since_progress(long) == SimpleSolvers.F_STALL_REPORT_MINIMUM
+    @test !isconverged(NonlinearSolverStatus(long, config₀))
+    @test 2 * iterations_since_progress(long) < iteration_number(long)
+    @test !spent_without_progress(NonlinearSolverStatus(long, config₀))
+
+    # ... and a *converged* solve is never reported however lopsided the proportion. That is the
+    # guard `show` needs, having no `Options` with which to check the budget the warning checks:
+    # a plateau the solve sits on for most of its iterations is stagnation only if it is above
+    # the tolerance. Here the same 0.8 plateau is read against a tolerance that accepts it, and
+    # two identical iterates make both successive residuals vanish, so the solve has converged.
+    loose = Options(Float64; f_abstol=1.0, f_reltol=0.0, f_stall_window=3)
+    for _ in 1:2
+        state.iterations += 1
+        update!(state, [9.0], [0.8])
+        record_progress!(state, loose)        # still not progress: the plateau does not move
+    end
+    converged = NonlinearSolverStatus(state, loose)
+    @test isconverged(converged)
+    @test converged.iterations_since_progress ≥ SimpleSolvers.F_STALL_REPORT_MINIMUM
+    @test 2 * converged.iterations_since_progress ≥ converged.iterations
+    @test !spent_without_progress(converged)
+    @test !occursin("no progress", sprint(show, converged))
+
+    # the absolute minimum is the backstop for the solve that is short rather than converged: two
+    # iterations of which the last did not halve the residual satisfies the proportion on its own
     short = NonlinearSolverState([1.0])
     initialize!(short, [1.0], [1.0])
     short.iterations = 1
     update!(short, [2.0], [0.9])
     @test record_progress!(short, config₀) == 1
     short.iterations = 2
+    @test !isconverged(NonlinearSolverStatus(short, config₀))
     @test 2 * iterations_since_progress(short) ≥ iteration_number(short)
     @test !spent_without_progress(NonlinearSolverStatus(short, config₀))
 
     # a freshly initialized state is neither, so a fresh status prints unchanged
     fresh = NonlinearSolverState([1.0])
     @test !spent_without_progress(NonlinearSolverStatus(fresh, config₀))
+end
+
+@testset "$(rpad("an iteration that never records keeps both counters at zero", 80))" begin
+    # `record_stall!` and `record_progress!` are increments, not predicates: the counters are
+    # fields of the state rather than differences of iteration numbers, so a hand-rolled loop
+    # that drives `solver_step!` directly and never calls `record_iteration!` behaves exactly as
+    # it did before either counter existed. Were `iterations_since_progress` derived from
+    # `iteration_number`, such a loop would report every one of its iterations as unproductive —
+    # and with `f_stall_window` set, `meets_stopping_criteria` would cut it short for it.
+    config₀ = Options(Float64; f_abstol=1e-10, f_reltol=0.0, f_stall_window=5)
+
+    state = NonlinearSolverState([1.0])
+    initialize!(state, [1.0], [1.0])
+    for i in 1:15
+        increase_iteration_number!(state)
+        update!(state, [Float64(i)], [1.0])   # the residual never moves, and nobody records it
+    end
+
+    @test iteration_number(state) == 15
+    @test iterations_since_progress(state) == 0
+    @test stall_number(state) == 0
+
+    st = NonlinearSolverStatus(state, config₀)
+    @test !spent_without_progress(st)
+    @test !isnotprogressing(st)
+    @test !occursin("no progress", sprint(show, st))
+    @test !meets_stopping_criteria(state, config₀)
+
+    # ... whereas recording those same iterations does report them
+    for _ in 1:15
+        record_progress!(state, config₀)
+    end
+    @test iterations_since_progress(state) == 15
+    @test spent_without_progress(NonlinearSolverStatus(state, config₀))
 end
 
 @testset "$(rpad("a solve that moves but gets nowhere is reported, and can be stopped", 80))" begin

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -1060,13 +1060,30 @@ end
     @test !no_progress(rfₐ, Options(Float64; f_abstol=1e10, f_stall_window=3), state)  # residual small
     @test !no_progress(rfₐ, Options(Float64; f_abstol=1e-10, f_reltol=0.0), state)     # window disabled
 
-    # the report threshold is independent of the window: half the iterations without progress
+    # the report threshold is independent of the window: half the iterations without progress,
+    # and at least `F_STALL_REPORT_MINIMUM` of them
     status₁ = NonlinearSolverStatus(state, config₀)
     @test status₁.iterations_since_progress == 3
     @test status₁.iterations == 7
-    @test !spent_without_progress(status₁)    # 3 of 7
-    state.iterations = 8                      # ⇒ 4 of 8
+    @test !spent_without_progress(status₁)    # 3 of 7: neither half nor enough
+    state.iterations = 6                      # ⇒ 2 of 6
+    @test !spent_without_progress(NonlinearSolverStatus(state, config₀))
+    state.iterations = 8                      # ⇒ 4 of 8: half, but too few to mean anything
+    @test 2 * iterations_since_progress(state) ≥ iteration_number(state)
+    @test !spent_without_progress(NonlinearSolverStatus(state, config₀))
+    state.iterations = 4 + SimpleSolvers.F_STALL_REPORT_MINIMUM   # iter_ref is 4
     @test spent_without_progress(NonlinearSolverStatus(state, config₀))
+
+    # ... which is what keeps a *healthy* short solve from explaining itself: two iterations of
+    # which the last did not halve the residual satisfies the proportion on its own
+    short = NonlinearSolverState([1.0])
+    initialize!(short, [1.0], [1.0])
+    short.iterations = 1
+    update!(short, [2.0], [0.9])
+    @test record_progress!(short, config₀) == 1
+    short.iterations = 2
+    @test 2 * iterations_since_progress(short) ≥ iteration_number(short)
+    @test !spent_without_progress(NonlinearSolverStatus(short, config₀))
 
     # a freshly initialized state is neither, so a fresh status prints unchanged
     fresh = NonlinearSolverState([1.0])


### PR DESCRIPTION
Closes #173.

## The gap

`max_stalls` (0.10) catches a solve whose **iterate has frozen**: the step has fallen below the round-off level of `x` while the residual is not small, so no progress is possible along the current direction. The case next to it is uncovered *by construction* — the iterate keeps moving perfectly normally while the residual sits on a floor far above the requested tolerance:

- `iterate_settled` is false, because the step is not small;
- `residual_small` is false, because the residual is not either;
- `stalled_step` needs both, and neither convergence branch can fire.

So the solve spends `max_iterations` in full and reports `"Solver took 1000 iterations."` — a symptom, no cause.

The floor in the reported case was set by the **problem**: an under-parameterised network ansatz whose approximation error put `‖F‖` at 2e-6, six orders of magnitude above the tolerance asked for. That is not round-off, so no `eps(T)`-scaled tolerance can bound it, and the remedy is one level up from the solver.

## The measurement

`SimpleSolvers.record_progress!` keeps, per solve, the residual as of the last iteration that counted as *progress* and the number of iterations since, which `SimpleSolvers.iterations_since_progress` reads: how long the residual has been going nowhere. The reference is monotone — the best residual so far — so an iteration that undoes the previous one's progress does not reset the clock.

Like `record_stall!` it is an increment rather than a predicate, so it **owns** its counter instead of deriving it from `iteration_number`. That is what makes the guarantee `stall_number` already gave true here too: a hand-rolled iteration that drives `solver_step!` directly and never records leaves the count at zero and behaves exactly as before. Were it a difference of iteration numbers, such a loop would report every one of its iterations as unproductive — and with `f_stall_window` set, `meets_stopping_criteria` would cut it short for progress nobody had measured.

`SimpleSolvers.record_iteration!` takes both per-iteration measurements from a single `residuals` call and is what `solve!` calls, so the loop computes three norms an iteration rather than four and the "exactly once per iteration" contract lives in one place instead of being restated in two docstrings.

That one number is used twice, and the asymmetry between the two uses is the design.

**The report is unconditional.** A solve that did not converge and spent at least half of its iterations — and at least `F_STALL_REPORT_MINIMUM` of them, below which the proportion is not evidence of anything — without progressing now names the residual it achieved, the tolerance it was asked for, how many iterations it went without improving, and the fact that the iterate did *not* freeze, which is what distinguishes a floor of the problem from the round-off floor `max_stalls` reports. Both guards live in `spent_without_progress` rather than at its call sites, because `show` has no `Options` with which to apply them and is the caller most exposed to a false positive: without the convergence gate, a solve held to a large `min_iterations` on a plateau *below* its tolerance would start explaining itself.

**The three "this solve did not do what you asked" messages are mutually exclusive**, most specific first: stagnation (the iterate froze) wins over lack of progress (the iterate moves, the residual does not), which in turn replaces the bare iteration count — which on its own names a symptom and no cause. The bare count also gained a `maxlog`: it had none, so a time-stepping caller got one per step.

**The stopping criterion is opt-in**, through two new `Options` fields: `f_stall_window` (default `0`, disabled) and `f_stall_factor` (default `0.5`, the drop that counts as progress; only `0 < f ≤ 1` is meaningful, since above one a residual that *grew* would count as progress and the reference would climb). `SimpleSolvers.no_progress` is gated on `!residual_small` exactly as `stalled_step` is, so giving up and converging stay mutually exclusive.

It has to be opt-in. The threshold is a policy, not a test: an iteration converging linearly with rate ρ improves by ρ^W over a window W, so a window of 50 at the default factor abandons every ρ > 0.986 — and a `PicardSolver` on a stiff problem is slower than that. No value is right for every problem. The *diagnosis* is consulted only about a solve that has already spent its budget and therefore decides nothing about it, so it costs nothing to be wrong; the *criterion* can cut short a solve that would have succeeded. Hence one is free and the other is asked for.

This is also why the diagnosis is the more useful half here: a knob you must already suspect the problem to enable does not diagnose the problem you did not suspect. In the reported case it was the *message* that led to the ansatz width rather than to the solver.

## Behaviour

Unchanged at default options except for what is printed. No solve stops earlier than it did, and `f_stall_window = 0` makes `no_progress` constant `false`.

## Tests

- the gap itself, end to end: a `PicardSolver` whose `F` is constant, so no step can reduce the residual while `d = -F` moves the iterate by twelve orders of magnitude more than its round-off level. `stalls` stays 0 for all 1000 iterations — the failure mode exactly;
- the same problem stopping at 20 iterations with `f_stall_window = 20`;
- **the false positive the default guards against**: a solve contracting by 0.9 per iteration needs 316 of them, far more than that window, and must survive it — it halves its residual every seven, which is what `f_stall_factor` measures and `max_iterations` alone cannot tell apart;
- an iteration that never records keeps *both* counters at zero, does not print a no-progress line, and is not stopped by `f_stall_window`;
- a converged status is never `spent_without_progress`, however lopsided the proportion; and the proportion is exercised as the independent half of the threshold — the same run of unproductive iterations after a long productive stretch is not reported;
- a stagnated solve that also reaches `warn_iterations` emits the stagnation message and *not* the bare count;
- unit tests for the counter, the monotonicity of the reference, and both gates of `no_progress`; `verbosity = 0` silences the new message completely.

The `PicardSolver` case in the DogLeg testset turns out to be an instance of this failure mode (locally expanding map, residual pinned at 10.4 for 1000 iterations), so its expected message changes with it.

Full suite green, also under `--check-bounds=yes`; doctests and docs build clean.

## Downstream

`GeometricProblems.ThreeBody`'s collisional initial condition — for which no root exists — is now diagnosed rather than merely counted:

> Nonlinear solver spent its full budget of max_iterations = 1000 iterations without converging: the residual rfₐ = 0.3746 did not improve by the factor f_stall_factor = 0.5 in the last 997 of them, so either it is on a floor this problem imposes — in which case a larger budget will not help — or it is converging far too slowly for the budget it was given […] The iterate has not frozen (the last step was rxₛ = 2.19e-6) […]

A 1000-step `LotkaVolterra2d` run with `Gauss(2)` stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
