### PR TITLE
Detect an overflowed residual, not just an undefined one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,9 +237,11 @@ Three defects next to it are fixed with it, the first of which is the serious on
   its docstring advertises — that `solution(cache)` and `value(cache)` hold this step's trial and
   its residual — was false. The `PicardSolver` step documents that it reads that cache instead of
   re-evaluating `F`, so it tested a stale residual and committed a stale iterate from the
-  *previous* solver step. One trial is now always evaluated; the budget bounds the damping, not
-  the evaluation. The Picard step additionally refuses to commit a trial that is not finite, as
-  `DogLegSolver` already did on radius underflow.
+  *previous* solver step. One trial is now always evaluated and the damping happens before the
+  trial it is for, so the budget bounds the damping rather than the evaluation and the cached
+  residual always belongs to the direction the cache holds. The Picard step additionally refuses
+  to commit a trial whose *residual* is not finite, as `DogLegSolver` already did on radius
+  underflow.
 
 Behaviour on any solve that stays finite is unchanged, and the guards cost the same as before —
 one pass over the residual either way. Where it changes, it changes in the direction of saying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to SimpleSolvers.jl are documented here.
 
 ## [0.11.0]
 
-Three independent changes. **Breaking**: `Backtracking` loses its `α₀` key and its positional
+Four independent changes. **Breaking**: `Backtracking` loses its `α₀` key and its positional
 constructor, and gains an opt-in expansion phase. Additive: a `NonlinearProblem` can be solved
 without assembling a solver by hand, and a `NonlinearSolver` reports — and, on request, stops —
 a solve that is *not progressing*, the case
 [issue #173](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/173) found next to the
-`max_stalls` machinery of 0.10.0.
+`max_stalls` machinery of 0.10.0. Fixed: the nonlinear solvers looked for `NaN` where they
+should have looked for any non-finite value, so an *overflowed* residual passed every guard
+they have —
+[issue #130](https://github.com/JuliaGNI/SimpleSolvers.jl/issues/130) — and could be reported
+as convergence.
 
 ### Convenience entry points for solving a `NonlinearProblem`
 
@@ -192,6 +196,58 @@ report has told you the floor is real.
 
 Behaviour at default options is unchanged except for what is printed: no solve stops earlier than
 it did, and `f_stall_window = 0` makes `no_progress` constant `false`.
+
+### `NaN` was only half of it
+
+Every guard the nonlinear solvers had against a trial iterate leaving the region where the
+problem is representable tested `isnan`, and `isnan` is false for `Inf`. Issue #130 asks whether
+that detection works, on the example `f(x) = 5|x-2|³ - 1/|x|` — whose singularity produces `Inf`
+at `x = 0`, not `NaN`, so for its own fixture the answer was no. Nothing downstream of the guards
+caught it either: `rfₐ > f_abstol_break` cannot, since `f_abstol_break` defaults to `Inf` and
+`Inf > Inf` is false. The line searches had never had this gap — `check_anchor` has always tested
+`isfinite` — and neither did the `Optimizer` removed in 0.11.0, which tested `isnan(f) || isinf(f)`.
+The solvers were the only ones left looking for half the problem.
+
+The distinction the fix turns on is that a non-finite **direction** and a non-finite **residual**
+are not the same failure:
+
+- A non-finite **direction is rejected**, as a `NaN` one always was. It cannot be recovered from:
+  `nan_recovery!` damps by a factor and `Inf * nan_factor` is `Inf`, so the loop would spend its
+  whole budget reproducing the same trial iterate. Rejecting it first is also what makes the
+  damping sound — past that guard the direction is finite, so every halving really does shorten
+  the step. Previously such a step was not rejected and not damped: the line search saw an
+  infinite directional derivative, returned `LINESEARCH_NO_DESCENT`, and the solve made no
+  progress without saying why.
+- A non-finite **trial residual is damped**, exactly as a `NaN` one was. `nan_recovery!`,
+  `report_dogleg_nan` and the dogleg trust-region rejection now all test `isfinite`.
+- `havenan` is now `SimpleSolvers.havenonfinite` and tests all three residuals for finiteness.
+  It is unexported and internal, so there is no deprecation.
+
+Three defects next to it are fixed with it, the first of which is the serious one:
+
+- **`residual_small` could report convergence on an overflowed solve.** It guarded only
+  `isnan(r₀)`, so an infinite `‖F(x₀)‖` made the relative term `f_reltol * Inf = Inf` and the
+  gate vacuously true — a residual of `1e10` counted as small, and the solve claimed success
+  wherever it happened to land. An overflowed initial residual is no more a usable reference
+  scale than an uninitialized one, and is now treated the same way.
+- **`iterate_settled` counted an infinite step as a frozen iterate**, since `Inf ≤ ‖x‖·x_suctol`
+  holds once `‖x‖` has overflowed too. An iterate that jumped to infinity has neither converged
+  nor stagnated; it has broken down, which is what `havenonfinite` is for.
+- **`nan_recovery!` at `nan_max_iterations = 0` left its cache untouched**, so the post-condition
+  its docstring advertises — that `solution(cache)` and `value(cache)` hold this step's trial and
+  its residual — was false. The `PicardSolver` step documents that it reads that cache instead of
+  re-evaluating `F`, so it tested a stale residual and committed a stale iterate from the
+  *previous* solver step. One trial is now always evaluated; the budget bounds the damping, not
+  the evaluation. The Picard step additionally refuses to commit a trial that is not finite, as
+  `DogLegSolver` already did on radius underflow.
+
+Behaviour on any solve that stays finite is unchanged, and the guards cost the same as before —
+one pass over the residual either way. Where it changes, it changes in the direction of saying
+so: a non-finite direction now raises `NonlinearSolverException` where it used to stall silently,
+which a caller driving `solve!` in a time-stepping loop will see as an exception rather than as a
+step that quietly achieved nothing. Downstream trajectories are bit-identical
+(GeometricIntegrators × GeometricProblems, five integrators over 1000 steps, plus a collisional
+initial condition with no root).
 
 ## [0.10.1]
 

--- a/src/nonlinear/dogleg_solver.jl
+++ b/src/nonlinear/dogleg_solver.jl
@@ -51,7 +51,7 @@ const DogLegSolver{T} = NonlinearSolver{T,DogLeg}
 end
 
 @noinline function report_dogleg_nan(config::Options)
-    verbosity(config) ≥ 2 && @warn "DogLeg: undefined merit (NaN) at the trial step; shrinking the trust-region radius."
+    verbosity(config) ≥ 2 && @warn "DogLeg: non-finite merit (NaN or Inf) at the trial step; shrinking the trust-region radius."
     nothing
 end
 
@@ -210,8 +210,8 @@ function solver_step!(x::AbstractVector{T}, s::DogLegSolver{T}, state::Nonlinear
     force_refresh = collapsed || needs_refresh(state)
 
     directions!(s, x, params, iteration_number(state); force_refactorize=force_refresh)
-    any(isnan, direction₁(cache(s))) && throw(NonlinearSolverException("NaN detected in direction₁ vector"))
-    any(isnan, direction₂(cache(s))) && throw(NonlinearSolverException("NaN detected in direction₂ vector"))
+    all(isfinite, direction₁(cache(s))) || throw(NonlinearSolverException("non-finite direction₁ vector"))
+    all(isfinite, direction₂(cache(s))) || throw(NonlinearSolverException("non-finite direction₂ vector"))
 
     # Trust-region step with a ρ-based radius update (Nocedal & Wright, Alg. 4.1).
     # The radius Δ is *carried across outer solver steps* in the cache (rather than
@@ -232,14 +232,16 @@ function solver_step!(x::AbstractVector{T}, s::DogLegSolver{T}, state::Nonlinear
         value!(value(cache(s)), nonlinearproblem(s), solution(cache(s)), params)
         φ = L2norm(value(cache(s)))
 
-        # An undefined merit (`F` evaluated outside its domain, e.g. `log`/`sqrt`
-        # of a negative trial iterate) is treated exactly like a rejected step:
-        # shrink the radius and retry with a shorter step along the *same* dogleg
-        # path.  (Rescaling d₁ or d₂ themselves would
+        # A merit that is not finite — undefined (`F` evaluated outside its domain,
+        # e.g. `log`/`sqrt` of a negative trial iterate) or overflowed — is treated
+        # exactly like a rejected step: shrink the radius and retry with a shorter
+        # step along the *same* dogleg path.  (Rescaling d₁ or d₂ themselves would
         # destroy the ‖d₁‖ ≤ ‖d₂‖ relation the dogleg interpolation assumes; a NaN
         # merit must also not reach the ρ update below, where every comparison
-        # with NaN is false and the loop would spin forever at constant Δ.)
-        if isnan(φ)
+        # with NaN is false and the loop would spin forever at constant Δ.  An
+        # infinite one does reach a correct verdict there — ρ = -Inf shrinks Δ —
+        # but arriving at it through the model is an accident, not a policy.)
+        if !isfinite(φ)
             report_dogleg_nan(config(s))
             Δ *= config(s).dogleg_radius_shrink
             continue

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -166,9 +166,13 @@ end
     nan_recovery!(s, x, params)
 
 Damp `direction(cache(s))` by `nan_factor` until the trial iterate `x + d` has a
-finite residual (or the `nan_max_iterations` budget is exhausted). On return
-`solution(cache(s))` and `value(cache(s))` hold the last trial iterate and its
-residual. Used by the generic and Picard [`solver_step!`](@ref)s. Returns the solver `s`.
+finite residual (or the `nan_max_iterations` budget of dampings is exhausted). On return
+`solution(cache(s))` and `value(cache(s))` hold the last trial iterate and its residual, and
+`direction(cache(s))` is the direction that trial was built from — so `value(cache(s))` is
+`F(x + direction(cache(s)))` on every exit path, which is what the Picard
+[`solver_step!`](@ref) reads instead of re-evaluating `F`. One trial is always evaluated, so a
+budget of zero refreshes the cache without damping at all. Used by the generic and Picard
+[`solver_step!`](@ref)s. Returns the solver `s`.
 
 "Finite" means `isfinite`, not merely "not `NaN`": a residual that has *overflowed* is
 as unusable as an undefined one and is just as much a symptom of a step that left the
@@ -182,16 +186,22 @@ reject a non-finite one outright (see [`solver_step!`](@ref)), and they must, si
 same trial iterate.
 """
 function nan_recovery!(s::NonlinearSolver{T}, x, params) where {T}
-    # `max(1, …)`: the budget bounds the *damping*, not the trial evaluation. A budget of zero used
-    # to skip the body entirely and leave the cache holding whatever the previous solver step had
-    # put there — which the Picard step then read as if it were this step's trial, committing a
-    # stale iterate. One trial is always evaluated, so the post-condition above always holds.
-    for _ in 1:max(1, config(s).nan_max_iterations)
+    # The damping happens *before* the trial it is for, not after the one that failed. That is what
+    # makes both post-conditions hold on every exit path: the budget bounds the *damping* (a budget
+    # of zero damps not at all), and `value(cache(s))` is the residual of the trial built from the
+    # direction the cache currently holds — damping after the last trial would leave the two one
+    # factor apart, and the Picard step reads them as a pair. The `i = 0` pass evaluates one trial
+    # unconditionally: a budget of zero used to skip the body entirely and leave the cache holding
+    # whatever the previous solver step had put there, which the Picard step then read as if it were
+    # this step's trial, committing a stale iterate.
+    for i in 0:config(s).nan_max_iterations
+        if i > 0
+            report_nan_direction(config(s))
+            direction(cache(s)) .*= T(config(s).nan_factor)
+        end
         solution(cache(s)) .= x .+ direction(cache(s))
         value!(value(cache(s)), nonlinearproblem(s), solution(cache(s)), params)
         all(isfinite, value(cache(s))) && break
-        report_nan_direction(config(s))
-        direction(cache(s)) .*= T(config(s).nan_factor)
     end
     s
 end

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -158,7 +158,7 @@ end
 # Behind a barrier because `nan_recovery!` below is specialized on the `NonlinearSolver`, hence on
 # its problem's closure types — see `report_linesearch_status`.
 @noinline function report_nan_direction(config::Options)
-    verbosity(config) ≥ 2 && @warn "NaN detected in nonlinear solver. Reducing length of direction vector."
+    verbosity(config) ≥ 2 && @warn "Non-finite value (NaN or Inf) at the trial iterate. Reducing length of direction vector."
     nothing
 end
 
@@ -169,12 +169,27 @@ Damp `direction(cache(s))` by `nan_factor` until the trial iterate `x + d` has a
 finite residual (or the `nan_max_iterations` budget is exhausted). On return
 `solution(cache(s))` and `value(cache(s))` hold the last trial iterate and its
 residual. Used by the generic and Picard [`solver_step!`](@ref)s. Returns the solver `s`.
+
+"Finite" means `isfinite`, not merely "not `NaN`": a residual that has *overflowed* is
+as unusable as an undefined one and is just as much a symptom of a step that left the
+region where `F` is representable — the `-1/|x|` of issue #130 gives `Inf` at `x = 0`,
+not `NaN`. The option names (`nan_factor`, `nan_max_iterations`) predate that and are
+kept for compatibility.
+
+Damping is only meaningful because the *direction* is known to be finite: the callers
+reject a non-finite one outright (see [`solver_step!`](@ref)), and they must, since
+`Inf * nan_factor` is `Inf` and the loop would spend its whole budget reproducing the
+same trial iterate.
 """
 function nan_recovery!(s::NonlinearSolver{T}, x, params) where {T}
-    for _ in 1:config(s).nan_max_iterations
+    # `max(1, …)`: the budget bounds the *damping*, not the trial evaluation. A budget of zero used
+    # to skip the body entirely and leave the cache holding whatever the previous solver step had
+    # put there — which the Picard step then read as if it were this step's trial, committing a
+    # stale iterate. One trial is always evaluated, so the post-condition above always holds.
+    for _ in 1:max(1, config(s).nan_max_iterations)
         solution(cache(s)) .= x .+ direction(cache(s))
         value!(value(cache(s)), nonlinearproblem(s), solution(cache(s)), params)
-        any(isnan, value(cache(s))) || break
+        all(isfinite, value(cache(s))) && break
         report_nan_direction(config(s))
         direction(cache(s)) .*= T(config(s).nan_factor)
     end
@@ -219,7 +234,11 @@ function solver_step!(x::AbstractVector{T}, s::NonlinearSolver{T}, state::Nonlin
     # A previous step that made no progress gets a freshly evaluated Jacobian rather than the
     # stale one that produced it (see `maybe_refactorize!`).
     direction!(s, x, params, iteration_number(state); stalled=needs_refresh(state))
-    any(isnan, direction(cache(s))) && throw(NonlinearSolverException("NaN detected in direction vector"))
+    # A non-finite direction is not a step that can be shortened — `nan_recovery!` damps by a
+    # factor and `Inf * nan_factor` is still `Inf` — so it is rejected outright rather than
+    # handed to a recovery that cannot work. This is also what makes the recovery below sound:
+    # past this line the direction is finite and each damping actually shortens the trial step.
+    all(isfinite, direction(cache(s))) || throw(NonlinearSolverException("non-finite direction vector"))
 
     nan_recovery!(s, x, params)
 
@@ -267,7 +286,7 @@ function solve!(x::AbstractArray, s::NonlinearSolver, state::NonlinearSolverStat
     # `initialize!`), so this fires exactly when ‖F(x₀)‖ ≤ f_abstol — for the default
     # `f_abstol = 0` only at an exact root. A caller who insists on at least one iteration
     # (`min_iterations ≥ 1`) still gets one, and a `NaN` initial residual still gets a step
-    # (the `havenan` branch requires `iterations ≥ 1`).
+    # (the `havenonfinite` branch requires `iterations ≥ 1`).
     while !meets_stopping_criteria(state, config(s))
         increase_iteration_number!(state)
         solver_step!(x, s, state, params)

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -144,7 +144,11 @@ two are therefore mutually exclusive by construction.
 """
 function residual_small(rfₐ::Number, config::Options, state::NonlinearSolverState)
     r₀ = initial_residual(state)
-    relative_residual = isnan(r₀) ? zero(rfₐ) : config.f_reltol * r₀
+    # `isfinite`, not `!isnan`: an *infinite* initial residual would make the relative term `Inf`
+    # and this gate vacuously true, so every finite residual — a residual of 1e10 included —
+    # would count as small and the solve would report convergence wherever it happened to land.
+    # An overflowed `‖F(x₀)‖` is no more a usable reference scale than an uninitialized one.
+    relative_residual = isfinite(r₀) ? config.f_reltol * r₀ : zero(rfₐ)
     rfₐ ≤ config.f_abstol + relative_residual
 end
 
@@ -153,9 +157,13 @@ end
 
 Return `true` when the last step did not move the iterate, `rxₛ ≤ ‖x‖·x_suctol`. Used by
 [`assess_convergence`](@ref) and [`stalled_step`](@ref).
+
+An infinite step never counts as settled, even though `Inf ≤ ‖x‖·x_suctol` holds once `‖x‖` has
+overflowed too: an iterate that jumped to infinity has neither converged nor frozen, it has
+broken down, and that is what [`havenonfinite`](@ref) is for.
 """
 iterate_settled(rxₛ::Number, config::Options, state::NonlinearSolverState) =
-    rxₛ ≤ norm(solution(state)) * config.x_suctol
+    isfinite(rxₛ) && rxₛ ≤ norm(solution(state)) * config.x_suctol
 
 @doc raw"""
     stalled_step(rxₛ, rfₐ, config, state)
@@ -325,7 +333,27 @@ Check if either `x` or `f` has converged.
 The `status` is a [`NonlinearSolverStatus`](@ref).
 """
 isconverged(status::NonlinearSolverStatus) = status.x_converged || status.f_converged
-havenan(status::NonlinearSolverStatus) = isnan(status.rxₛ) || isnan(status.rfₐ) || isnan(status.rfₛ)
+
+"""
+    havenonfinite(status)
+
+Check whether any of the three residuals of a [`NonlinearSolverStatus`](@ref) — `rxₛ`, `rfₐ`,
+`rfₛ` — is not finite, i.e. whether the iteration has left the region where the problem is
+representable. Used by [`meets_stopping_criteria`](@ref) to give up and by
+[`nonlinear_solver_warnings`](@ref) to say so.
+
+The test is `isfinite`, not `!isnan`: a residual that has *overflowed* is as unusable as an
+undefined one, and the pure-`NaN` test used to miss it entirely — neither this predicate nor
+the `rfₐ > f_abstol_break` gate fired for an infinite residual, since `f_abstol_break` defaults
+to `Inf` and `Inf > Inf` is false, so such a solve ran its whole `max_iterations` budget with no
+diagnosis at all. The same widening was made to the solver-side guards; see
+[`nan_recovery!`](@ref).
+
+Note that a status is never *converged* by accident here — every comparison with `NaN` is false
+and no infinite residual passes [`residual_small`](@ref) — so this predicate decides when to
+stop and what to report, not whether the answer is good.
+"""
+havenonfinite(status::NonlinearSolverStatus) = !(isfinite(status.rxₛ) && isfinite(status.rfₐ) && isfinite(status.rfₛ))
 
 """
     isstalled(status, config)
@@ -408,7 +436,7 @@ The function `meets_stopping_criteria` returns `true` if one of the following is
 - `status.f_increased` and `config.allow_f_increases = false` (i.e. `f` increased even though we do not allow it),
 - `state.iterations ≥ config.max_iterations`,
 - `status.rfₐ > config.f_abstol_break` (by default `Inf`). In theory this returns `true` if the residual gets too big.
-- one of the residuals (`rxₛ`, `rfₐ`, `rfₛ`) is `NaN` (checked with `havenan`) and `state.iterations ≥ 1`,
+- one of the residuals (`rxₛ`, `rfₐ`, `rfₛ`) is not finite (checked with [`havenonfinite`](@ref)) and `state.iterations ≥ 1`,
 So convergence is only one possible criterion for which [`meets_stopping_criteria`](@ref). We may also satisfy a stopping criterion without having convergence!
 
 # Examples
@@ -453,7 +481,7 @@ function meets_stopping_criteria(state::NonlinearSolverState, config::Options)
         (status.f_increased && !config.allow_f_increases) ||
         state.iterations ≥ config.max_iterations ||
         status.rfₐ > config.f_abstol_break ||
-        (havenan(status) && state.iterations ≥ 1)
+        (havenonfinite(status) && state.iterations ≥ 1)
 end
 
 # The two wordings of the no-progress message: the opt-in `f_stall_window` gave up, or the whole
@@ -473,8 +501,9 @@ Report a [`NonlinearSolverStatus`](@ref) at the end of a [`solve!`](@ref): the i
 if it reached `warn_iterations`, *stagnation* at the residual floor (see [`isstalled`](@ref)
 and [`stalled_step`](@ref)), a lack of *progress* (see [`spent_without_progress`](@ref) and
 [`isnotprogressing`](@ref)), a disallowed residual increase, a residual beyond
-`f_abstol_break`, and `NaN`s. Compare this to [`linesearch_warnings`](@ref), which does the
-same for the inner line search, and to [`print_status`](@ref).
+`f_abstol_break`, and non-finite residuals (see [`havenonfinite`](@ref)). Compare this to
+[`linesearch_warnings`](@ref), which does the same for the inner line search, and to
+[`print_status`](@ref).
 
 All messages except the iteration count and the two hard-failure ones are gated on
 `config.verbosity ≥ 1`.
@@ -520,7 +549,7 @@ function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Option
         (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖). If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this." maxlog = 3)
     (status.f_increased && !config.allow_f_increases) && (@warn "The function increased and the solver stopped!")
     (status.rfₐ > config.f_abstol_break) && (@warn "The residual rfₐ has reached the maximally allowed value $(config.f_abstol_break)!")
-    (havenan(status) && status.iterations ≥ 1 && config.verbosity ≥ 1) && (@warn "Nonlinear solver encountered NaNs in solution or function value.")
+    (havenonfinite(status) && status.iterations ≥ 1 && config.verbosity ≥ 1) && (@warn "Nonlinear solver encountered NaNs or Infs in solution or function value.")
 
     nothing
 end

--- a/src/nonlinear/picard_solver.jl
+++ b/src/nonlinear/picard_solver.jl
@@ -151,12 +151,15 @@ function solver_step!(x::AbstractVector{T}, s::PicardSolver{T}, state::Nonlinear
         compute_new_iterate!(solution(cache(s)), x, α, direction(cache(s)))
         value!(value(cache(s)), nonlinearproblem(s), solution(cache(s)), params)
     end
-    # A trial iterate that is not finite must not be committed, even though it is the last one
-    # evaluated: it is reachable when `nan_recovery!` exhausted `nan_max_iterations` without
-    # escaping the region where `F` is undefined or overflows. Leaving `x` where it was makes
-    # the step a frozen one, which `stalled_step` already diagnoses — the same choice
-    # `DogLegSolver` makes for a rejected trial on radius underflow.
-    all(isfinite, solution(cache(s))) && (x .= solution(cache(s)))
+    # A trial whose *residual* is not finite must not be committed, even though it is the last one
+    # evaluated: it is reachable when `nan_recovery!` exhausted `nan_max_iterations` and the
+    # backtracking above never found an α that got back inside the region where `F` is defined and
+    # representable. It is `value(cache(s))` that says so and not `solution(cache(s))`: the trial
+    # iterate is finite whenever `x` and the direction are, and the guard at the top of this
+    # function has already established the direction. Leaving `x` where it was makes the step a
+    # frozen one, which `stalled_step` already diagnoses — the same choice `DogLegSolver` makes
+    # for a rejected trial on radius underflow.
+    (all(isfinite, solution(cache(s))) && all(isfinite, value(cache(s)))) && (x .= solution(cache(s)))
 
     x
 end

--- a/src/nonlinear/picard_solver.jl
+++ b/src/nonlinear/picard_solver.jl
@@ -127,7 +127,9 @@ a false positive.
 """
 function solver_step!(x::AbstractVector{T}, s::PicardSolver{T}, state::NonlinearSolverState{T}, params) where {T}
     direction!(s, x, params, iteration_number(state))
-    any(isnan, direction(cache(s))) && throw(NonlinearSolverException("NaN detected in direction vector"))
+    # The Picard direction *is* the residual, so this rejects a non-finite `F(x)` at the current
+    # iterate. As in the generic step, damping cannot rescue a non-finite direction.
+    all(isfinite, direction(cache(s))) || throw(NonlinearSolverException("non-finite direction vector"))
 
     # NaN recovery on the residual direction (mirrors the generic solver step); leaves
     # the α = 1 trial residual in `value(cache(s))`, reused by the safeguard below.
@@ -149,7 +151,12 @@ function solver_step!(x::AbstractVector{T}, s::PicardSolver{T}, state::Nonlinear
         compute_new_iterate!(solution(cache(s)), x, α, direction(cache(s)))
         value!(value(cache(s)), nonlinearproblem(s), solution(cache(s)), params)
     end
-    x .= solution(cache(s))
+    # A trial iterate that is not finite must not be committed, even though it is the last one
+    # evaluated: it is reachable when `nan_recovery!` exhausted `nan_max_iterations` without
+    # escaping the region where `F` is undefined or overflows. Leaving `x` where it was makes
+    # the step a frozen one, which `stalled_step` already diagnoses — the same choice
+    # `DogLegSolver` makes for a rejected trial on radius underflow.
+    all(isfinite, solution(cache(s))) && (x .= solution(cache(s)))
 
     x
 end

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -634,6 +634,192 @@ end
     @test isapprox(x2[1], exp(-2.0); atol=1e-8)
 end
 
+@testset "Newton solver_step! damps the direction when the trial value is Inf" begin
+    # The companion of the testset above for the *other* way a trial iterate leaves the region
+    # where F is representable, and the one issue #130 actually asks about: its fixture
+    # 5|x-2|³ - 1/|x| is singular at x = 0, where 1/x overflows to `Inf` rather than going `NaN`.
+    # The guard used to test `isnan` only, so an infinite residual broke out of the recovery loop
+    # on the first pass and the undamped step was taken.
+    #
+    # F(x) = 1/x - 1 has its root at x = 1.  From x₀ = 2 the Newton step is exactly d = -2
+    # (F = -0.5, J = -1/x² = -0.25), landing exactly on x = 0 in floating point.  One halving
+    # gives d = -1, i.e. the root itself.  `Static` evaluates no merit at all, so `nan_recovery!`
+    # is the only thing standing between the solver and x = 0 here.
+    Finv(y, x, p) = (y .= 1 ./ x .- 1)
+    for T in (Float64, Float32)
+        x = T[2]
+        s = NewtonSolver(x, similar(x); F=Finv, linesearch=Static(), verbosity=0)
+        initialize!(s, x)
+        y = similar(x)
+        Finv(y, x, NullParameters())
+        state = NonlinearSolverState(x, y)
+        initialize!(state, x, y)
+
+        solver_step!(x, s, state, NullParameters())
+        @test x[1] ≈ one(T)                     # one halving landed the step on the root
+        @test all(isfinite, value(cache(s)))    # the committed trial value is finite
+
+        # ... and a full solve converges rather than dying: undamped, the next step divides the
+        # -Inf residual at x = 0 by the -Inf Jacobian there and throws on the NaN direction.
+        x2 = T[2]
+        s2 = NewtonSolver(x2, similar(x2); F=Finv, linesearch=Static(), verbosity=0)
+        solve!(x2, s2)
+        @test isapprox(x2[1], one(T); atol=∛(eps(T)))
+    end
+end
+
+@testset "a non-finite direction is rejected rather than damped" begin
+    # `nan_recovery!` damps by a *factor*, and `Inf * nan_factor` is `Inf`, so a non-finite
+    # direction is not something the recovery can shorten — it would spend its whole
+    # `nan_max_iterations` budget reproducing the same trial iterate.  The guard in
+    # `solver_step!` therefore rejects it outright, as it always has for a `NaN` direction.
+    #
+    # A Jacobian pinned at the smallest positive subnormal makes d = -F/J overflow exactly:
+    # from x₀ = 2 the residual is 1 and the step is -1/5e-324 = -Inf.  Before, this slipped
+    # through the `isnan` guard; the line search then saw an infinite directional derivative,
+    # reported `LINESEARCH_NO_DESCENT` and left the iterate where it was — a solve that silently
+    # made no progress instead of one that said what was wrong.
+    Flin(y, x, p) = (y .= x .- 1)
+    DFtiny(J, x, p) = (J .= 5e-324)
+    x = [2.0]
+    s = NewtonSolver(x, similar(x); F=Flin, DF! = DFtiny, verbosity=0)
+    initialize!(s, x)
+    y = similar(x)
+    Flin(y, x, NullParameters())
+    state = NonlinearSolverState(x, y)
+    initialize!(state, x, y)
+
+    @test_throws NonlinearSolverException solver_step!(x, s, state, NullParameters())
+
+    x2 = [2.0]
+    s2 = NewtonSolver(x2, similar(x2); F=Flin, DF! = DFtiny, verbosity=0)
+    @test_throws NonlinearSolverException solve!(x2, s2)
+end
+
+@testset "nan_factor and nan_max_iterations are honoured" begin
+    # The two `Options` that configure `nan_recovery!` had no test at all — neither their
+    # defaults nor a non-default value.  The damped iterate encodes both exactly, so this pins
+    # them without reaching into the loop.
+    Finv(y, x, p) = (y .= 1 ./ x .- 1)
+
+    # `nan_factor` — from x₀ = 2 the Newton step d = -2 lands on the singularity at x = 0.  The
+    # default 0.5 halves it to d = -1 (x = 1); 0.25 shortens it to d = -0.5 (x = 1.5) instead.
+    for (factor, expected) in ((0.5, 1.0), (0.25, 1.5))
+        x = [2.0]
+        s = NewtonSolver(x, similar(x); F=Finv, linesearch=Static(), verbosity=0, nan_factor=factor)
+        initialize!(s, x)
+        y = similar(x)
+        Finv(y, x, NullParameters())
+        state = NonlinearSolverState(x, y)
+        initialize!(state, x, y)
+        solver_step!(x, s, state, NullParameters())
+        @test x[1] ≈ expected
+    end
+
+    # `nan_max_iterations` — the domain-restricted log of the testset above needs *two* halvings
+    # (d = -2 → -1, x = 0 still NaN → -0.5, x = 0.5 finite).  A budget of one therefore leaves
+    # the loop with a NaN residual, which is the exhaustion path: nothing reports it there, so
+    # what has to hold is that the *outer* iteration notices.  It stops on the non-finite
+    # residual instead of spending `max_iterations`, does not claim convergence, and says so.
+    nanlog(v) = v > 0 ? log(v) : oftype(v, NaN)
+    Flog(y, x, p) = (y .= nanlog.(x) .+ 2)
+    x = [1.0]
+    s = NewtonSolver(x, similar(x); F=Flog, linesearch=Static(), verbosity=0, nan_max_iterations=1)
+    state = SolverState(s)
+    solve!(x, s, state)
+    st = status(s, state)
+    @test SimpleSolvers.havenonfinite(st)
+    @test !isconverged(st)
+    @test iteration_number(state) < config(s).max_iterations
+
+    # ... and the full budget rescues the same solve.
+    x2 = [1.0]
+    s2 = NewtonSolver(x2, similar(x2); F=Flog, linesearch=Static(), verbosity=0)
+    solve!(x2, s2)
+    @test isapprox(x2[1], exp(-2.0); atol=1e-8)
+
+    # A budget of zero used to skip the loop body altogether, so the cache still held the trial
+    # of the *previous* solver step.  The Picard step documents that it reuses that cache rather
+    # than re-evaluating F (`picard_solver.jl`), so it read a stale residual and committed a
+    # stale iterate — the sentinel below, from nowhere near the current one.  At least one trial
+    # is now always evaluated, so the post-condition `nan_recovery!` advertises always holds.
+    x3 = [1.0]
+    s3 = PicardSolver(x3, Flog, similar(x3); verbosity=0, nan_max_iterations=0)
+    initialize!(s3, x3)
+    solution(cache(s3)) .= -99.0
+    value(cache(s3)) .= 0.0
+    y3 = similar(x3)
+    Flog(y3, x3, NullParameters())
+    state3 = NonlinearSolverState(x3, y3)
+    initialize!(state3, x3, y3)
+    solver_step!(x3, s3, state3, NullParameters())
+    @test x3[1] ≠ -99.0
+    @test all(isfinite, x3)
+end
+
+@testset "a non-finite status stops the solve and is reported" begin
+    # `havenonfinite`, the branch of `meets_stopping_criteria` that consults it and the warning
+    # that reports it had no test between them.  The `Inf` rows are the ones that used to fail:
+    # an overflowed residual passed the `isnan` test, and `rfₐ > f_abstol_break` does not catch
+    # it either, since `f_abstol_break` defaults to `Inf` and `Inf > Inf` is false — so such a
+    # solve ran its whole `max_iterations` budget with no diagnosis at all.
+    for bad in (NaN, Inf)
+        config = Options(verbosity=1)
+        state = NonlinearSolverState([1.0])
+        update!(state, [bad], [bad])
+        increase_iteration_number!(state)
+        st = NonlinearSolverStatus(state, config)
+
+        @test SimpleSolvers.havenonfinite(st)
+        @test !isconverged(st)
+        @test meets_stopping_criteria(state, config)
+        @test logged_any(() -> nonlinear_solver_warnings(st, config), "NaNs or Infs")
+        @test !logged_any(() -> nonlinear_solver_warnings(st, Options(verbosity=0)), "NaNs or Infs")
+    end
+
+    # An overflowed initial residual is not a usable reference scale.  `residual_small` guarded
+    # only `isnan(r₀)`, so `f_reltol * Inf = Inf` made its gate vacuously true and *any* finite
+    # residual counted as small — the solve then reported convergence wherever it landed, which
+    # is a far worse failure than not converging.  Likewise an infinite step is not a settled
+    # one, even though `Inf ≤ ‖x‖·x_suctol` holds once ‖x‖ has overflowed as well.
+    state = NonlinearSolverState([1.0])
+    SimpleSolvers.initialize!(state, [1.0], [Inf])
+    @test !residual_small(1.0e10, Options(), state)
+    @test !iterate_settled(Inf, Options(), state)
+
+    # A finite status is untouched by the widening.  Two `update!`s, because a single one leaves
+    # the *previous* iterate at the `NaN` the state is allocated with, so `rxₛ` and `rfₛ` are
+    # `NaN` until the second — which is exactly why the two consumers above require
+    # `iterations ≥ 1` (see the `initialize!` note in the first testset of this file).
+    state = NonlinearSolverState([1.0])
+    update!(state, [1.0], [1.0])
+    update!(state, [1.0], [1.0])
+    @test !SimpleSolvers.havenonfinite(NonlinearSolverStatus(state, Options()))
+end
+
+@testset "Picard rejects a non-finite direction and commits only finite iterates" begin
+    # The Picard direction *is* the residual (d = -F(x)), so a non-finite `F` at the current
+    # iterate is a non-finite direction and must be rejected for the same reason the Newton one
+    # is: damping cannot shorten it.  `1/x - 1` at x₀ = 0 gives exactly that.
+    Finv(y, x, p) = (y .= 1 ./ x .- 1)
+    x = [0.0]
+    s = PicardSolver(x, Finv, similar(x); verbosity=0)
+    @test_throws NonlinearSolverException solve!(x, s)
+
+    # And the commit guard: with the recovery budget exhausted, the residual-monotonicity
+    # backtracking only ever sees NaN (`NaN ≤ r₀` is false), halves α down to the underflow
+    # bound and would previously have written that non-finite trial into `x`.  A frozen iterate
+    # is the honest outcome — `stalled_step` diagnoses it — and it is what lets the solve be
+    # reported rather than propagating NaNs to the caller.
+    nanlog(v) = v > 0 ? log(v) : oftype(v, NaN)
+    Fneg(y, x, p) = (y .= .-nanlog.(x) .- 2)   # Picard step d = -F = log(x) + 2 leaves the domain
+    x2 = [1.0]
+    s2 = PicardSolver(x2, Fneg, similar(x2); verbosity=0, nan_max_iterations=1)
+    state2 = SolverState(s2)
+    solve!(x2, s2, state2)
+    @test all(isfinite, x2)
+end
+
 @testset "DogLeg recovers from a collapsed trust-region radius" begin
     # Once the carried trust radius underflowed (Δ ≤ eps), the next
     # solver_step!'s `while Δ > eps(T)` never ran, so the iterate froze and the
@@ -1544,8 +1730,19 @@ end
         x = [1.0]
         solve!(x, DogLegSolver(x, Flog, similar(x); verbosity=v))
     end
-    @test logged_any(nanmerit(2), "undefined merit")
-    @test !logged_any(nanmerit(1), "undefined merit")
+    @test logged_any(nanmerit(2), "non-finite merit")
+    @test !logged_any(nanmerit(1), "non-finite merit")
+
+    # The generic step's own damping reporter, which was the one message in this family with no
+    # gate assertion at all. `Finv` overshoots from x₀ = 2 to exactly x = 0, where 1/x is `Inf`
+    # — the `-1/|x|` singularity of issue #130 — so `nan_recovery!` reports and halves.
+    Finv(y, x, p) = (y .= 1 ./ x .- 1)
+    nonfinite(v) = function ()
+        x = [2.0]
+        solve!(x, NewtonSolver(x, similar(x); F=Finv, linesearch=Static(), verbosity=v))
+    end
+    @test logged_any(nonfinite(2), "Reducing length of direction vector")
+    @test !logged_any(nonfinite(1), "Reducing length of direction vector")
 end
 
 @testset "$(rpad("a converged solve allocates nothing", 80))" begin

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -755,6 +755,29 @@ end
     solver_step!(x3, s3, state3, NullParameters())
     @test x3[1] ≠ -99.0
     @test all(isfinite, x3)
+
+    # ... and a budget of zero must not damp *either*: refreshing the cache with one trial while
+    # still halving the direction on the way out made a budget of zero behave exactly like a
+    # budget of one, so this solve landed on the root and reported convergence.  With no damping
+    # the full step onto the singularity is taken, and the solve has to fail and say so.
+    x4 = [2.0]
+    s4 = NewtonSolver(x4, similar(x4); F=Finv, linesearch=Static(), verbosity=0, nan_max_iterations=0)
+    state4 = SolverState(s4)
+    solve!(x4, s4, state4)
+    @test !isconverged(status(s4, state4))
+    @test SimpleSolvers.havenonfinite(status(s4, state4))
+
+    # The pairing `nan_recovery!` leaves behind: `value(cache)` is the residual of the trial built
+    # from the direction `cache` currently holds.  Damping *after* the failed trial rather than
+    # before the next one left the two a factor apart on every exhaustion path, and the Picard
+    # step reads them as a pair.
+    x5 = [2.0]
+    s5 = NewtonSolver(x5, similar(x5); F=Finv, linesearch=Static(), verbosity=0, nan_max_iterations=1)
+    initialize!(s5, x5)
+    direction!(s5, x5, NullParameters(), 0)
+    SimpleSolvers.nan_recovery!(s5, x5, NullParameters())
+    @test solution(cache(s5)) ≈ x5 .+ direction(cache(s5))
+    @test value(cache(s5)) ≈ [1 / solution(cache(s5))[1] - 1]
 end
 
 @testset "a non-finite status stops the solve and is reported" begin
@@ -766,7 +789,11 @@ end
     for bad in (NaN, Inf)
         config = Options(verbosity=1)
         state = NonlinearSolverState([1.0])
-        update!(state, [bad], [bad])
+        # Primed with a finite step first: a single `update!` leaves the *previous* iterate and
+        # value at the `NaN` the state is allocated with, so `rxₛ` and `rfₛ` would be `NaN`
+        # whatever `bad` is and the `Inf` row would pass under the old `isnan`-only predicate too.
+        update!(state, [1.0], [1.0])
+        update!(state, [2.0], [bad])
         increase_iteration_number!(state)
         st = NonlinearSolverStatus(state, config)
 
@@ -785,7 +812,13 @@ end
     state = NonlinearSolverState([1.0])
     SimpleSolvers.initialize!(state, [1.0], [Inf])
     @test !residual_small(1.0e10, Options(), state)
-    @test !iterate_settled(Inf, Options(), state)
+
+    # `iterate_settled` needs ‖x‖ itself to have overflowed, which is the only fixture that
+    # separates the new gate from the old one: with a finite iterate `Inf ≤ ‖x‖·x_suctol` was
+    # already false.
+    settled_state = NonlinearSolverState([1.0])
+    SimpleSolvers.initialize!(settled_state, [Inf], [Inf])
+    @test !iterate_settled(Inf, Options(), settled_state)
 
     # A finite status is untouched by the widening.  Two `update!`s, because a single one leaves
     # the *previous* iterate at the `NaN` the state is allocated with, so `rxₛ` and `rfₛ` are
@@ -806,18 +839,21 @@ end
     s = PicardSolver(x, Finv, similar(x); verbosity=0)
     @test_throws NonlinearSolverException solve!(x, s)
 
-    # And the commit guard: with the recovery budget exhausted, the residual-monotonicity
-    # backtracking only ever sees NaN (`NaN ≤ r₀` is false), halves α down to the underflow
-    # bound and would previously have written that non-finite trial into `x`.  A frozen iterate
-    # is the honest outcome — `stalled_step` diagnoses it — and it is what lets the solve be
-    # reported rather than propagating NaNs to the caller.
-    nanlog(v) = v > 0 ? log(v) : oftype(v, NaN)
-    Fneg(y, x, p) = (y .= .-nanlog.(x) .- 2)   # Picard step d = -F = log(x) + 2 leaves the domain
+    # And the commit guard.  `F` is finite on x ≤ 1 and `Inf` beyond it, with a residual large
+    # enough that even the underflowed backtracking step α‖d‖ still crosses that wall — so no
+    # trial the step evaluates has a finite residual, and the last one would be committed.  The
+    # trial *iterate* is finite throughout (x is, and the direction is past the guard above),
+    # which is why the guard has to test `value(cache)` rather than `solution(cache)`.  A frozen
+    # iterate is the honest outcome — `stalled_step` diagnoses it — and it is what lets the solve
+    # be reported rather than handing the caller an x whose residual is `Inf`.
+    Fwall(y, x, p) = (y .= [xi ≤ 1 ? -1.0e10 : oftype(xi, Inf) for xi in x])
     x2 = [1.0]
-    s2 = PicardSolver(x2, Fneg, similar(x2); verbosity=0, nan_max_iterations=1)
+    s2 = PicardSolver(x2, Fwall, similar(x2); verbosity=0)
     state2 = SolverState(s2)
     solve!(x2, s2, state2)
-    @test all(isfinite, x2)
+    @test x2 == [1.0]                                            # the poisoned trial was not committed
+    @test !SimpleSolvers.havenonfinite(status(s2, state2))
+    @test isstalled(status(s2, state2), config(s2))              # ... and the solve says why
 end
 
 @testset "DogLeg recovers from a collapsed trust-region radius" begin


### PR DESCRIPTION
Closes #130.

## The gap

Every guard the nonlinear solvers had against a trial iterate leaving the region where the problem is representable tested `isnan` — and `isnan` is false for `Inf`.

Issue #130 asks whether that detection works, on the example `f(x) = 5|x-2|³ - 1/|x|`. Its singularity produces `Inf` at `x = 0`, not `NaN`, so **for the issue's own fixture the answer was no**. Nor did anything downstream of the guards catch it: `rfₐ > f_abstol_break` cannot, because `f_abstol_break` defaults to `Inf` and `Inf > Inf` is false.

The line searches never had this gap — `check_anchor` has always tested `isfinite` — and neither did the `Optimizer` removed in 0.11.0, which tested `isnan(f) || isinf(f)` ([#138](https://github.com/JuliaGNI/SimpleSolvers.jl/pull/138), commit `0f22e16`). The solvers were the only ones left looking for half the problem.

Reproducer, before this PR — `F(x) = 1/x - 1` from `x₀ = 2`, where the Newton step is exactly `d = -2` and lands exactly on `x = 0`:

| | before | after |
|:--|:--|:--|
| `F(x) = 1/x - 1`, `x₀ = 2`, `Static()` | steps onto `x = 0`, residual `Inf`, next step throws on the `NaN` direction | damps once, lands on the root `x = 1` |
| `Inf` direction | passes the guard, cannot be damped, solve stalls silently | `NonlinearSolverException` |

## Direction and residual are not the same problem

That distinction is what the fix turns on.

A non-finite **direction is rejected**, as a `NaN` one always was. It cannot be recovered from: `nan_recovery!` damps by a *factor*, and `Inf * nan_factor` is `Inf`, so the loop would spend its whole budget reproducing the same trial iterate. Rejecting it first is also what makes the damping sound — past that guard the direction is finite, so every halving really does shorten the step. Previously such a step was neither rejected nor damped: the line search saw an infinite directional derivative, returned `LINESEARCH_NO_DESCENT`, and the solve made no progress without saying why.

A non-finite **trial residual is damped**, exactly as a `NaN` one was — `nan_recovery!`, `report_dogleg_nan` and the dogleg trust-region rejection now all test `isfinite`.

`havenan` becomes `SimpleSolvers.havenonfinite`. It is unexported and internal (nothing downstream references it), so there is no deprecation.

## What else was wrong

Three defects sit next to this one and are fixed with it. **The first is the serious one** — it is the difference between a solve that fails and a solve that lies:

- **`residual_small` could report *convergence* on an overflowed solve.** It guarded only `isnan(r₀)`, so an infinite `‖F(x₀)‖` made the relative term `f_reltol * Inf = Inf` and the gate vacuously true. A residual of `1e10` counted as small, and the solve claimed success wherever it happened to land. An overflowed initial residual is no more a usable reference scale than an uninitialized one, and is now treated the same way.
- **`iterate_settled` counted an infinite step as a frozen iterate**, since `Inf ≤ ‖x‖·x_suctol` holds once `‖x‖` has overflowed too. An iterate that jumped to infinity has neither converged nor stagnated — it has broken down, which is what `havenonfinite` is for.
- **`nan_recovery!` at `nan_max_iterations = 0` left its cache untouched**, so the post-condition its docstring advertises — that `solution(cache)` and `value(cache)` hold *this* step's trial and its residual — was false. The `PicardSolver` step documents that it reads that cache rather than re-evaluating `F`, so it tested a stale residual and committed a stale iterate from the **previous** solver step. One trial is now always evaluated, and the damping happens *before* the trial it is for rather than after the one that failed: the budget bounds the damping, not the evaluation, and `value(cache)` is always `F(x + direction(cache))`. Picard additionally refuses to commit a trial whose *residual* is not finite, as `DogLegSolver` already did on radius underflow.

## Behaviour

Unchanged on any solve that stays finite, and at the same cost — one pass over the residual either way. Where it changes, it changes in the direction of saying so: **a non-finite direction now raises `NonlinearSolverException` where it used to stall silently.** A caller driving `solve!` in a time-stepping loop will see that as an exception rather than as a step that quietly achieved nothing, which is the one visible regression risk here.

## Tests

The fixture is `F(x) = 1/x - 1` from `x₀ = 2`, chosen because the arithmetic is exact in floating point: `F = -0.5`, `J = -1/x² = -0.25`, so the Newton step is `d = -2` and `x + d = 0` exactly, and one halving gives `d = -1` — the root itself. `Static()` evaluates no merit at all, so `nan_recovery!` is the only thing standing between the solver and `x = 0`.

New testsets in `test/nonlinear_solver_tests.jl` cover: the `Inf` damping path (`Float64` and `Float32`); rejection of a non-finite direction; `nan_factor` and `nan_max_iterations`, which had **no test at all** before, neither their defaults nor a non-default value; the status-level `havenonfinite` / `meets_stopping_criteria` / warning trio, also previously untested; the Picard direction guard and commit guard; and the `residual_small` / `iterate_settled` finiteness gates. The verbosity gate of `report_nan_direction` is now pinned alongside the two `DogLeg` reporters that already were.

## Verification

- Full suite green — 2980 nonlinear-solver assertions.
- Doctests pass; docs build resolves the new `@ref`s with no new warnings.
- Downstream **bit-identical** before and after: GeometricIntegrators × GeometricProblems, `LotkaVolterra2d` over 1000 steps under five integrators, plus the collisional `ThreeBody` initial condition that has no root. Nothing downstream references `havenan` or matches on the changed message texts.

## Review round

A second commit fixes what reviewing the first one turned up — two guards that did not do what their comments said, and three assertions that passed for the wrong reason:

- **`nan_recovery!` damped outside its budget.** Damping after the failed trial rather than before the next one meant one more damping than evaluation: `nan_max_iterations = 0` still halved the direction once (so it behaved exactly like `1`, and the `1/x - 1` solve *converged on the root*), and on every exhaustion path `value(cache)` was the residual of a trial built from a direction one factor away from the one the cache holds — which is the pair the Picard step reads. Raised by Copilot for the budget-0 half.
- **The Picard commit guard tested the trial iterate**, but the failure it names is a non-finite *residual*, and there the iterate is finite by construction. So it passed and the poisoned trial was committed: with `F` finite on `x ≤ 1` and `Inf` beyond, the solve returned `x = 1.0000000021684043` with `F(x) = Inf`.
- The `Inf` row of the status testset left `rxₛ`/`rfₛ` at `NaN`, so the old `havenan` accepted it too; `!iterate_settled(Inf, …)` was already false with `‖x‖ = 1`; and the Picard fixture never produced a non-finite trial at all, making its assertion vacuous. Two further testsets now pin the recovery budget and the direction/residual pairing.

All six new assertions fail against the first commit and pass against the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

