### PR TITLE
Tell a located root from a failed bracket, and report to the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,111 @@
 
 All notable changes to SimpleSolvers.jl are documented here.
 
+## [0.12.0]
+
+Two defects reported from downstream by
+[GeometricOptimizers.jl](https://github.com/JuliaGNI/GeometricOptimizers.jl), filed there as **D3**
+and **D4**. **Breaking**: a `NonlinearSolver` no longer emits line-search warnings from inside its
+iteration, and `NonlinearSolverStatus` gains a field.
+
+### `Bisection` no longer reports success when it cannot bracket
+
+#### The gap
+
+`_bisection_core` returned `(α, converged::Bool, n)` and set `converged = true` on the branch that
+handles *no sign change between the endpoints*:
+
+```julia
+if y₀ * y₁ > zero(y₀)                                  # no sign change
+    report_bisection_nobracket(α₀, α₁, y₀, y₁, config)
+    return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), true, n      # ← converged = true
+end
+```
+
+The intent was that a flat derivative at a minimum is benign. The effect was that the core could
+not tell *"found the root"* from *"gave up"*, and the endpoint of a bracket that never existed was
+handed on as if it were the located line minimiser.
+
+That claim then propagated. `Bisection` bisects ``\varphi'`` but brackets on ``\varphi``, so the
+two disagree exactly when something is wrong — a stale or regularized Jacobian, an inexact linear
+solve, a non-smooth merit. In that case the returned endpoint typically does not improve the merit
+either, and the search classified it as `LINESEARCH_FLOOR`: *"no line search can make progress
+here"*. The outer iteration acts on that (`flag_stall!`, then `max_stalls`), so a failure to
+bracket was being read as a property of the problem. Downstream it contributed to a diverging
+`_BFGS` + `Bisection` + `Geodesic` run in which the step was taken regardless.
+
+#### Changed
+
+- `_bisection_core` now returns a `BisectionOutcome` — `BISECTION_CONVERGED`,
+  `BISECTION_NOBRACKET` or `BISECTION_EXHAUSTED` — in place of the `Bool`. Internal, like the
+  `Symbol` that `_triple_point_core` returns. The `α` it returns is unchanged in every case.
+- `bisection` dispatches on it, so a spent budget and a failed bracket get the wording that fits
+  each (*"I did not narrow the interval far enough"* versus *"there is no root in it at all"*;
+  only the first is fixed by a larger budget).
+- The `Bisection` **line search** classifies a failed bracket by the merit alone, with
+  `LINESEARCH_FLOOR` disallowed: `LINESEARCH_DECREASED` when the returned step still beats
+  ``\varphi(0)`` by more than ``\tau``, `LINESEARCH_EXHAUSTED` when it does not. `LINESEARCH_FLOOR`
+  is now reachable only from a bisection that actually converged. The retry from the ``\alpha = 0``
+  anchor carries its own verdict through for the same reason; it used to be discarded.
+- The standalone `bisection`'s no-bracket warning moved from `verbosity ≥ 2` to `≥ 1`. It sat at 2
+  only because of the benign line-search case, and the line search no longer routes through
+  `bisection` — it calls `_bisection_core` and reports through its `LinesearchStatus`. For a
+  caller asking for a root, "there is no root in your interval" is a genuine failure.
+
+### A line search reports to its caller, not to the user
+
+#### The gap
+
+The `maxlog` caps on the line-search warnings were keyed on the *source location* of the `@warn`,
+so they were process-global and were never reset between `solve!` calls. Once spent, a message was
+gone for the rest of the session, including for later solves of entirely different problems — a
+genuine line-search failure in the tenth solve of a run was silent. This mattered because the log
+was the only channel by which a rejected line search was visible at all.
+
+The caps were a symptom. The channel split already existed — `solve_with_status` returns a
+`LinesearchStatus` and emits nothing, `solve` adds `linesearch_warnings` — but `solver_step!`
+called `solve_with_status` and then `linesearch_warnings` *anyway*, once per outer iteration. A
+solve that cannot make progress asks the line search for an impossible decrease at every one of its
+iterations, so that call is what turned one diagnosis into thousands of identical messages, and the
+caps existed to hold it back.
+
+#### Changed
+
+- `solver_step!` no longer calls `linesearch_warnings`. A line search now reports to its *caller*
+  through `LinesearchStatus`, and to the *user* only when the user called `solve(ls, α)` directly.
+  One direct call yields one message, so there is nothing left to rate limit and the three
+  `maxlog` caps in `report_linesearch_status` are **removed** rather than reimplemented.
+- One deliberate loss: a solver at `verbosity ≥ 2` no longer gets `curvature_diagnostic` per
+  iteration, which cost a full Jacobian evaluation each time.
+
+#### Added
+
+- `NonlinearSolverState` tallies the `LinesearchOutcome` of every step (`record_linesearch!`),
+  reset per solve by `initialize!` exactly like `stalls`.
+- `NonlinearSolverStatus` carries a snapshot of that tally, read with `linesearch_outcomes`,
+  `linesearch_failures` and `dominant_linesearch_outcome`. This is the programmatic channel the
+  package lacked: a caller that wants to *act* on a rejected line search — restart an approximate
+  Hessian, fall back to steepest descent — reads the status instead of scraping the log. Not
+  exported, per the convention the other status predicates follow.
+- The stagnation and no-progress messages of `nonlinear_solver_warnings` name what the line search
+  reported and how often ("the line search reported `LINESEARCH_NO_DESCENT` on 194 of the 200
+  step(s)"), so a failed solve names the cause and not only the symptom. A solve that converged
+  despite line-search failures says the same at `verbosity ≥ 2`, as an `@info`.
+
+### The solver's own report backs off instead of going silent
+
+`nonlinear_solver_warnings` fires once per `solve!` and is the one place a cross-solve cap is still
+needed — a time-stepping loop over an unattainable tolerance would otherwise report at every step.
+Its three repeatable messages are now gated on `should_report!`, which reports the 1st, 2nd, 4th,
+8th … occurrence of a diagnosis rather than the first three and then nothing ever again. Keys
+include the dominant line-search outcome, so a solve that starts failing for a *new* reason is
+reported at once.
+
+Be clear about the trade: a *repeating* diagnosis is reported on occurrences 1, 2, 4, 8, 16 …, so
+occurrence 10 is silent and occurrence 16 is not. Every occurrence is not promised — that would be
+the flood back. `verbosity = 0` still silences a solver completely, and the status is still the way
+to act on an outcome rather than read about it. `reset_warning_counts!` clears the counters.
+
 ## [0.11.0]
 
 Four independent changes. **Breaking**: `Backtracking` loses its `α₀` key and its positional
@@ -905,3 +1010,59 @@ Second review pass (seven further correctness fixes):
 - `StrongWolfe` now composes the shared `SufficientDecreaseCondition` and
   `CurvatureCondition(…, Val(:Strong))` (issue #166) instead of re-implementing the
   Wolfe inequalities inline; the evaluation count and behavior are unchanged.
+
+---
+
+## Open Issues
+
+Problems that surfaced while working on a release but were **not** fixed in it. Each entry says
+what is wrong, how it was established, and why it was left. When one is fixed, move it out of this
+section and into the release that fixed it.
+
+### Reported by GeometricOptimizers.jl, not addressed in 0.12.0
+
+- **`Bisection` can converge onto a *maximum*.** The 0.12.0 fix closed the route by which a
+  *failed* bracket became `LINESEARCH_FLOOR`; it did not touch the route by which a *successful*
+  one does. `bracket_minimum` brackets a minimum in **value**, which on a non-convex ray can
+  enclose several stationary points, and the bisection of ``\varphi'`` inside it may settle on any
+  of them. Landing on a maximum is not caught: the step is classified by the merit like any other,
+  so it is `LINESEARCH_DECREASED` when it happens to improve ``\varphi`` and `LINESEARCH_FLOOR`
+  when it does not — the same overclaim, reached by a different path. GeometricOptimizers observed
+  exactly this (`_BFGS` + `Bisection` + `Geodesic`: `LINESEARCH_FLOOR` with ``\varphi(1) =
+  \varphi(0)``, and the step taken regardless). A second-order check at the located root, or
+  rejecting a root with ``\varphi'' < 0`` and re-bracketing, would close it. Left out because it
+  changes what the method *searches for*, not merely what it *reports*, which is a larger change
+  than the reporting defect that prompted 0.12.0.
+- **`store_trace`, `show_trace` and `extended_trace` have no readers.** `grep` over `src/` finds
+  them only in `Options` itself — they are accepted, printed by `show(::Options)`, and then
+  ignored, so a caller who sets one gets silence rather than a trace or an error.
+  GeometricOptimizers implements `store_trace` itself for this reason. Either implement them or
+  remove them; both are breaking, so neither belongs in a release driven by something else.
+
+### Introduced or left standing by 0.12.0
+
+- **The status can misreport ``\varphi(\alpha)`` when the merit cannot be bracketed at all.** When
+  `bracket_minimum` returns `nothing`, `Bisection`'s `solve_with_status` returns a
+  `LinesearchStatus` whose `φ` field is filled with ``\varphi(0)`` rather than the merit at the
+  ``\alpha`` it hands back. Reproducer: ``\varphi(\alpha) = 1 - \alpha`` descends forever, and the
+  status reports `α = 1.0, φ(α) = 1.0` where the true value is `0.0`. Nothing acts on that field —
+  the outcome is decided before it is filled — but `linesearch_exhausted_reason` interpolates the
+  difference into its message, where it reads as "the merit did not change" when in fact it was
+  never measured. Pre-existing, not a regression. The honest fix is to evaluate the merit at the
+  returned step, which costs one evaluation on a path that is already a failure.
+- **A third-party `LinesearchMethod` still reports from inside a solve.** The layering that 0.12.0
+  established — a program calls `solve_with_status` and gets no messages — holds because all six
+  built-in methods implement `solve_with_status` directly. The generic fallback does not: it calls
+  `solve`, which calls `linesearch_warnings`. So a downstream method that implements only `solve`
+  reinstates the per-iteration message the release removed, and now without a `maxlog` to bound it.
+  Inverting the fallback (have the default `solve` call `solve_with_status`) would fix it, but the
+  default `solve` is also the documented extension point, so this needs a decision about which of
+  the two a method is expected to define.
+- **`should_report!` does not promise every occurrence, and its counters are global.** A repeating
+  diagnosis is reported on occurrences 1, 2, 4, 8, 16 … — occurrence 10 is silent. This is the
+  intended trade (see its docstring) and not a defect, but it *is* a behaviour a caller can be
+  surprised by, and there is no `Options` knob to opt out of it: the only controls are
+  `verbosity = 0` and `reset_warning_counts!`. The counters are also process-global and shared
+  across unrelated solvers, which is deliberate — a per-solver counter would reset on every step of
+  a loop that rebuilds its solver, which is exactly the flood the cap exists for — but it means two
+  independent solves can suppress each other's reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to SimpleSolvers.jl are documented here.
 
 Two defects reported from downstream by
 [GeometricOptimizers.jl](https://github.com/JuliaGNI/GeometricOptimizers.jl), filed there as **D3**
-and **D4**. **Breaking**: a `NonlinearSolver` no longer emits line-search warnings from inside its
-iteration, and `NonlinearSolverStatus` gains a field.
+and **D4**, and the two reporting defects a review of that work turned up. **Breaking**: a
+`NonlinearSolver` no longer emits line-search warnings from inside its iteration,
+`NonlinearSolverStatus` gains a field, and a `LinesearchMethod` now implements `solve_with_status`
+rather than `solve`.
 
 ### `Bisection` no longer reports success when it cannot bracket
 
@@ -91,7 +93,35 @@ caps existed to hold it back.
 - The stagnation and no-progress messages of `nonlinear_solver_warnings` name what the line search
   reported and how often ("the line search reported `LINESEARCH_NO_DESCENT` on 194 of the 200
   step(s)"), so a failed solve names the cause and not only the symptom. A solve that converged
-  despite line-search failures says the same at `verbosity ≥ 2`, as an `@info`.
+  despite line-search failures says the same at `verbosity ≥ 2`, as an `@info` — but only for a
+  failure other than `LINESEARCH_FLOOR`. The last step of a converged solve reaches the merit's
+  round-off floor as a matter of course, so counting it announced that *every* healthy solve "did
+  not go smoothly", which is exactly the noise `linesearch_reason` exists to avoid.
+
+### A line search is implemented by `solve_with_status`, and `solve` is derived
+
+The layering above held for the six built-in methods because each implemented `solve_with_status`
+and defined the same three-line `solve` on top of it. It did not hold for anyone else: the *generic*
+fallback ran the other way — `solve_with_status(ls, α, params) = LinesearchStatus(solve(ls, α,
+params))` — so a third-party method that implemented only `solve` was reached through `solve` from
+inside every iteration of a solve and emitted its messages there, which is the one thing the
+contract in `LinesearchMethod` promises does not happen. And now without a `maxlog` to bound it.
+
+- `solve(ls::Linesearch, α, params)` is **one derived definition** for every method:
+  `solve_with_status`, then `linesearch_warnings`, then `steplength`. The six identical per-method
+  definitions are gone, and so is the "Solve method missing" stub they were dispatched around. `α`
+  is converted to the element type of the `Linesearch`, so `solve(ls, 1)` now works.
+- The generic `solve_with_status` raises instead of deriving a status from `solve`, naming the
+  method and the signature it owes. **Breaking** for a `LinesearchMethod` that implements only
+  `solve`; such a method moves its body into `solve_with_status` and gets `solve` back for free.
+  (GeometricOptimizers' `DecayingStatic` implements both and is unaffected.)
+- `Bisection` reports the merit it *measured* at the step it hands back. Two of its returns — no
+  bracket at all, and a bisection that landed on a non-positive step — filled the `φ` field of the
+  `LinesearchStatus` with `φ(0)`, which `linesearch_exhausted_reason` then interpolated as "the
+  merit changed by 0.0" for a merit nothing had evaluated. For `φ(α) = 1 − α` it reported
+  `α = 1.0, φ(α) = 1.0` where the value is `0.0`. Costs one merit evaluation on a path that has
+  already failed. The `check_anchor` returns still report `φ(0)`, deliberately: the point of an
+  ascent or stationary anchor is that no trial step is worth an evaluation.
 
 ### The solver's own report backs off instead of going silent
 
@@ -1041,23 +1071,6 @@ section and into the release that fixed it.
 
 ### Introduced or left standing by 0.12.0
 
-- **The status can misreport ``\varphi(\alpha)`` when the merit cannot be bracketed at all.** When
-  `bracket_minimum` returns `nothing`, `Bisection`'s `solve_with_status` returns a
-  `LinesearchStatus` whose `φ` field is filled with ``\varphi(0)`` rather than the merit at the
-  ``\alpha`` it hands back. Reproducer: ``\varphi(\alpha) = 1 - \alpha`` descends forever, and the
-  status reports `α = 1.0, φ(α) = 1.0` where the true value is `0.0`. Nothing acts on that field —
-  the outcome is decided before it is filled — but `linesearch_exhausted_reason` interpolates the
-  difference into its message, where it reads as "the merit did not change" when in fact it was
-  never measured. Pre-existing, not a regression. The honest fix is to evaluate the merit at the
-  returned step, which costs one evaluation on a path that is already a failure.
-- **A third-party `LinesearchMethod` still reports from inside a solve.** The layering that 0.12.0
-  established — a program calls `solve_with_status` and gets no messages — holds because all six
-  built-in methods implement `solve_with_status` directly. The generic fallback does not: it calls
-  `solve`, which calls `linesearch_warnings`. So a downstream method that implements only `solve`
-  reinstates the per-iteration message the release removed, and now without a `maxlog` to bound it.
-  Inverting the fallback (have the default `solve` call `solve_with_status`) would fix it, but the
-  default `solve` is also the documented extension point, so this needs a decision about which of
-  the two a method is expected to define.
 - **`should_report!` does not promise every occurrence, and its counters are global.** A repeating
   diagnosis is reported on occurrences 1, 2, 4, 8, 16 … — occurrence 10 is silent. This is the
   intended trade (see its docstring) and not a defect, but it *is* a behaviour a caller can be

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleSolvers"
 uuid = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Michael Kraus"]
 
 [deps]

--- a/src/SimpleSolvers.jl
+++ b/src/SimpleSolvers.jl
@@ -91,8 +91,9 @@ export Backtracking,
 
 # Types and enum values are exported; the predicates and accessors that go with them
 # (`steplength`, `outcome`, `trials`, `issufficient`, `isfloor`, `isbenign`, and the
-# `linesearch_outcomes`/`linesearch_failures`/`linesearch_index` trio that reads the tally a
-# `NonlinearSolverStatus` carries) are not, because they are generic names that a package doing
+# `linesearch_outcomes`/`linesearch_failures`/`linesearch_index`/`dominant_linesearch_outcome`
+# quartet that reads the tally a `NonlinearSolverStatus` carries) are not, because they are
+# generic names that a package doing
 # `using SimpleSolvers` may well want for itself. Reach them as `SimpleSolvers.steplength` and
 # friends.
 export LinesearchStatus, LinesearchOutcome, solve_with_status

--- a/src/SimpleSolvers.jl
+++ b/src/SimpleSolvers.jl
@@ -90,9 +90,11 @@ export Backtracking,
     StrongWolfe
 
 # Types and enum values are exported; the predicates and accessors that go with them
-# (`steplength`, `outcome`, `trials`, `issufficient`, `isfloor`) are not, because they are
-# generic names that a package doing `using SimpleSolvers` may well want for itself. Reach them
-# as `SimpleSolvers.steplength` and friends.
+# (`steplength`, `outcome`, `trials`, `issufficient`, `isfloor`, `isbenign`, and the
+# `linesearch_outcomes`/`linesearch_failures`/`linesearch_index` trio that reads the tally a
+# `NonlinearSolverStatus` carries) are not, because they are generic names that a package doing
+# `using SimpleSolvers` may well want for itself. Reach them as `SimpleSolvers.steplength` and
+# friends.
 export LinesearchStatus, LinesearchOutcome, solve_with_status
 export LINESEARCH_DECREASED,
     LINESEARCH_FLOOR,

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -378,21 +378,12 @@ function backtracking_expand(f, sdc::SufficientDecreaseCondition{T}, φ₀::T, d
 end
 
 """
-    solve(ls::Linesearch{T,<:Backtracking}, α, params)
+    solve_with_status(ls::Linesearch{T,<:Backtracking}, α, params)
 
-Run the backtracking line search from the trial step `α`, report the outcome through
-[`linesearch_warnings`](@ref) and return the accepted step length.
-
-Use [`solve_with_status`](@ref) to obtain the [`LinesearchStatus`](@ref) instead: a caller
-that has to tell "I found a decreasing step" from "the merit is at its round-off floor and
-nothing can decrease it" cannot do so from the step length alone.
+Run the backtracking line search from the trial step `α` and return the
+[`LinesearchStatus`](@ref), emitting no messages. [`solve`](@ref) is this plus the report; see
+[`Backtracking`](@ref).
 """
-function solve(ls::Linesearch{T,<:Backtracking}, α::T, params=NullParameters()) where {T}
-    status = solve_with_status(ls, α, params)
-    linesearch_warnings(status, ls, params)
-    steplength(status)
-end
-
 function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullParameters()) where {T}
     m = method(ls)
     f(a) = value(problem(ls), a, params)

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -219,18 +219,12 @@ _bisect_on(ls::Linesearch{T,<:Bisection}, α₀::T, α₁::T, params) where {T} 
     _bisection_core(problem(ls).D, α₀, α₁, params, config(ls))
 
 """
-    solve(ls::Linesearch{T,<:Bisection}, α, params)
+    solve_with_status(ls::Linesearch{T,<:Bisection}, α, params)
 
-Bisect the derivative of the merit to approximate the line minimiser, report the outcome
-through [`linesearch_warnings`](@ref) and return the step length. See [`Bisection`](@ref) and
-[`solve_with_status`](@ref).
+Bisect the derivative of the merit to approximate the line minimiser and return the
+[`LinesearchStatus`](@ref), emitting no messages. [`solve`](@ref) is this plus the report; see
+[`Bisection`](@ref).
 """
-function solve(ls::Linesearch{T,<:Bisection}, α::T, params=NullParameters()) where {T}
-    status = solve_with_status(ls, α, params)
-    linesearch_warnings(status, ls, params)
-    steplength(status)
-end
-
 function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullParameters()) where {T}
     prob = problem(ls)
     φ₀ = value(prob, zero(T), params)
@@ -256,7 +250,13 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # direction, i.e. for a merit that keeps decreasing. There is then no interval to bisect —
         # but that is a failure to *report*, not a round-off floor: calling it a floor would make
         # the outer iteration count a descending merit as stagnation.
-        isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, φ₀, τ, zero(T))
+        # The merit *is* evaluated at the step handed back, at the cost of one evaluation on a path
+        # that has already failed. Filling `φ` with `φ₀` instead would be a claim that the merit did
+        # not change, which is what `linesearch_exhausted_reason` would then interpolate into its
+        # message — and for a merit that descends forever it is exactly wrong. (The `check_anchor`
+        # returns do fill `φ` with `φ₀`, deliberately: the whole point of an ascent or stationary
+        # anchor is that no trial step is worth an evaluation.)
+        isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, α, params), τ, zero(T))
         _bisect_on(ls, bracket..., params)
     end
     # A spent budget is reported through the status rather than logged here, so that
@@ -277,6 +277,13 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
             n += nretry
             # The retry's own verdict counts too: a retry that could not bracket either must not
             # be allowed to claim the floor below, for exactly the reason the first one may not.
+            # Note that this keeps the *worse* of the two verdicts rather than replacing the first
+            # with the retry's, even though `αres` now comes wholly from the retry. That is
+            # deliberate. The two disagree only when a failed bracket is followed by a converged
+            # retry, which needs φ′ to be inconsistent with φ (a derivative that agrees with the
+            # merit changes sign inside a bracket `bracket_minimum` found, so the first bisection
+            # would have converged) — and `LINESEARCH_EXHAUSTED`, whose reported reason is exactly
+            # "φ′(0) is inconsistent with the merit", is then the better diagnosis of the two.
             bretry === BISECTION_CONVERGED || (bres = bretry)
         end
     end
@@ -291,8 +298,10 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
 
     # Still non-positive: no positive step improves the merit as far as this search can tell.
     # That is the floor, not a non-descent anchor — `check_anchor` established above that the
-    # anchor *does* descend.
-    αres > zero(T) || return LinesearchStatus{T}(α, nodecrease, n, φ₀, d₀, φ₀, τ, zero(T))
+    # anchor *does* descend. As on the no-bracket path above, `φ` is the merit at the step handed
+    # back and not `φ₀`: the caller's `α` is what is returned here, and nothing has measured the
+    # merit there.
+    αres > zero(T) || return LinesearchStatus{T}(α, nodecrease, n, φ₀, d₀, value(prob, α, params), τ, zero(T))
 
     φres = value(prob, αres, params)
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : nodecrease,

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -40,15 +40,19 @@ So the algorithm checks in each step where the sign change occurred and moves th
 
 !!! info
     Bisection can only locate a root if the endpoints straddle a sign change. If the
-    endpoints have the same sign there is no (odd-multiplicity) root in the interval;
-    this arises benignly in the line search once the derivative has flattened at a
-    minimum (both endpoint values ≈ 0 with the same sign). Rather than erroring,
-    `bisection` then returns the endpoint closest to a root (smallest `|f|`) and warns
-    only at high verbosity.
+    endpoints have the same sign there is no (odd-multiplicity) root in the interval.
+    Rather than erroring — a line search must not abort the enclosing solve — `bisection`
+    returns the endpoint closest to a root (smallest `|f|`) and *reports* the failure:
+    `_bisection_core` distinguishes it from a located root with
+    `BISECTION_NOBRACKET`, and `bisection` warns accordingly.
 """
 function bisection(f::Callable, αmin::T, αmax::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
-    α, converged, _ = _bisection_core(f, αmin, αmax, params, config)
-    converged || report_bisection_nonconvergence(α, config)
+    α, outcome, _ = _bisection_core(f, αmin, αmax, params, config)
+    # Each failure gets the wording that fits it. The two are not interchangeable: a spent budget
+    # says "the interval does contain a root, I did not narrow it far enough", a failed bracket says
+    # "there is no root in this interval at all", and only the first is fixed by a larger budget.
+    outcome === BISECTION_EXHAUSTED && report_bisection_nonconvergence(α, config)
+    outcome === BISECTION_NOBRACKET && report_bisection_nobracket(αmin, αmax, α, config)
     α
 end
 
@@ -59,17 +63,49 @@ end
     nothing
 end
 
-@noinline function report_bisection_nobracket(α₀::Number, α₁::Number, y₀::Number, y₁::Number, config::Options)
-    verbosity(config) ≥ 2 && @warn "Bisection bracket [$(α₀), $(α₁)] shows no sign change (f = $(y₀), $(y₁)); returning the endpoint with the smallest |f|."
+@noinline function report_bisection_nobracket(αmin::Number, αmax::Number, α::Number, config::Options)
+    lo, hi = minmax(αmin, αmax)
+    verbosity(config) ≥ 1 && @warn "Bisection bracket [$(lo), $(hi)] shows no sign change, so it contains no root of odd multiplicity and no bisection can locate one in it. Returning the endpoint with the smallest |f|, α = $(α)."
     nothing
 end
 
-# The bisection loop, returning `(α, converged, n)` so a caller can report non-convergence
-# itself instead of having this function log it, and report the evaluation count `n` as the
-# `trials` of a `LinesearchStatus`. The `Bisection` *line search* needs both: it reports through
+@doc raw"""
+    BisectionOutcome
+
+Why `_bisection_core` stopped. This is what lets a caller tell *"found the root"* from
+*"gave up"* — a distinction a `Bool` cannot carry, and whose absence made an unbracketable
+derivative look like a located line minimiser (see [`Bisection`](@ref)).
+
+- `BISECTION_CONVERGED`: a root was located, either because ``|f(\alpha)| \leq`` `f_abstol` or
+  because the bracket collapsed to `x_suctol`.
+- `BISECTION_NOBRACKET`: the endpoint values share a sign, so the interval contains no root of
+  odd multiplicity and bisection cannot start. The endpoint with the smallest ``|f|`` is returned,
+  but it is *not* a root — this is a failure to report, not a result.
+- `BISECTION_EXHAUSTED`: the `linesearch_max_iterations` budget of [`Options`](@ref) was spent
+  with the interval still straddling a sign change. Unlike `BISECTION_NOBRACKET` there *is* a root
+  in the interval, so a larger budget would find it; the best estimate so far is returned.
+
+This is internal: it is the return type of a private function, like the `Symbol` that
+`_triple_point_core` reports. Callers of a *line search* see a
+[`LinesearchOutcome`](@ref) instead.
+"""
+@enum BisectionOutcome::Int8 begin
+    BISECTION_CONVERGED
+    BISECTION_NOBRACKET
+    BISECTION_EXHAUSTED
+end
+
+# The bisection loop, returning `(α, outcome, n)` so a caller can report the failure itself
+# instead of having this function log it, and report the evaluation count `n` as the `trials` of
+# a `LinesearchStatus`. The `Bisection` *line search* needs all three: it reports through
 # `linesearch_warnings` like every other line search, so a message emitted from here would
 # duplicate it and bypass the shared verbosity policy. The public `bisection` above keeps
 # warning, since it is also used standalone as a root finder.
+#
+# The outcome is a `BisectionOutcome` and not a `Bool` because "no sign change" used to be folded
+# into `converged = true` — the endpoint with the smallest |f| was returned and *claimed* as a
+# root. That claim then propagated into `LINESEARCH_FLOOR`, which asserts that no step can decrease
+# the merit; a failed bracket establishes nothing of the kind. See `solve_with_status` below.
 function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Options) where {T<:Number}
     n = 0
     R = float(T)
@@ -88,11 +124,10 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
     y = zero(y₀)
 
     if y₀ * y₁ > zero(y₀)
-        report_bisection_nobracket(α₀, α₁, y₀, y₁, config)
-        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), true, n
+        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), BISECTION_NOBRACKET, n
     end
 
-    converged = false
+    outcome = BISECTION_EXHAUSTED
     for _ in 1:config.linesearch_max_iterations
         α = (α₀ + α₁) / 2
         y = f(α, params)
@@ -100,7 +135,7 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
 
         # break if y is close to zero.
         if ≈(y, zero(y); atol=config.f_abstol)
-            converged = true
+            outcome = BISECTION_CONVERGED
             break
         end
 
@@ -113,12 +148,12 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
         end
 
         if isapprox(α₁ - α₀, zero(α), atol=config.x_suctol * max(abs(α₀), abs(α₁)))
-            converged = true
+            outcome = BISECTION_CONVERGED
             break
         end
     end
 
-    α, converged, n
+    α, outcome, n
 end
 
 function bisection(f::Callable, α::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
@@ -154,6 +189,23 @@ via one extra derivative evaluation (see issue #164):
 
 This keeps the safe ``\\alpha = 0`` anchor while letting the caller's `α` set the
 search scale and, when it overshoots, serve directly as the upper bracket bound.
+
+## A bracket that fails is never a floor
+
+Bisection drives on the *sign* of ``\\varphi'``, so it can only work on an interval whose
+endpoints straddle a sign change. When [`bracket_minimum`](@ref) hands it an interval that
+brackets a minimum in *value* but over which ``\\varphi'`` keeps its sign — a non-smooth or
+noisy merit, or a derivative inconsistent with it — there is nothing to bisect and
+`_bisection_core` reports `BISECTION_NOBRACKET`.
+
+That case used to be folded into "converged", so the endpoint with the smallest ``|\\varphi'|``
+was *claimed* as the line minimiser and, when it did not improve the merit, classified as
+`LINESEARCH_FLOOR` — which asserts that **no** line search can make progress along this
+direction and makes the outer iteration count the step towards `max_stalls`. A failed bracket
+establishes nothing of the kind. So the outcome is now classified by the merit alone:
+`LINESEARCH_DECREASED` when the returned step still beats ``\\varphi(0)`` by more than
+``\\tau``, and `LINESEARCH_EXHAUSTED` when it does not. `LINESEARCH_FLOOR` is reachable only
+from a bisection that actually converged.
 """
 struct Bisection{T} <: LinesearchMethod{T} end
 
@@ -192,7 +244,7 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # Lower-anchor the bracket at α = 0, where a genuine descent direction has a decreasing
     # merit (φ′(0) < 0, now guaranteed by `check_anchor`). Probe the caller's trial step α (one
     # extra derivative evaluation) to decide how to fold it in; see the docstring and #164.
-    αres, converged, n = if α > zero(T) && derivative(prob, α, params) ≥ zero(T)
+    αres, bres, n = if α > zero(T) && derivative(prob, α, params) ≥ zero(T)
         # α overshot the minimum: [0, α] already brackets the stationary point.
         _bisect_on(ls, zero(T), α, params)
     else
@@ -207,9 +259,12 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, φ₀, τ, zero(T))
         _bisect_on(ls, bracket..., params)
     end
-    # Non-convergence of the bisection is reported through the status rather than logged here,
-    # so that `linesearch_warnings` remains the only place a line search emits messages.
-    converged || return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, n, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
+    # A spent budget is reported through the status rather than logged here, so that
+    # `linesearch_warnings` remains the only place a line search emits messages. Note that this
+    # is *only* the budget case: a failed bracket carries on below, because the endpoint it
+    # returns may still improve the merit and there is no reason to throw that away.
+    bres === BISECTION_EXHAUSTED &&
+        return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, n, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
 
     # `bracket_minimum` flips direction when the merit rises to the right of its start, so the
     # bracket — and hence the bisected result — can lie left of zero. A negative step is not a
@@ -218,17 +273,29 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     if αres ≤ zero(T)
         bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s))
         if !isnothing(bracket)
-            αres, _, nretry = _bisect_on(ls, bracket..., params)
+            αres, bretry, nretry = _bisect_on(ls, bracket..., params)
             n += nretry
+            # The retry's own verdict counts too: a retry that could not bracket either must not
+            # be allowed to claim the floor below, for exactly the reason the first one may not.
+            bretry === BISECTION_CONVERGED || (bres = bretry)
         end
     end
+
+    # A bisection that could not bracket has located nothing, so the only honest thing left to say
+    # about its endpoint is what the *merit* says about it. `LINESEARCH_FLOOR` — "no step can
+    # decrease φ, so no line search can help here" — is a claim only a converged bisection has
+    # earned; a failed bracket that did not improve the merit is `LINESEARCH_EXHAUSTED`, which says
+    # no acceptable step was found while leaving open that one exists.
+    bracketed = bres === BISECTION_CONVERGED
+    nodecrease = bracketed ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
+
     # Still non-positive: no positive step improves the merit as far as this search can tell.
     # That is the floor, not a non-descent anchor — `check_anchor` established above that the
     # anchor *does* descend.
-    αres > zero(T) || return LinesearchStatus{T}(α, LINESEARCH_FLOOR, n, φ₀, d₀, φ₀, τ, zero(T))
+    αres > zero(T) || return LinesearchStatus{T}(α, nodecrease, n, φ₀, d₀, φ₀, τ, zero(T))
 
     φres = value(prob, αres, params)
-    LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
+    LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : nodecrease,
         n, φ₀, d₀, φres, τ, zero(T))
 end
 

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -25,8 +25,11 @@ Every method reached through [`solve`](@ref) or [`solve_with_status`](@ref) guar
    outer iterate (`x .+= 0 .* d`), and never a negative step: ``\\alpha`` scales a direction
    that has already been chosen, so its sign is not the line search's to decide.
 3. **It reports through [`linesearch_warnings`](@ref) only** — one message site and one
-   verbosity policy for all methods (genuine failure at `verbosity ≥ 1`, rate limited; the
-   benign round-off-floor and stationary outcomes at `≥ 2`).
+   verbosity policy for all methods (genuine failure at `verbosity ≥ 1`; the benign
+   round-off-floor and stationary outcomes at `≥ 2`). And it reports there only when the *user*
+   called it: a program calls [`solve_with_status`](@ref), acts on the
+   [`LinesearchStatus`](@ref) and sees no messages at all. A [`NonlinearSolver`](@ref) is such a
+   program — see [`record_linesearch!`](@ref).
 4. **A non-finite or ascending anchor is reported, not assumed away** — see
    [`check_anchor`](@ref).
 5. **It terminates in a bounded number of merit evaluations, independently of the merit's

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -29,7 +29,9 @@ Every method reached through [`solve`](@ref) or [`solve_with_status`](@ref) guar
    round-off-floor and stationary outcomes at `≥ 2`). And it reports there only when the *user*
    called it: a program calls [`solve_with_status`](@ref), acts on the
    [`LinesearchStatus`](@ref) and sees no messages at all. A [`NonlinearSolver`](@ref) is such a
-   program — see [`record_linesearch!`](@ref).
+   program — see [`record_linesearch!`](@ref). This is structural rather than a convention a
+   method has to keep: a method implements `solve_with_status`, and [`solve`](@ref) is derived
+   from it once, for all methods, as that call plus the report.
 4. **A non-finite or ascending anchor is reported, not assumed away** — see
    [`check_anchor`](@ref).
 5. **It terminates in a bounded number of merit evaluations, independently of the merit's
@@ -137,12 +139,35 @@ method(s::Linesearch) = s.method
 """
     solve(linesearch, α, params=NullParameters())
 
-Solve the [`LinesearchProblem`](@ref) (contained in [`Linesearch`](@ref)) starting at `α`.
+Solve the [`LinesearchProblem`](@ref) (contained in [`Linesearch`](@ref)) starting at `α`,
+report the outcome through [`linesearch_warnings`](@ref) and return the step length.
 
 The argument `params` needs to be of an appropriate form expected by the respective [`LinesearchProblem`](@ref).
 
+Use [`solve_with_status`](@ref) to obtain the [`LinesearchStatus`](@ref) instead: a caller that
+has to tell "I found a decreasing step" from "the merit is at its round-off floor and nothing
+can decrease it" cannot do so from the step length alone — and it is the call that emits no
+messages, which is what a *program* wants (see [`record_linesearch!`](@ref)).
+
 See [`linesearch_problem`](@ref).
+
+# Implementation
+
+This is *derived*, and it is the only definition: a [`LinesearchMethod`](@ref) implements
+[`solve_with_status`](@ref), and `solve` is that plus the report. It used to be the other way
+round — every method defined this same three-line body, and a method that defined only `solve`
+got `solve_with_status` from a fallback that called it. That fallback made the layering of the
+contract unenforceable: a third-party method reached through `solve` emits its messages from
+wherever it is called, including from inside every iteration of a [`NonlinearSolver`](@ref),
+which is precisely what a program must not see. With the direction reversed, there is no path
+by which the package calls a method's `solve` during a solve, so the guarantee holds by
+construction rather than by convention.
+
+`α` is converted to the element type of the `Linesearch` here, as the problem-taking method
+above does, so `solve(ls, 1)` on a `Linesearch{Float64}` means what it looks like it means.
 """
-function solve(::Linesearch{T,MET}, α, params=NullParameters()) where {T, MET<:LinesearchMethod{T}}
-    error("Solve method missing for $(MET).")
+function solve(ls::Linesearch{T}, α, params=NullParameters()) where {T}
+    status = solve_with_status(ls, T(α), params)
+    linesearch_warnings(status, ls, params)
+    steplength(status)
 end

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -24,8 +24,9 @@ returned by [`solve_with_status`](@ref).
   finite. No ``\alpha`` can satisfy the sufficient decrease condition.
 - `LINESEARCH_STATIONARY`: ``\varphi'(0) = 0``, e.g. a vanishing direction at an exact root.
   Benign — there is nothing to search for.
-- `LINESEARCH_UNKNOWN`: the method does not report an outcome (the generic fallback of
-  [`solve_with_status`](@ref)).
+- `LINESEARCH_UNKNOWN`: the method does not report an outcome — [`Static`](@ref), which
+  evaluates no merit and so has established nothing, and any third-party method that chooses not
+  to report one.
 """
 @enum LinesearchOutcome::Int8 begin
     LINESEARCH_DECREASED
@@ -122,8 +123,9 @@ end
     LinesearchStatus(α, outcome=LINESEARCH_UNKNOWN)
 
 Construct a [`LinesearchStatus`](@ref) that carries only the step length and the
-[`LinesearchOutcome`](@ref); the remaining diagnostics are filled with `NaN`/zero. Used by
-the generic fallback of [`solve_with_status`](@ref) for methods that do not report them.
+[`LinesearchOutcome`](@ref); the remaining diagnostics are filled with `NaN`/zero. For a method
+that does not measure them — [`Static`](@ref), or a third-party method whose
+[`solve_with_status`](@ref) has nothing more to say.
 """
 LinesearchStatus(α::T, outcome::LinesearchOutcome=LINESEARCH_UNKNOWN) where {T} =
     LinesearchStatus{T}(α, outcome, 0, T(NaN), T(NaN), T(NaN), zero(T), zero(T))
@@ -217,19 +219,36 @@ function check_anchor(φ₀::T, d₀::T, α::T) where {T}
     end
 end
 
-"""
+@doc raw"""
     solve_with_status(ls, α, params=NullParameters())
 
 Like [`solve`](@ref), but return a [`LinesearchStatus`](@ref) — the step length *plus* the
 reason the search stopped — and emit no log messages. Use [`linesearch_warnings`](@ref) to
-report the status.
+report the status; that is all [`solve`](@ref) adds.
 
-Only [`Backtracking`](@ref) reports a genuine [`LinesearchOutcome`](@ref); the generic
-fallback calls [`solve`](@ref) and reports `LINESEARCH_UNKNOWN`, so a caller may use
-`solve_with_status` uniformly for every [`LinesearchMethod`](@ref).
+This is what a *program* calls, and it is the [`LinesearchMethod`](@ref) extension point: every
+built-in method (all six of [`Backtracking`](@ref), [`StrongWolfe`](@ref), [`Bisection`](@ref),
+[`Quadratic`](@ref), [`BierlaireQuadratic`](@ref) and [`Static`](@ref)) implements *this*, and
+gets [`solve`](@ref) derived from it. A method that reports no outcome of its own returns
+`LINESEARCH_UNKNOWN`, as [`Static`](@ref) does.
+
+!!! warning "A method must implement this"
+    There is no fallback: the generic method below raises rather than deriving a status from
+    [`solve`](@ref). It used to do exactly that, and the derivation ran the wrong way — a method
+    that defined only `solve` was then reached *through* `solve` from inside every iteration of a
+    [`NonlinearSolver`](@ref), and emitted its messages there, which is the one thing the contract
+    in [`LinesearchMethod`](@ref) promises does not happen. Deriving `solve` from this instead
+    makes that promise structural. A third-party method that defines only `solve` therefore has to
+    move its body here; the boilerplate it used to carry (`solve_with_status`, then
+    [`linesearch_warnings`](@ref), then [`steplength`](@ref)) is what it gets for free in exchange.
 """
-solve_with_status(ls::Linesearch{T}, α::T, params=NullParameters()) where {T} =
-    LinesearchStatus(solve(ls, α, params))
+function solve_with_status(ls::Linesearch{T}, α::T, params=NullParameters()) where {T}
+    throw(ArgumentError("$(nameof(typeof(method(ls)))) does not implement `solve_with_status`, " *
+                        "which is what a LinesearchMethod implements; `solve` is derived from it. " *
+                        "Define `solve_with_status(::Linesearch{T,<:$(nameof(typeof(method(ls))))}, α::T, params)` " *
+                        "returning a LinesearchStatus (use `LinesearchStatus(α, LINESEARCH_UNKNOWN)` " *
+                        "if the method has no outcome to report)."))
+end
 
 """
     curvature_diagnostic(status, ls, params)
@@ -320,12 +339,13 @@ Emit the messages for a [`LinesearchStatus`](@ref); the reporting half of
 # Implementation
 
 This is a function barrier, and its signature is what makes it one. [`linesearch_warnings`](@ref)
-is called from [`solver_step!`](@ref) on every iteration of every solve, and takes a
-[`Linesearch`](@ref) — which carries the closure types of its [`LinesearchProblem`](@ref) — and a
-`NamedTuple` of parameters, so it is specialized once per *problem* a solver is built for. A
-message in its body is specialized with it, and all of the `Base.CoreLogging` and
-string-interpolation code that `@warn` expands to is re-inferred and re-codegen'd for each one,
-which on a caller that builds one solver per tableau dominates the cost of the whole solve.
+is called from [`solve`](@ref) — every direct call to a line search, and nothing else since
+[`solver_step!`](@ref) stopped reporting per iteration — and takes a [`Linesearch`](@ref), which
+carries the closure types of its [`LinesearchProblem`](@ref), and a `NamedTuple` of parameters. So
+it is specialized once per *problem* a line search is built for. A message in its body is
+specialized with it, and all of the `Base.CoreLogging` and string-interpolation code that `@warn`
+expands to is re-inferred and re-codegen'd for each one, which on a caller that builds one line
+search per tableau dominates the cost of the calls themselves.
 
 Taking `name` and `config`, and nothing whose type can vary per solver, bounds the specializations
 of this function to one per element-type combination for the whole session.

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -36,6 +36,44 @@ returned by [`solve_with_status`](@ref).
     LINESEARCH_UNKNOWN
 end
 
+"""
+    const NLINESEARCH_OUTCOMES
+
+The number of [`LinesearchOutcome`](@ref)s, i.e. the length of the tally a
+[`NonlinearSolverState`](@ref) keeps of the outcomes its line search reported (see
+[`record_linesearch!`](@ref)). A `const` rather than `length(instances(LinesearchOutcome))` at
+each use, because it is a type parameter of that tally's `MVector` and so has to be known to the
+compiler.
+"""
+const NLINESEARCH_OUTCOMES = length(instances(LinesearchOutcome))
+
+"""
+    linesearch_index(oc)
+
+The index of the [`LinesearchOutcome`](@ref) `oc` in a tally of length
+[`NLINESEARCH_OUTCOMES`](@ref) — the enum's value plus one, since the enum starts at zero and
+Julia indexes from one. See [`record_linesearch!`](@ref) and
+[`linesearch_outcomes`](@ref).
+"""
+linesearch_index(oc::LinesearchOutcome) = Int(oc) + 1
+
+"""
+    isbenign(oc)
+
+`true` for the [`LinesearchOutcome`](@ref)s that report no failure: `LINESEARCH_DECREASED` (a
+genuine decrease), `LINESEARCH_STATIONARY` (nothing to search for) and `LINESEARCH_UNKNOWN` (the
+method does not report one). The remaining three — `LINESEARCH_FLOOR`, `LINESEARCH_EXHAUSTED`
+and `LINESEARCH_NO_DESCENT` — are what [`linesearch_failures`](@ref) counts and what
+[`linesearch_warnings`](@ref) reports on.
+
+`LINESEARCH_FLOOR` counts as a failure here even though it is the *expected* final state of a
+converged solve, because whether it matters is the outer iteration's call and this is how the
+outer iteration is told: the tally is read by [`nonlinear_solver_warnings`](@ref), which names it
+only for a solve that did *not* converge.
+"""
+isbenign(oc::LinesearchOutcome) =
+    oc === LINESEARCH_DECREASED || oc === LINESEARCH_STATIONARY || oc === LINESEARCH_UNKNOWN
+
 @doc raw"""
     LinesearchStatus{T}
 
@@ -201,6 +239,11 @@ Method-specific extra diagnostic emitted by [`linesearch_warnings`](@ref) at
 [`CurvatureCondition`](@ref), which costs a derivative evaluation — a full
 [`Jacobian`](@ref) for the line search problem of a [`NonlinearSolver`](@ref), hence the
 verbosity gate.
+
+Reached only from a direct [`solve`](@ref) call, since that is the only caller of
+[`linesearch_warnings`](@ref). A `NonlinearSolver` at `verbosity = 2` therefore no longer pays for
+this once per iteration; to see it for a step of a solve, call the line search on that step's
+problem directly.
 """
 curvature_diagnostic(::LinesearchStatus, ::Linesearch, params) = nothing
 
@@ -209,28 +252,38 @@ curvature_diagnostic(::LinesearchStatus, ::Linesearch, params) = nothing
 
 Report a [`LinesearchStatus`](@ref) obtained from [`solve_with_status`](@ref). Compare this
 to [`nonlinear_solver_warnings`](@ref). This is the *only* place where a line search emits
-log messages, so [`solve`](@ref) and [`solver_step!`](@ref) report identically.
+log messages, so every [`LinesearchMethod`](@ref) reports identically.
 
-Two things keep this quiet in normal use. `LINESEARCH_FLOOR` and `LINESEARCH_STATIONARY` are
-reported only at `verbosity ≥ 2`, because both are the *expected* final state of a converged
-solve — a residual that cannot be improved because it is already as small as the arithmetic
-allows. And the remaining outcomes are rate limited with `maxlog`, because a solve that cannot
-make progress asks the line search for an impossible decrease at every one of its iterations,
-which an unconditional warning turns into thousands of identical messages.
+`LINESEARCH_FLOOR` and `LINESEARCH_STATIONARY` are reported only at `verbosity ≥ 2`, because both
+are the *expected* final state of a converged solve — a residual that cannot be improved because it
+is already as small as the arithmetic allows.
 
-!!! warning "`maxlog` is per session, not per solve"
-    Julia keys `maxlog` on the *source location* of the `@warn`, so the caps in
-    [`report_linesearch_status`](@ref) are process-global and are **not** reset between `solve!`
-    calls — one source location for every solver in the session. Once a message has appeared its
-    quota is spent for the lifetime of the session, including for later solves of entirely
-    different problems. That is deliberate — a time-stepping loop calling `solve!` once per step
-    is precisely the case these caps exist for — but it does mean a genuinely new line-search
-    failure late in a long run can go unreported. Raise `verbosity` to 2 and re-run when
-    diagnosing one.
+!!! info "Who this is for"
+    This function is reached from [`solve`](@ref) and from nowhere else, which is what makes it
+    safe for it to report unconditionally. A line search has two callers and owes them different
+    things:
+
+    - a **program** — a [`NonlinearSolver`](@ref), an optimizer — calls
+      [`solve_with_status`](@ref), gets a [`LinesearchStatus`](@ref) it can act on, and gets no
+      messages. It is not the user, and a diagnosis it can read is worth more to it than one it
+      would have to scrape out of a log. What it does with the status is its own business:
+      [`solver_step!`](@ref) tallies it (see [`record_linesearch!`](@ref)) and lets
+      [`nonlinear_solver_warnings`](@ref) explain the solve once, at the end.
+    - a **user** calls `solve`, which is this path, and a single call yields a single message.
+
+    So there is nothing here to rate limit, and none of these messages carries a `maxlog`. They
+    used to, because [`solver_step!`](@ref) called this function once per iteration and a solve
+    that cannot make progress asks the line search for an impossible decrease at *every* one of
+    them — thousands of identical messages. But `maxlog` is keyed on the source location of the
+    `@warn`, so the caps were process-global and were never reset between `solve!` calls: once
+    spent, they were spent for the rest of the session, and a genuine line-search failure in a
+    later solve of a long run was silent. Not reporting from inside the loop removes the flood at
+    its source, so the caps are gone and nothing goes permanently silent.
 
 Whether an irreducible merit actually *matters* is the outer iteration's call, and
 [`nonlinear_solver_warnings`](@ref) makes it: it reports stagnation once, naming the residual
-that was achieved and the tolerance that was requested.
+that was achieved, the tolerance that was requested, and what the line search reported along the
+way.
 
 The messages themselves live in [`report_linesearch_status`](@ref) rather than here, which is a
 compile-time rather than a stylistic decision — see its docstring before merging them back.
@@ -262,7 +315,7 @@ end
     report_linesearch_status(status, name, config)
 
 Emit the messages for a [`LinesearchStatus`](@ref); the reporting half of
-[`linesearch_warnings`](@ref), whose docstring documents the verbosity and `maxlog` policy.
+[`linesearch_warnings`](@ref), whose docstring documents the verbosity policy and who it is for.
 
 # Implementation
 
@@ -310,13 +363,13 @@ written the same way.
         # `αmin` is a `Backtracking` quantity (zero means "not applicable", see `LinesearchStatus`),
         # so the clause naming it is only included when there is a value to name. It sits inside the
         # message rather than in a temporary before it: Julia evaluates a `@warn` message only once
-        # the verbosity gate and `maxlog` have both passed, and a stalling solve reports the same
-        # outcome on every iteration, so a temporary would be built and discarded each time.
-        verbose ≥ 2 && @warn "$(name) line search: no trial step changed the merit by more than the round-off resolution τ = $(status.τ) in $(trials(status)) trial step(s). φ(0) = $(status.φ₀) has reached its round-off floor, so no step can decrease it$(iszero(status.αmin) ? "" : " (the smallest informative step is αmin = $(status.αmin))"). Returning α = $(steplength(status)). Check whether the requested residual tolerance is attainable in this precision." maxlog = 1
+        # the verbosity gate has passed, and the overwhelmingly common case is a caller running at
+        # a verbosity that discards it, so a temporary would be built and thrown away every time.
+        verbose ≥ 2 && @warn "$(name) line search: no trial step changed the merit by more than the round-off resolution τ = $(status.τ) in $(trials(status)) trial step(s). φ(0) = $(status.φ₀) has reached its round-off floor, so no step can decrease it$(iszero(status.αmin) ? "" : " (the smallest informative step is αmin = $(status.αmin))"). Returning α = $(steplength(status)). Check whether the requested residual tolerance is attainable in this precision."
     elseif oc === LINESEARCH_EXHAUSTED
-        verbose ≥ 1 && @warn "$(name) line search: no step satisfied the sufficient decrease condition in $(trials(status)) trial step(s) — $(linesearch_exhausted_reason(status, config)). Returning α = $(steplength(status))." maxlog = 3
+        verbose ≥ 1 && @warn "$(name) line search: no step satisfied the sufficient decrease condition in $(trials(status)) trial step(s) — $(linesearch_exhausted_reason(status, config)). Returning α = $(steplength(status))."
     elseif oc === LINESEARCH_NO_DESCENT
-        verbose ≥ 1 && @warn "$(name) line search: φ'(0) = $(status.d₀) (with φ(0) = $(status.φ₀)) is not a descent direction, so no α can satisfy the sufficient decrease condition. Returning α = $(steplength(status))." maxlog = 3
+        verbose ≥ 1 && @warn "$(name) line search: φ'(0) = $(status.d₀) (with φ(0) = $(status.φ₀)) is not a descent direction, so no α can satisfy the sufficient decrease condition. Returning α = $(steplength(status))."
     elseif oc === LINESEARCH_STATIONARY
         verbose ≥ 2 && @warn "$(name) line search: φ'(0) = 0, the merit is stationary at α = 0. Returning α = $(steplength(status))."
     end

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -49,18 +49,12 @@ end
 Quadratic(::Type{T}, ::SolverMethod) where {T} = Quadratic(T)
 
 """
-    solve(ls::Linesearch{T,<:Quadratic}, α, params)
+    solve_with_status(ls::Linesearch{T,<:Quadratic}, α, params)
 
-Fit successive quadratics to approximate the line minimiser, report the outcome through
-[`linesearch_warnings`](@ref) and return the step length. See [`Quadratic`](@ref) and
-[`solve_with_status`](@ref).
+Fit successive quadratics to approximate the line minimiser and return the
+[`LinesearchStatus`](@ref), emitting no messages. [`solve`](@ref) is this plus the report; see
+[`Quadratic`](@ref).
 """
-function solve(ls::Linesearch{T,<:Quadratic}, α::T, params=NullParameters()) where {T}
-    status = solve_with_status(ls, α, params)
-    linesearch_warnings(status, ls, params)
-    steplength(status)
-end
-
 function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters()) where {T}
     φ₀ = value(problem(ls), zero(T), params)
     d₀ = derivative(problem(ls), zero(T), params)

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -153,18 +153,12 @@ function _bierlaire_fit(ls::Linesearch{T,<:BierlaireQuadratic}, a::T, b::T, c::T
 end
 
 """
-    solve(ls::Linesearch{T,<:BierlaireQuadratic}, α, params)
+    solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α, params)
 
-Fit successive quadratics through three bracketing points to approximate the line minimiser,
-report the outcome through [`linesearch_warnings`](@ref) and return the step length. See
-[`BierlaireQuadratic`](@ref) and [`solve_with_status`](@ref).
+Fit successive quadratics through three bracketing points to approximate the line minimiser and
+return the [`LinesearchStatus`](@ref), emitting no messages. [`solve`](@ref) is this plus the
+report; see [`BierlaireQuadratic`](@ref).
 """
-function solve(ls::Linesearch{T,<:BierlaireQuadratic}, α::T, params=NullParameters()) where {T}
-    status = solve_with_status(ls, α, params)
-    linesearch_warnings(status, ls, params)
-    steplength(status)
-end
-
 function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, params=NullParameters()) where {T}
     prob = problem(ls)
     φ₀ = value(prob, zero(T), params)

--- a/src/linesearch/static.jl
+++ b/src/linesearch/static.jl
@@ -25,15 +25,11 @@ end
 Static(::Type{T}=Float64; α=one(T)) where {T} = Static{T}(α)
 Static(::Type{T}, ::SolverMethod) where {T} = Static(T)
 
-function solve(ls::Linesearch{T,<:Static}, α::T, params=NullParameters()) where {T}
-    method(ls).α
-end
-
 # `Static` ignores the caller's trial step and cannot fail, so it has nothing to report; the
 # outcome is `LINESEARCH_UNKNOWN` rather than `LINESEARCH_DECREASED` because no merit is ever
-# evaluated and hence no decrease has been established. It implements `solve_with_status`
-# anyway so that every built-in method goes through the same entry point (see
-# `solve_with_status`).
+# evaluated and hence no decrease has been established. `linesearch_warnings` passes
+# `LINESEARCH_UNKNOWN` over in silence, so the derived `solve` returns `method(ls).α` and says
+# nothing — which is what the hand-written `solve` this replaced did.
 solve_with_status(ls::Linesearch{T,<:Static}, α::T, params=NullParameters()) where {T} =
     LinesearchStatus(method(ls).α, LINESEARCH_UNKNOWN)
 

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -120,18 +120,12 @@ function _wolfe_zoom(ls::Linesearch{T}, φ, dφ, sdc::SufficientDecreaseConditio
 end
 
 """
-    solve(ls::Linesearch{T,<:StrongWolfe}, α, params)
+    solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α, params)
 
-Run the strong-Wolfe bracketing line search starting from the trial step `α`, report the
-outcome through [`linesearch_warnings`](@ref) and return the accepted step length.
-See [`StrongWolfe`](@ref) and [`solve_with_status`](@ref).
+Run the strong-Wolfe bracketing line search from the trial step `α` and return the
+[`LinesearchStatus`](@ref), emitting no messages. [`solve`](@ref) is this plus the report; see
+[`StrongWolfe`](@ref).
 """
-function solve(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) where {T}
-    status = solve_with_status(ls, α, params)
-    linesearch_warnings(status, ls, params)
-    steplength(status)
-end
-
 function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullParameters()) where {T}
     m = method(ls)
     c₁ = m.c₁

--- a/src/nonlinear/nonlinear_solver.jl
+++ b/src/nonlinear/nonlinear_solver.jl
@@ -256,7 +256,11 @@ function solver_step!(x::AbstractVector{T}, s::NonlinearSolver{T}, state::Nonlin
     # just evaluated at the current iterate — see `linesearch_problem`.
     lsparams = (x=x, parameters=params, φ₀=L2norm(value(state)))
     lsstatus = solve_with_status(linesearch(s), one(T), lsparams)
-    linesearch_warnings(lsstatus, linesearch(s), lsparams)
+    # `solve_with_status` and not `solve`: a line search reports to its *caller*, and only a caller
+    # who invoked it directly is a user. So nothing is logged from inside this loop — the outcome is
+    # tallied instead, and the solve explains itself once, at the end, through
+    # `nonlinear_solver_warnings`. See `record_linesearch!` for why that is the right layer.
+    record_linesearch!(state, outcome(lsstatus))
 
     # A line search that reports the merit's round-off floor or a non-descent anchor knows the
     # iteration cannot make progress along this direction, one iteration before the step-based

--- a/src/nonlinear/nonlinear_solver_state.jl
+++ b/src/nonlinear/nonlinear_solver_state.jl
@@ -10,7 +10,7 @@ The `NonlinearSolverState` to be used together with a [`NonlinearSolver`](@ref).
 
 ```jldoctest; setup = :(using SimpleSolvers)
 julia> state = NonlinearSolverState(zeros(3))
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], NaN, 0, false, NaN, 0)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN], NaN, 0, false, NaN, 0, [0, 0, 0, 0, 0, 0])
 ```
 """
 mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T}} <: AbstractSolverState
@@ -39,6 +39,10 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
                                # that, exactly like `stalls`, it stays at zero for an iteration
                                # that never records.
 
+    ls_outcomes::MVector{NLINESEARCH_OUTCOMES,Int}  # how often each `LinesearchOutcome` was
+                               # reported during this solve, indexed by `Int(oc) + 1`; maintained
+                               # by `record_linesearch!` and read by `NonlinearSolverStatus`
+
     function NonlinearSolverState(X::AbstractVector{T}, Y::AbstractVector{T}=X) where {T}
         x = zero(X)
         x̄ = zero(X)
@@ -50,7 +54,8 @@ mutable struct NonlinearSolverState{T,XT<:AbstractVector{T},YT<:AbstractVector{T
         y .= T(NaN)
         ȳ .= T(NaN)
 
-        new{T,typeof(x),typeof(y)}(0, x, x̄, y, ȳ, T(NaN), 0, false, T(NaN), 0)
+        new{T,typeof(x),typeof(y)}(0, x, x̄, y, ȳ, T(NaN), 0, false, T(NaN), 0,
+            zeros(MVector{NLINESEARCH_OUTCOMES,Int}))
     end
 end
 
@@ -105,6 +110,10 @@ function initialize!(state::NonlinearSolverState{T}, x::AbstractVector{T}, y::Ab
     # where it started, so `iterations_since_progress` counts from iteration 0.
     state.rf_ref = state.r₀
     state.iters_since_progress = 0
+    # Per solve, exactly like `stalls`: what the line search reported during the *previous* solve
+    # says nothing about this one, and `nonlinear_solver_warnings` reads the tally to explain the
+    # solve that has just finished.
+    fill!(state.ls_outcomes, 0)
 end
 
 """
@@ -173,6 +182,53 @@ function record_progress!(state::NonlinearSolverState, config::Options, rfₐ::N
 end
 
 """
+    linesearch_outcomes(state)
+
+Return the tally of [`LinesearchOutcome`](@ref)s reported during this solve, indexed by
+[`linesearch_index`](@ref). Maintained by [`record_linesearch!`](@ref) and reset per solve by
+[`initialize!`](@ref); [`NonlinearSolverStatus`](@ref) carries a copy of it out to the caller.
+"""
+linesearch_outcomes(state::NonlinearSolverState) = state.ls_outcomes
+
+@doc raw"""
+    record_linesearch!(state, oc)
+
+Count one [`LinesearchOutcome`](@ref) `oc` into the tally of
+`state::`[`NonlinearSolverState`](@ref). Called once per [`solver_step!`](@ref) that consults a
+line search, and — like [`record_stall!`](@ref) and [`record_progress!`](@ref) — a measurement
+rather than a predicate, so it must be called exactly once per such step.
+
+This is the channel by which a line-search failure reaches the user. A line search reports to its
+*caller* through the [`LinesearchStatus`](@ref) that [`solve_with_status`](@ref) returns and emits
+nothing; only a caller who invoked [`solve`](@ref) directly is a user, and only that path goes
+through [`linesearch_warnings`](@ref). A [`NonlinearSolver`](@ref) is not that caller — it
+*consumes* the status ([`flag_stall!`](@ref), and it declines to step along a
+`LINESEARCH_NO_DESCENT` direction) and accumulates it here, so that the solve explains itself once,
+at the end, through [`nonlinear_solver_warnings`](@ref), instead of once per iteration.
+
+That is not a cosmetic difference. A solve that cannot make progress asks the line search for an
+impossible decrease at *every* one of its iterations, so reporting per iteration turned a single
+diagnosis into thousands of identical messages — which is what the `maxlog` caps used to hold back,
+at the price of being keyed on source location and therefore process-global: once spent, they
+stayed spent for the rest of the session, and a genuine failure in a later solve was silent. Not
+reporting from inside the loop removes the flood at its source, so no cap is needed and nothing
+goes permanently silent.
+"""
+function record_linesearch!(state::NonlinearSolverState, oc::LinesearchOutcome)
+    state.ls_outcomes[linesearch_index(oc)] += 1
+    state
+end
+
+"""
+    linesearch_failures(state)
+
+The number of steps in this solve whose line search reported a failure, i.e. the tally of
+[`linesearch_outcomes`](@ref) summed over the outcomes that are not [`isbenign`](@ref).
+"""
+linesearch_failures(state::NonlinearSolverState) =
+    sum(oc -> isbenign(oc) ? 0 : state.ls_outcomes[linesearch_index(oc)], instances(LinesearchOutcome))
+
+"""
     flag_stall!(state)
 
 Record that the line search of the current step reported that it cannot make progress along
@@ -228,10 +284,10 @@ julia> y = zero(x); f(y, x, NullParameters())
  0.06120871905481365
 
 julia> state = NonlinearSolverState(x)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN], [NaN], [NaN], [NaN], NaN, 0, false, NaN, 0)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [NaN], [NaN], [NaN], [NaN], NaN, 0, false, NaN, 0, [0, 0, 0, 0, 0, 0])
 
 julia> update!(state, x, y)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.25], [NaN], [0.06120871905481365], [NaN], NaN, 0, false, NaN, 0)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.25], [NaN], [0.06120871905481365], [NaN], NaN, 0, false, NaN, 0, [0, 0, 0, 0, 0, 0])
 
 julia> x = ones(1) / 2
 1-element Vector{Float64}:
@@ -242,7 +298,7 @@ julia> f(y, x, NullParameters())
  0.0
 
 julia> update!(state, x, y)
-NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.5], [0.25], [0.0], [0.06120871905481365], NaN, 0, false, NaN, 0)
+NonlinearSolverState{Float64, Vector{Float64}, Vector{Float64}}(0, [0.5], [0.25], [0.0], [0.06120871905481365], NaN, 0, false, NaN, 0, [0, 0, 0, 0, 0, 0])
 ```
 
 The [`NonlinearSolverState`](@ref) stores the previous solution, the previous value, the current solution and the current value.

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -18,6 +18,16 @@ Stores absolute and successive residuals for `x` and `f`. It is used as a diagno
 - `f_increased::Bool`
 - `stalled::Bool`: the *last* step stalled, see [`stalled_step`](@ref)
 - `not_progressing::Bool`: the iteration is not getting anywhere, see [`no_progress`](@ref)
+- `ls_outcomes`: how often the line search reported each [`LinesearchOutcome`](@ref) during the
+  solve, indexed by [`linesearch_index`](@ref); see [`linesearch_outcomes`](@ref) and
+  [`linesearch_failures`](@ref)
+
+!!! info "The line-search tally is the programmatic channel"
+    A line search does not log from inside a solve — it reports to the solver, which accumulates
+    the outcomes here (see [`record_linesearch!`](@ref)). A caller that wants to *act* on a
+    rejected line search rather than read about it — restart an approximate Hessian, fall back to
+    steepest descent — reads this tally instead of scraping the log. That is what
+    [`solve_with_status!`](@ref) is for.
 
 # Examples
 
@@ -50,6 +60,67 @@ struct NonlinearSolverStatus{T}
     f_increased::Bool
     stalled::Bool
     not_progressing::Bool
+
+    # An `NTuple` and not the `MVector` the state keeps: the status is immutable and is built more
+    # than once per iteration (see `record_progress!`), so it takes a snapshot rather than a handle
+    # on a buffer that keeps changing under it.
+    ls_outcomes::NTuple{NLINESEARCH_OUTCOMES,Int}
+end
+
+"""
+    linesearch_outcomes(status)
+
+Return the tally of [`LinesearchOutcome`](@ref)s the line search reported during the solve,
+indexed by [`linesearch_index`](@ref). See [`record_linesearch!`](@ref) for why this, and not the
+log, is how a caller learns that the line search was rejected.
+
+# Examples
+
+```jldoctest; setup = :(using SimpleSolvers; using SimpleSolvers: linesearch_outcomes, linesearch_index)
+julia> F(y, x, params) = y .= x .^ 2 .- 2;
+
+julia> x = [1.0];
+
+julia> st = solve_with_status!(x, NonlinearProblem(F, zero(x)), Newton(); verbosity = 0);
+
+julia> linesearch_outcomes(st)[linesearch_index(LINESEARCH_NO_DESCENT)]
+0
+```
+"""
+linesearch_outcomes(status::NonlinearSolverStatus) = status.ls_outcomes
+
+"""
+    linesearch_failures(status)
+
+The number of steps whose line search reported a failure, i.e. [`linesearch_outcomes`](@ref)
+summed over the outcomes that are not [`isbenign`](@ref).
+"""
+linesearch_failures(status::NonlinearSolverStatus) =
+    sum(oc -> isbenign(oc) ? 0 : status.ls_outcomes[linesearch_index(oc)], instances(LinesearchOutcome))
+
+"""
+    dominant_linesearch_outcome(status)
+
+The non-[`isbenign`](@ref) [`LinesearchOutcome`](@ref) the line search reported most often during
+the solve, or `nothing` if it reported none. This is what
+[`nonlinear_solver_warnings`](@ref) names when it explains a solve that did not converge: a solve
+whose line search failed does so for one reason nearly every time, and naming that one reason is
+more use than a histogram.
+
+Ties go to the outcome declared first in [`LinesearchOutcome`](@ref), which orders them from the
+benign end (`LINESEARCH_FLOOR`, the merit is simply irreducible) towards the actionable one
+(`LINESEARCH_NO_DESCENT`, the direction is wrong and the [`Jacobian`](@ref) is the suspect) — so a
+tie is broken *away* from the more alarming diagnosis rather than towards it.
+"""
+function dominant_linesearch_outcome(status::NonlinearSolverStatus)
+    best = nothing
+    count = 0
+    for oc in instances(LinesearchOutcome)
+        isbenign(oc) && continue
+        n = status.ls_outcomes[linesearch_index(oc)]
+        n > count && ((best, count) = (oc, n))
+    end
+    best
 end
 
 @doc raw"""
@@ -292,7 +363,8 @@ function NonlinearSolverStatus(state::NonlinearSolverState{T}, config::Options{T
     # convergence question: it reads a measurement taken once per iteration by `record_progress!`
     # instead of the residuals of the current step.
     NonlinearSolverStatus{T}(iteration_number(state), stall_number(state), iterations_since_progress(state),
-        rxₛ, rfₐ, rfₛ, x_converged, f_converged, f_increased, stalled, no_progress(rfₐ, config, state))
+        rxₛ, rfₐ, rfₛ, x_converged, f_converged, f_increased, stalled, no_progress(rfₐ, config, state),
+        Tuple(linesearch_outcomes(state)))
 end
 
 # The stall and no-progress lines are appended only when they are relevant, so the printout of a
@@ -494,6 +566,34 @@ function no_progress_reason(status::NonlinearSolverStatus, config::Options)
     "spent its full budget of max_iterations = $(config.max_iterations) iterations without converging: the residual rfₐ = $(status.rfₐ) did not improve by the factor f_stall_factor = $(config.f_stall_factor) in the last $(status.iterations_since_progress) of them, so either it is on a floor this problem imposes — in which case a larger budget will not help — or it is converging far too slowly for the budget it was given. Set f_stall_window to stop at that point instead of spending the whole budget"
 end
 
+@doc raw"""
+    linesearch_reason(status, config)
+
+The clause [`nonlinear_solver_warnings`](@ref) appends to explain a failed solve in terms of what
+its line search reported, or `""` when it reported nothing but success.
+
+This is the *only* thing said about the line search during a solve. A line search does not log
+from inside the iteration — it reports to the solver, which tallies the outcomes (see
+[`record_linesearch!`](@ref)) — so without this clause a solve that stagnated because every one of
+its steps was rejected would name the symptom and not the cause. A count is what makes it
+evidence: "the line search rejected 194 of 200 steps" is a diagnosis, "the line search failed once"
+is noise from the last step of an otherwise healthy solve.
+
+Like `no_progress_reason` and `linesearch_exhausted_reason`, this is called from
+*inside* the `@warn` message so the string is built only for a message that is actually shown.
+"""
+function linesearch_reason(status::NonlinearSolverStatus, config::Options)
+    oc = dominant_linesearch_outcome(status)
+    isnothing(oc) && return ""
+    n = linesearch_outcomes(status)[linesearch_index(oc)]
+    " The line search reported $(oc) on $(n) of the $(status.iterations) step(s)" *
+    (oc === LINESEARCH_NO_DESCENT ?
+     ", i.e. φ'(0) > 0 — the direction was not a descent direction at all, which points at the Jacobian rather than at the tolerance: a stale one under refactorize > 1, a nonzero regularization_factor, or an inexact linear solve." :
+     oc === LINESEARCH_EXHAUSTED ?
+     ", i.e. the merit does vary but no trial step was acceptable, so either φ'(0) is inconsistent with φ (a stale or regularized Jacobian, an inexact linear solve, or a non-smooth problem) or linesearch_max_iterations = $(config.linesearch_max_iterations) was too small." :
+     ", i.e. no trial step changed the merit by more than its round-off resolution — the same floor this message reports one level up.")
+end
+
 """
     nonlinear_solver_warnings(status, config)
 
@@ -512,6 +612,27 @@ The three "this solve did not do what you asked" messages are mutually exclusive
 first: stagnation (the iterate froze) wins over lack of progress (the iterate moves but the
 residual is going nowhere), which in turn replaces the bare iteration count — which on its own
 names a symptom and no cause, and was the only thing a non-progressing solve used to report.
+
+# The line search reports here, not from inside the loop
+
+A line search emits nothing during a solve: it reports to the solver through the
+[`LinesearchStatus`](@ref) that [`solve_with_status`](@ref) returns, and [`solver_step!`](@ref)
+tallies the outcomes (see [`record_linesearch!`](@ref)). So the two failure messages above carry
+the clause [`linesearch_reason`](@ref) builds, which names the outcome the line search reported
+most often and how often — the cause behind the symptom they otherwise report on their own. A
+solve that converged anyway says the same thing at `verbosity ≥ 2`, as an `@info`.
+
+To *act* on the outcome rather than read about it, use [`solve_with_status!`](@ref) and the tally
+on the returned [`NonlinearSolverStatus`](@ref); see [`linesearch_outcomes`](@ref).
+
+# Rate limiting
+
+The three repeatable messages are gated on [`should_report!`](@ref), which reports the 1st, 2nd,
+4th, 8th … occurrence of a diagnosis rather than the first three and then nothing ever again.
+Their keys include the dominant line-search outcome, so a solve that starts failing for a new
+reason is reported at once. The trade-off — a *repeating* diagnosis is not reported on every
+occurrence — is spelled out in that docstring. `verbosity = 0` still silences the solver
+completely.
 """
 function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Options)
     # Stagnation is the more specific diagnosis and is reported below, so it suppresses the
@@ -523,33 +644,48 @@ function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Option
                  (isnotprogressing(status) ||
                   (status.iterations ≥ config.max_iterations && spent_without_progress(status)))
 
+    # A solve that failed usually failed the same way at every step, so the dominant line-search
+    # outcome is both the cause worth naming and the right thing to key the backoff on: a solve that
+    # starts failing for a *new* reason is a new diagnosis and is reported at once, rather than
+    # inheriting the suppressed counter of the old one.
+    lskey = something(dominant_linesearch_outcome(status), :none)
+
     # The bare count names a symptom and no cause, so either of the two diagnoses below replaces it
     # rather than joining it — the mutual exclusivity the docstring promises.
-    # `maxlog` for the same reason the messages below have one: a caller that drives `solve!` in a
+    # Rate limited for the same reason the messages below are: a caller that drives `solve!` in a
     # loop would otherwise get this once per step for as long as the problem stays unattainable.
     (config.warn_iterations > 0 && status.iterations ≥ config.warn_iterations &&
-     !noprogress && !stagnated) &&
-        (@warn "Solver took $(status.iterations) iterations." maxlog = 3)
+     !noprogress && !stagnated && should_report!(:iterations)) &&
+        (@warn "Solver took $(status.iterations) iterations.")
     # Same shape as the stagnation message: say what the solve achieved, what was asked of it, and
     # how to make the request attainable. The distinguishing news is that the iterate is *not*
     # stuck — the steps are healthy and the residual is simply not heading for the tolerance —
     # which points at the problem rather than at the solver or the precision.
-    (noprogress && config.verbosity ≥ 1) &&
-        (@warn "Nonlinear solver $(no_progress_reason(status, config)). The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖).$(status.stalled ? "" : " The iterate has not frozen (the last step was rxₛ = $(status.rxₛ)), so this is not the round-off floor of x that stagnation detection reports; a residual that is not heading for the tolerance while the steps are healthy usually means a floor of the problem itself — a model, discretisation or ansatz error that F cannot resolve, and that no eps-scaled tolerance can bound.") If rfₐ is accurate enough for you, raise f_abstol above it; otherwise improve the approximation F is built on until its floor lies below the tolerance you need. Set verbosity = 0 to silence this." maxlog = 3)
+    (noprogress && config.verbosity ≥ 1 && should_report!(Symbol(:noprogress_, lskey))) &&
+        (@warn "Nonlinear solver $(no_progress_reason(status, config)). The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖).$(status.stalled ? "" : " The iterate has not frozen (the last step was rxₛ = $(status.rxₛ)), so this is not the round-off floor of x that stagnation detection reports; a residual that is not heading for the tolerance while the steps are healthy usually means a floor of the problem itself — a model, discretisation or ansatz error that F cannot resolve, and that no eps-scaled tolerance can bound.")$(linesearch_reason(status, config)) If rfₐ is accurate enough for you, raise f_abstol above it; otherwise improve the approximation F is built on until its floor lies below the tolerance you need. Set verbosity = 0 to silence this.")
     # A stagnated solve is not an error, but it did not achieve what was asked of it, so say
     # what it *did* achieve and how to make the request attainable. This replaces the former
     # pair of misleading messages (a line-search warning per iteration plus "Solver took 1000
     # iterations."), neither of which named the actual problem.
-    # `maxlog` for the same reason every line-search message has one: a caller that drives
-    # `solve!` in a loop — a time-stepping integrator, say — would otherwise get this once per
-    # step for as long as the problem stays unattainable, which is the message flood this
-    # replaced. Note that `maxlog` is keyed on the source location and so is process-global, not
-    # per solve; see `linesearch_warnings`.
-    (stagnated && config.verbosity ≥ 1) &&
-        (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖). If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this." maxlog = 3)
+    # Rate limited because a caller that drives `solve!` in a loop — a time-stepping integrator,
+    # say — would otherwise get this once per step for as long as the problem stays unattainable,
+    # which is the message flood this replaced. `should_report!` and not `maxlog`: the latter is
+    # keyed on the source location, so its budget is process-global *and* never reset, which left a
+    # genuinely new failure late in a long run unreported. See `should_report!`.
+    (stagnated && config.verbosity ≥ 1 && should_report!(Symbol(:stagnated_, lskey))) &&
+        (@warn "Nonlinear solver stagnated after $(status.iterations) iterations: the last $(status.stalls) steps did not move the iterate, so the residual rfₐ = $(status.rfₐ) cannot be reduced further — this is the achievable floor for this problem in this precision. The requested residual tolerance was f_abstol = $(config.f_abstol) (plus f_reltol = $(config.f_reltol) times the initial residual ‖F(x₀)‖).$(linesearch_reason(status, config)) If rfₐ is accurate enough for you, raise f_abstol above it; otherwise rescale F so that its round-off floor lies below the tolerance you need. Set verbosity = 0 to silence this.")
     (status.f_increased && !config.allow_f_increases) && (@warn "The function increased and the solver stopped!")
     (status.rfₐ > config.f_abstol_break) && (@warn "The residual rfₐ has reached the maximally allowed value $(config.f_abstol_break)!")
     (havenonfinite(status) && status.iterations ≥ 1 && config.verbosity ≥ 1) && (@warn "Nonlinear solver encountered NaNs or Infs in solution or function value.")
+
+    # A solve that *converged* despite a line search that kept failing got where it was going, so
+    # this is not a warning about the result — but the route it took is worth seeing when you are
+    # already looking, and it is the only trace of the line search a solve leaves. `verbosity ≥ 2`,
+    # the same gate `LINESEARCH_FLOOR` and `LINESEARCH_STATIONARY` use, and for the same reason:
+    # the last step of a converged solve reports a floor as a matter of course.
+    (isconverged(status) && !stagnated && !noprogress && config.verbosity ≥ 2 &&
+     linesearch_failures(status) > 0) &&
+        (@info "Nonlinear solver converged after $(status.iterations) iterations to rfₐ = $(status.rfₐ), but not every step went smoothly.$(linesearch_reason(status, config))")
 
     nothing
 end

--- a/src/nonlinear/nonlinear_solver_status.jl
+++ b/src/nonlinear/nonlinear_solver_status.jl
@@ -99,7 +99,7 @@ linesearch_failures(status::NonlinearSolverStatus) =
     sum(oc -> isbenign(oc) ? 0 : status.ls_outcomes[linesearch_index(oc)], instances(LinesearchOutcome))
 
 """
-    dominant_linesearch_outcome(status)
+    dominant_linesearch_outcome(status, count_floor=true)
 
 The non-[`isbenign`](@ref) [`LinesearchOutcome`](@ref) the line search reported most often during
 the solve, or `nothing` if it reported none. This is what
@@ -111,12 +111,18 @@ Ties go to the outcome declared first in [`LinesearchOutcome`](@ref), which orde
 benign end (`LINESEARCH_FLOOR`, the merit is simply irreducible) towards the actionable one
 (`LINESEARCH_NO_DESCENT`, the direction is wrong and the [`Jacobian`](@ref) is the suspect) — so a
 tie is broken *away* from the more alarming diagnosis rather than towards it.
+
+`count_floor = false` skips `LINESEARCH_FLOOR`, which is how a *converged* solve is asked whether
+anything went wrong: reaching the merit's round-off floor on the last step is how a solve converges,
+so for that question the floor is not a failure at all. It is the tie rule above that makes the
+distinction matter — a converged solve that floored once and was exhausted once would otherwise be
+explained by the floor, which is the half of it that is expected.
 """
-function dominant_linesearch_outcome(status::NonlinearSolverStatus)
+function dominant_linesearch_outcome(status::NonlinearSolverStatus, count_floor::Bool=true)
     best = nothing
     count = 0
     for oc in instances(LinesearchOutcome)
-        isbenign(oc) && continue
+        (isbenign(oc) || (!count_floor && oc === LINESEARCH_FLOOR)) && continue
         n = status.ls_outcomes[linesearch_index(oc)]
         n > count && ((best, count) = (oc, n))
     end
@@ -567,10 +573,14 @@ function no_progress_reason(status::NonlinearSolverStatus, config::Options)
 end
 
 @doc raw"""
-    linesearch_reason(status, config)
+    linesearch_reason(status, config, oc=dominant_linesearch_outcome(status))
 
 The clause [`nonlinear_solver_warnings`](@ref) appends to explain a failed solve in terms of what
-its line search reported, or `""` when it reported nothing but success.
+its line search reported, or `""` when it reported nothing but success. `oc` is the outcome to
+explain — by default the dominant one, and for a converged solve the dominant one *other than*
+`LINESEARCH_FLOOR`, which is what made that message fire (see
+[`dominant_linesearch_outcome`](@ref)); the clause has to name the outcome the caller acted on,
+not a different one that happens to be as frequent.
 
 This is the *only* thing said about the line search during a solve. A line search does not log
 from inside the iteration — it reports to the solver, which tallies the outcomes (see
@@ -582,8 +592,8 @@ is noise from the last step of an otherwise healthy solve.
 Like `no_progress_reason` and `linesearch_exhausted_reason`, this is called from
 *inside* the `@warn` message so the string is built only for a message that is actually shown.
 """
-function linesearch_reason(status::NonlinearSolverStatus, config::Options)
-    oc = dominant_linesearch_outcome(status)
+function linesearch_reason(status::NonlinearSolverStatus, config::Options,
+    oc::Union{LinesearchOutcome,Nothing}=dominant_linesearch_outcome(status))
     isnothing(oc) && return ""
     n = linesearch_outcomes(status)[linesearch_index(oc)]
     " The line search reported $(oc) on $(n) of the $(status.iterations) step(s)" *
@@ -620,7 +630,9 @@ A line search emits nothing during a solve: it reports to the solver through the
 tallies the outcomes (see [`record_linesearch!`](@ref)). So the two failure messages above carry
 the clause [`linesearch_reason`](@ref) builds, which names the outcome the line search reported
 most often and how often — the cause behind the symptom they otherwise report on their own. A
-solve that converged anyway says the same thing at `verbosity ≥ 2`, as an `@info`.
+solve that converged anyway says the same thing at `verbosity ≥ 2`, as an `@info`, and only for a
+failure that is *not* `LINESEARCH_FLOOR`: the last step of a converged solve reaches the merit's
+round-off floor as a matter of course, so counting that would report every healthy solve.
 
 To *act* on the outcome rather than read about it, use [`solve_with_status!`](@ref) and the tally
 on the returned [`NonlinearSolverStatus`](@ref); see [`linesearch_outcomes`](@ref).
@@ -628,11 +640,11 @@ on the returned [`NonlinearSolverStatus`](@ref); see [`linesearch_outcomes`](@re
 # Rate limiting
 
 The three repeatable messages are gated on [`should_report!`](@ref), which reports the 1st, 2nd,
-4th, 8th … occurrence of a diagnosis rather than the first three and then nothing ever again.
-Their keys include the dominant line-search outcome, so a solve that starts failing for a new
-reason is reported at once. The trade-off — a *repeating* diagnosis is not reported on every
-occurrence — is spelled out in that docstring. `verbosity = 0` still silences the solver
-completely.
+4th, 8th … occurrence of a diagnosis rather than the first three and then nothing ever again. The
+keys of the two *diagnoses* carry the dominant line-search outcome, so a solve that starts failing
+for a new reason is reported at once; the bare iteration count has no cause to key on and uses a
+plain one. The trade-off — a *repeating* diagnosis is not reported on every occurrence — is spelled
+out in that docstring. `verbosity = 0` still silences the solver completely.
 """
 function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Options)
     # Stagnation is the more specific diagnosis and is reported below, so it suppresses the
@@ -681,11 +693,21 @@ function nonlinear_solver_warnings(status::NonlinearSolverStatus, config::Option
     # A solve that *converged* despite a line search that kept failing got where it was going, so
     # this is not a warning about the result — but the route it took is worth seeing when you are
     # already looking, and it is the only trace of the line search a solve leaves. `verbosity ≥ 2`,
-    # the same gate `LINESEARCH_FLOOR` and `LINESEARCH_STATIONARY` use, and for the same reason:
-    # the last step of a converged solve reports a floor as a matter of course.
-    (isconverged(status) && !stagnated && !noprogress && config.verbosity ≥ 2 &&
-     linesearch_failures(status) > 0) &&
-        (@info "Nonlinear solver converged after $(status.iterations) iterations to rfₐ = $(status.rfₐ), but not every step went smoothly.$(linesearch_reason(status, config))")
+    # the same gate `LINESEARCH_FLOOR` and `LINESEARCH_STATIONARY` use.
+    #
+    # `LINESEARCH_FLOOR` does not count towards it, although `linesearch_failures` counts it: the
+    # last step of a converged solve reports the merit's round-off floor as a matter of course — a
+    # solve that reached its tolerance did so by making the residual as small as the arithmetic
+    # allows — so a floor here is the healthy case, and counting it would announce that *every*
+    # converged solve did not go smoothly. That is the standard `linesearch_reason` states: one
+    # failure is noise from the last step, a count is evidence. It is also what `isbenign`
+    # promises — that the tally is named only for a solve that did not converge — and the promise
+    # holds for the two messages above, which fire only when it did not.
+    # The same outcome is handed to `linesearch_reason`, so the clause names what made the message
+    # fire rather than the floor it is deliberately ignoring.
+    rough = dominant_linesearch_outcome(status, false)
+    (isconverged(status) && !stagnated && !noprogress && config.verbosity ≥ 2 && !isnothing(rough)) &&
+        (@info "Nonlinear solver converged after $(status.iterations) iterations to rfₐ = $(status.rfₐ), but not every step went smoothly.$(linesearch_reason(status, config, rough))")
 
     nothing
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,3 +42,81 @@ function outer!(O, x, y)
     end
 
 end
+
+
+"""
+    const WARNING_COUNTS
+
+How often each *diagnosis* has been reported so far, keyed by the `Symbol` passed to
+[`should_report!`](@ref). Process-global, and guarded by [`WARNING_LOCK`](@ref).
+
+The number of keys is bounded by the number of message sites, so this does not grow without
+limit. It is reset by [`reset_warning_counts!`](@ref).
+"""
+const WARNING_COUNTS = Dict{Symbol,Int}()
+
+"Guards [`WARNING_COUNTS`](@ref); see [`should_report!`](@ref)."
+const WARNING_LOCK = ReentrantLock()
+
+@doc raw"""
+    should_report!(key)
+
+Count one occurrence of the diagnosis `key` and return `true` when it should be reported, i.e.
+on its 1st, 2nd, 4th, 8th, 16th … occurrence. Used by [`nonlinear_solver_warnings`](@ref) in
+place of the `maxlog` keyword of `@warn`.
+
+# Extended help
+
+## Why not `maxlog`
+
+A `NonlinearSolver` reports at most once per [`solve!`](@ref), which is the right rate for a
+caller that solves once and far too high a one for a caller that solves in a loop — a
+time-stepping integrator asking for a tolerance its problem cannot attain would get the same
+message at every step. `maxlog` bounds that, but it is keyed on the *source location* of the
+`@warn`, so its budget is process-global and is never reset: once spent, the message is gone for
+the remainder of the session, including for later solves of entirely different problems. A
+genuine failure late in a long run was therefore silent.
+
+## What the backoff promises, and what it does not
+
+Doubling gives ``O(\log N)`` messages over ``N`` solves — a handful over a run of any length —
+while never reaching a point beyond which nothing is ever said again. Be clear about the two
+halves of that:
+
+- a diagnosis appearing for the **first time** is reported at once, whichever solve it happens
+  in, because its counter is still at zero. This is the case `maxlog` got wrong, and it is the
+  one that matters: a run that was healthy for ten thousand steps and then was not says so.
+- a diagnosis that **keeps repeating** is reported on solves 1, 2, 4, 8, 16 … of its own count.
+  Occurrence 10 is silent; occurrence 16 is not. Every occurrence is *not* promised, and asking
+  for that would be asking for the flood back.
+
+Keys should therefore be as specific as the distinctions worth waking the user for — which is why
+the caller folds the dominant [`LinesearchOutcome`](@ref) into the key of a stagnation report: a
+solve that starts stagnating for a *new* reason is a new diagnosis, and is reported immediately
+rather than inheriting the suppressed counter of the old one.
+
+`verbosity = 0` remains the way to silence a solver completely, and
+[`NonlinearSolverStatus`](@ref) remains the way to *act* on an outcome rather than read about it.
+"""
+function should_report!(key::Symbol)
+    # The lock is what `maxlog`'s own unsynchronized `Dict` lacks. It costs nothing worth counting:
+    # this is only ever reached once per solve, from a branch that has already decided there is
+    # something to say.
+    @lock WARNING_LOCK begin
+        n = get(WARNING_COUNTS, key, 0) + 1
+        WARNING_COUNTS[key] = n
+        ispow2(n)
+    end
+end
+
+"""
+    reset_warning_counts!()
+
+Forget every count kept by [`should_report!`](@ref), so that the next occurrence of each
+diagnosis is reported again.
+
+Mostly for tests: unlike `maxlog` — which `Test.TestLogger` sees straight through, since the
+suppression happens in the logger — a message the backoff suppresses is never emitted at all, so a
+test that asserts on a message has to start from a known count.
+"""
+reset_warning_counts!() = (@lock WARNING_LOCK empty!(WARNING_COUNTS); nothing)

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -717,13 +717,13 @@ end
     froot(α, _) = α - 1.0
     @test bisection(froot, 0.0, 2.0) ≈ 1.0 atol = 1e-6
 
-    # No sign change over the bracket: rather than silently collapsing onto α₁
-    # or erroring (which would break the line search once the
-    # derivative has flattened at a minimum), `bisection` returns the endpoint
-    # closest to a root (smallest |f|).
+    # No sign change over the bracket: rather than silently collapsing onto α₁ or erroring (which
+    # would abort the enclosing solve), `bisection` returns the endpoint closest to a root
+    # (smallest |f|) *and reports the failure* — silenced here, and asserted on its own below.
     fpos(α, _) = α + 1.0            # strictly positive on [0, 1] → no sign change
-    @test bisection(fpos, 0.0, 1.0) == 0.0    # |f(0)| = 1 < |f(1)| = 2
-    @test bisection(fpos, 1.0, 0.0) == 0.0    # endpoints get flipped internally
+    quiet = Options(Float64; verbosity=0)
+    @test bisection(fpos, 0.0, 1.0, NullParameters(), quiet) == 0.0    # |f(0)| = 1 < |f(1)| = 2
+    @test bisection(fpos, 1.0, 0.0, NullParameters(), quiet) == 0.0    # endpoints flipped internally
 
     # The debug `println` and hard `error("Max iteration number exceeded")` were
     # A tight tolerance forces exhaustion here.
@@ -732,6 +732,66 @@ end
     local αbest
     @test (αbest = bisection(fslow, 0.0, 1.0, NullParameters(), cfg)) isa Float64
     @test 0.0 ≤ αbest ≤ 1.0
+end
+
+@testset "$(rpad("_bisection_core tells a located root from a failed bracket", 80))" begin
+    # The three outcomes are distinct, and "no sign change" is not one of the successes. Folding it
+    # into `converged = true` is what let an unbracketable derivative be claimed as a line
+    # minimiser and then classified as `LINESEARCH_FLOOR` — see the `Bisection` testset below.
+    froot(α, _) = α - 1.0
+    fpos(α, _) = α + 1.0
+    fslow(α, _) = α - 1 / 3
+
+    @test SimpleSolvers._bisection_core(froot, 0.0, 2.0, NullParameters(), Options())[2] ===
+          SimpleSolvers.BISECTION_CONVERGED
+    @test SimpleSolvers._bisection_core(fpos, 0.0, 1.0, NullParameters(), Options())[2] ===
+          SimpleSolvers.BISECTION_NOBRACKET
+    @test SimpleSolvers._bisection_core(fslow, 0.0, 1.0, NullParameters(),
+        Options(Float64; linesearch_max_iterations=2, x_suctol=0.0, f_abstol=0.0))[2] ===
+          SimpleSolvers.BISECTION_EXHAUSTED
+
+    # The endpoint flip does not change the verdict, and the returned value is unchanged from
+    # before: the endpoint with the smallest |f|. Only the claim made about it is.
+    α, oc, _ = SimpleSolvers._bisection_core(fpos, 1.0, 0.0, NullParameters(), Options())
+    @test oc === SimpleSolvers.BISECTION_NOBRACKET
+    @test α == 0.0
+
+    # And the outcome is inferred, not boxed — it is on the line search's hot path.
+    @test (@inferred SimpleSolvers._bisection_core(froot, 0.0, 2.0, NullParameters(), Options())) isa
+          Tuple{Float64,SimpleSolvers.BisectionOutcome,Int}
+end
+
+@testset "$(rpad("a Bisection that cannot bracket never reports a floor", 80))" begin
+    # `LINESEARCH_FLOOR` asserts that *no* line search can make progress along this direction, and
+    # the outer iteration acts on it: `flag_stall!`, then `max_stalls`. A bisection that could not
+    # bracket φ′ has established nothing of the kind, so it may not make that claim (issue: the
+    # `converged = true` of the no-sign-change branch). It reports what the *merit* says instead.
+    #
+    # `Bisection` bisects φ′ but brackets on φ, so the case arises whenever the two disagree —
+    # which is the realistic one: a stale or regularized Jacobian, an inexact linear solve, a
+    # non-smooth merit. Both problems below state it outright, with a φ that has a proper minimum
+    # and a "derivative" that never changes sign, so `bracket_minimum` succeeds and the bisection
+    # it hands the bracket to cannot start.
+
+    # The minimum of φ lies at α = 1, so the search still finds a step that improves the merit.
+    # A genuine decrease stays reported as a decrease — the failed bracket is not held against it.
+    ok = LinesearchProblem{Float64}((α, _) -> (α - 1.0)^2, (α, _) -> -1.0)
+    st = solve_with_status(Linesearch(ok, Bisection(); verbosity=0), 1.0)
+    @test outcome(st) === LINESEARCH_DECREASED
+    @test steplength(st) > 0.0
+    @test st.φ ≤ st.φ₀ - st.τ
+
+    # The minimum of φ lies at α = -1, so no positive step improves the merit. This is the case
+    # the defect turned into `LINESEARCH_FLOOR`: the endpoint of a bracket that never was got
+    # claimed as the line minimiser, and the outer iteration counted the step towards `max_stalls`
+    # (`flag_stall!` in `solver_step!`) on the strength of that claim. It is `LINESEARCH_EXHAUSTED`
+    # — no acceptable step was *found*, which leaves open that one exists.
+    bad = LinesearchProblem{Float64}((α, _) -> (α + 1.0)^2, (α, _) -> -1.0)
+    stbad = solve_with_status(Linesearch(bad, Bisection(); verbosity=0), 0.01)
+    @test outcome(stbad) === LINESEARCH_EXHAUSTED
+    @test outcome(stbad) ≠ LINESEARCH_FLOOR
+    @test !SimpleSolvers.isfloor(stbad)
+    @test steplength(stbad) > 0.0      # the α > 0 contract holds either way
 end
 
 @testset "$(rpad("bisection interval/config disambiguation", 80))" begin
@@ -1219,8 +1279,16 @@ end
         @test !has_logging_code(f)
     end
 
-    # The barrier really is on the path a solve takes, for every method, and stays quiet when there
-    # is nothing to report.
+    # The barrier really is on the path a *direct* `solve(ls, α)` takes, for every method — that is
+    # the only path that reaches it, since a solver consults `solve_with_status` and reports through
+    # `nonlinear_solver_warnings` instead — and it stays quiet when there is nothing to report.
+    for ls in (Backtracking(), StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
+        lsp = Linesearch(make_linesearch_problem(-3.0), ls; verbosity=1)
+        @test (@test_logs solve(lsp, 1.0)) > 0.0
+    end
+
+    # ... and a solve is quiet too, for every method, now that the line search does not report from
+    # inside the iteration at all.
     F(y, x, params) = y .= x .^ 2 .- 2
     for ls in (Backtracking(), StrongWolfe(), Bisection(), Quadratic(), BierlaireQuadratic())
         x = ones(3)
@@ -1232,17 +1300,22 @@ end
     # The two `bisection` messages moved into reporters of their own, so their verbosity gates are
     # no longer visible at the site that decides to report. Pin them: each fires at its documented
     # level and is silent one below. Neither carries `maxlog`, so this is repeatable within a
-    # session, unlike the line-search messages.
+    # session.
     fslow(α, _) = α - 1 / 3
     nonconvergence(v) = () -> bisection(fslow, 0.0, 1.0, NullParameters(),
         Options(Float64; linesearch_max_iterations=2, x_suctol=0.0, f_abstol=0.0, verbosity=v))
     @test logged_any(nonconvergence(1), "did not converge within")
     @test !logged_any(nonconvergence(0), "did not converge within")
 
+    # `nobracket` sits at `verbosity ≥ 1`, not 2. It used to be gated at 2 because the *line
+    # search* routed through `bisection` and a flat derivative at a minimum made the message a
+    # false alarm; it no longer does — `_bisect_on` calls `_bisection_core` and reports through its
+    # `LinesearchStatus` — so the only caller left is a user asking for a root, and "there is no
+    # root in your interval" is a genuine failure for them.
     fpos(α, _) = α + 1.0            # strictly positive on [0, 1] → no sign change
     nobracket(v) = () -> bisection(fpos, 0.0, 1.0, NullParameters(), Options(Float64; verbosity=v))
-    @test logged_any(nobracket(2), "shows no sign change")
-    @test !logged_any(nobracket(1), "shows no sign change")
+    @test logged_any(nobracket(1), "shows no sign change")
+    @test !logged_any(nobracket(0), "shows no sign change")
 end
 
 @testset "$(rpad("every clause of a linesearch message is built only when it is shown", 80))" begin

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -39,6 +39,17 @@ function make_linesearch_problem(x₀::Number)
     LinesearchProblem{typeof(x₀)}(_f, _d)
 end
 
+# Two stand-ins for a downstream `LinesearchMethod`, used to pin the extension point: a method
+# implements `solve_with_status` and gets `solve` derived from it, and one that implements neither
+# is told which of the two it owes instead of recursing between the generic definitions.
+struct ToyLinesearch{T} <: LinesearchMethod{T} end
+ToyLinesearch(::Type{T}=Float64) where {T} = ToyLinesearch{T}()
+SimpleSolvers.solve_with_status(::Linesearch{T,<:ToyLinesearch}, α::T, params=SimpleSolvers.NullParameters()) where {T} =
+    LinesearchStatus{T}(T(0.25), LINESEARCH_EXHAUSTED, 1, one(T), -one(T), one(T), zero(T), zero(T))
+
+struct MuteLinesearch{T} <: LinesearchMethod{T} end
+MuteLinesearch(::Type{T}=Float64) where {T} = MuteLinesearch{T}()
+
 function test_linesearch(method::LinesearchMethod, n::Integer=1)
     x₀ = -3.0
     x₁ = +3.0
@@ -423,7 +434,7 @@ end
     @test n[] == 1
 end
 
-@testset "$(rpad("Backtracking: τ_ulps validation and generic solve_with_status fallback", 80))" begin
+@testset "$(rpad("Backtracking: τ_ulps validation, and solve is derived from the status", 80))" begin
     @test_throws AssertionError Backtracking(; τ_ulps=-1.0)
     @test Backtracking(; τ_ulps=0.0) isa Backtracking
     @test Backtracking().τ_ulps == SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS
@@ -433,9 +444,11 @@ end
     st = solve_with_status(Linesearch(noise, Backtracking(; τ_ulps=0.0); verbosity=0), 1.0)
     @test steplength(st) ≤ eps(1.0)
 
-    # Every built-in method reports a real outcome now, so none of them relies on the generic
-    # `LINESEARCH_UNKNOWN` fallback any more.  `Static` is the exception by nature: it ignores
-    # the caller's step and never evaluates the merit, so it has established nothing.
+    # Every built-in method reports a real outcome, and `solve` is *derived* from it — one
+    # definition for all of them, in `linesearch.jl` — so the two agree by construction rather
+    # than because six copies of the same three lines happen to.  `Static` is the exception by
+    # nature: it ignores the caller's step and never evaluates the merit, so it has established
+    # nothing and reports `LINESEARCH_UNKNOWN`, which `linesearch_warnings` passes over in silence.
     prob = LinesearchProblem{Float64}((α, _) -> (α - 0.7)^2, (α, _) -> 2 * (α - 0.7))
     for m in (Bisection(), Quadratic(), BierlaireQuadratic(), StrongWolfe(), Backtracking())
         ls = Linesearch(prob, m; verbosity=0)
@@ -453,8 +466,25 @@ end
     @test !isfloor(ststatic)
     @test steplength(ststatic) == solve(lstatic, 1.0)
 
-    # The generic `solve_with_status` fallback is kept for user-defined `LinesearchMethod`s
-    # (it reports `LINESEARCH_UNKNOWN`), but no built-in method dispatches to it any more.
+    # A user-defined method implements `solve_with_status` and gets `solve` for free, with the
+    # report and the α > 0 contract that come with it. This is the direction that makes the
+    # contract structural: there is no path by which the package calls a method's own `solve`, so
+    # a method cannot reinstate the per-iteration message a solve must not emit.
+    ls_toy = Linesearch(prob, ToyLinesearch(); verbosity=1)
+    @test solve(ls_toy, 1.0) == 0.25
+    @test outcome(solve_with_status(ls_toy, 1.0)) == LINESEARCH_EXHAUSTED
+    @test logged_any(() -> solve(ls_toy, 1.0), "no step satisfied the sufficient decrease")
+    @test !logged_any(() -> solve_with_status(ls_toy, 1.0), "no step satisfied the sufficient decrease")
+
+    # ... and a method that implements neither says which one it owes, rather than recursing
+    # between the two generic definitions.
+    ls_mute = Linesearch(prob, MuteLinesearch(); verbosity=0)
+    @test_throws "does not implement `solve_with_status`" solve_with_status(ls_mute, 1.0)
+    @test_throws "does not implement `solve_with_status`" solve(ls_mute, 1.0)
+
+    # `α` is converted to the element type of the `Linesearch`, so a caller does not have to spell
+    # out the precision of a step that has no fractional part.
+    @test solve(Linesearch(prob, Backtracking(); verbosity=0), 1) == 1.0
 end
 
 @testset "$(rpad("with_config replaces the Options and keeps problem and method", 80))" begin
@@ -792,6 +822,18 @@ end
     @test outcome(stbad) ≠ LINESEARCH_FLOOR
     @test !SimpleSolvers.isfloor(stbad)
     @test steplength(stbad) > 0.0      # the α > 0 contract holds either way
+
+    # Both of these return the caller's α rather than a step of their own, and the status says what
+    # the merit *is* there rather than repeating φ(0). Filling `φ` with `φ₀` used to make
+    # `linesearch_exhausted_reason` report "the merit changed by 0.0" for a merit nothing had
+    # measured — most visibly for one that descends forever, where `bracket_minimum` finds no
+    # bracket at all and the true value is as far from φ(0) as the step is long.
+    @test stbad.φ == (α -> (α + 1.0)^2)(steplength(stbad))
+    forever = LinesearchProblem{Float64}((α, _) -> 1.0 - α, (α, _) -> -1.0)
+    stf = solve_with_status(Linesearch(forever, Bisection(); verbosity=0), 1.0)
+    @test outcome(stf) === LINESEARCH_EXHAUSTED
+    @test stf.φ == 1.0 - steplength(stf)   # was φ₀ = 1.0, i.e. "the merit did not change"
+    @test stf.φ < stf.φ₀
 end
 
 @testset "$(rpad("bisection interval/config disambiguation", 80))" begin
@@ -1244,11 +1286,11 @@ end
 end
 
 @testset "$(rpad("the linesearch messages are compiled once, not once per solver", 80))" begin
-    # `linesearch_warnings` is called from `solver_step!` on every iteration of every solve, and
-    # it is specialized on the `Linesearch` — hence on the closure types of its
-    # `LinesearchProblem`, hence once per *problem* a solver is built for. The messages therefore
-    # live behind the `report_linesearch_status` barrier, whose signature mentions no closure type;
-    # see its docstring.
+    # `linesearch_warnings` is called from `solve`, i.e. from every direct call to a line search,
+    # and it is specialized on the `Linesearch` — hence on the closure types of its
+    # `LinesearchProblem`, hence once per *problem* a line search is built for. The messages
+    # therefore live behind the `report_linesearch_status` barrier, whose signature mentions no
+    # closure type; see its docstring.
 
     # Half one: the specialization set is bounded by the *signature*. Julia specializes on the
     # concrete types of the arguments, so if no parameter type can admit a `Linesearch` — which
@@ -1321,10 +1363,10 @@ end
 @testset "$(rpad("every clause of a linesearch message is built only when it is shown", 80))" begin
     # The `αmin` clause of `LINESEARCH_FLOOR` and both wordings of `LINESEARCH_EXHAUSTED` are
     # interpolated inside their `@warn` rather than into a temporary before it, so that a message
-    # the verbosity gate or `maxlog` discards costs nothing (see `report_linesearch_status`). The
-    # exact texts are pinned here because that laziness is easy to undo by rewriting the
-    # interpolation, and easy to undo *silently*. `Test.TestLogger` records every message regardless
-    # of `maxlog`, which is keyed on the source location and therefore process-global.
+    # the verbosity gate discards costs nothing (see `report_linesearch_status`) — and the
+    # overwhelmingly common case is a caller running at a verbosity that discards it. The exact
+    # texts are pinned here because that laziness is easy to undo by rewriting the interpolation,
+    # and easy to undo *silently*.
     reported(st, v) = () -> SimpleSolvers.report_linesearch_status(st, :Backtracking,
         Options(Float64; verbosity=v, linesearch_max_iterations=7))
 

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -10,6 +10,8 @@ using SimpleSolvers: config, linesearch, stall_number, record_stall!, flag_stall
 using SimpleSolvers: iterations_since_progress, record_progress!, no_progress
 using SimpleSolvers: compute_new_iterate!, increase_iteration_number!, Bisection, Quadratic,
     StrongWolfe, Backtracking, steplength, solve_with_status
+using SimpleSolvers: should_report!, reset_warning_counts!, linesearch_outcomes,
+    linesearch_failures, linesearch_index, dominant_linesearch_outcome, record_linesearch!
 using Test
 using Random
 using ForwardDiff
@@ -1128,6 +1130,10 @@ end
         # expanding here, so the residual safeguard damps α to nothing and the residual sits at
         # 10.4 for all 1000 iterations — a solve that makes no progress, which is what is now
         # reported instead of the bare "Solver took … iterations." (see `spent_without_progress`).
+        # The report is rate limited by `should_report!` (1st, 2nd, 4th … occurrence), and unlike
+        # `maxlog` — which suppresses inside the logger, where `TestLogger` still sees it — a
+        # suppressed message is never emitted, so the count has to start from a known point.
+        reset_warning_counts!()
         @test_logs (:warn, r"spent its full budget .* did not improve") match_mode = :any solve!(x0, solver)
         @test_throws AssertionError @assert ≈(x0, _root; atol=tol(T))
 
@@ -1194,7 +1200,34 @@ end
     # requested tolerance
     x2 = [1.0]
     s2 = NewtonSolver(x2, Ffloor, zero(x2); f_abstol=1e-20, f_reltol=0.0)
+    reset_warning_counts!()
     @test_logs (:warn, r"stagnated") match_mode = :any solve!(x2, s2, SolverState(s2))
+
+    # ... and it names what the line search reported, which is the only trace the line search
+    # leaves: it does not log from inside the iteration, it reports to the solver (see
+    # `record_linesearch!`). Without this clause the message would name the symptom and no cause.
+    x2b = [1.0]
+    s2b = NewtonSolver(x2b, Ffloor, zero(x2b); f_abstol=1e-20, f_reltol=0.0)
+    state2b = SolverState(s2b)
+    reset_warning_counts!()
+    @test_logs (:warn, r"The line search reported LINESEARCH_FLOOR on \d+ of the \d+ step\(s\)") match_mode = :any solve!(x2b, s2b, state2b)
+
+    # The same information, programmatically — this is what a caller acts on, rather than the log.
+    stb = status(s2b, state2b)
+    @test linesearch_failures(stb) > 0
+    @test dominant_linesearch_outcome(stb) === LINESEARCH_FLOOR
+    @test linesearch_outcomes(stb)[linesearch_index(LINESEARCH_FLOOR)] > 0
+    @test sum(linesearch_outcomes(stb)) == iteration_number(state2b)
+
+    # And no line-search message escapes the solve itself: the flood the caps used to hold back
+    # is gone at its source, not rate limited.
+    x2c = [1.0]
+    s2c = NewtonSolver(x2c, Ffloor, zero(x2c); f_abstol=1e-20, f_reltol=0.0, verbosity=2)
+    reset_warning_counts!()
+    logs2c, _ = Test.collect_test_logs() do
+        solve!(x2c, s2c, SolverState(s2c))
+    end
+    @test !any(r -> occursin("line search: ", string(r.message)), logs2c)
 
     # ... and it *replaces* the bare iteration count rather than joining it. This solve stagnates
     # after three iterations, so it only reaches `warn_iterations` when that is set below them;
@@ -1202,6 +1235,7 @@ end
     # `nonlinear_solver_warnings` promises would go untested.
     x4 = [1.0]
     s4 = NewtonSolver(x4, Ffloor, zero(x4); f_abstol=1e-20, f_reltol=0.0, warn_iterations=1)
+    reset_warning_counts!()
     logs, _ = Test.collect_test_logs() do
         solve!(x4, s4, SolverState(s4))
     end
@@ -1435,6 +1469,7 @@ end
     # of the bare "Solver took … iterations." that used to be the only signal
     x2 = [0.0]
     s2 = PicardSolver(x2, Ffloor, zero(x2))
+    reset_warning_counts!()
     @test_logs (:warn, r"spent its full budget .* did not improve by the factor") match_mode = :any solve!(x2, s2, SolverState(s2))
 
     # `f_stall_window` turns the report into a stopping criterion
@@ -1451,6 +1486,7 @@ end
 
     x4 = [0.0]
     s4 = PicardSolver(x4, Ffloor, zero(x4); f_stall_window=20)
+    reset_warning_counts!()
     @test_logs (:warn, r"gave up after 20 iterations") match_mode = :any solve!(x4, s4, SolverState(s4))
 
     # A slow but healthy solve must survive the same window: this one contracts by 0.9 per
@@ -1801,4 +1837,90 @@ end
     end
     @test solve_allocations(PicardSolver) == 0 skip = !AS_A_CALLER_COMPILES_IT
     @test solve_allocations(DogLegSolver) == 0 skip = !AS_A_CALLER_COMPILES_IT
+end
+
+@testset "$(rpad("the solver report backs off geometrically instead of going silent", 80))" begin
+    # `maxlog` is keyed on the source location of the `@warn`, so its budget was process-global
+    # *and* was never reset between solves: after three reports the message was gone for the rest
+    # of the session, and a genuine failure in the tenth solve of a run was silent. `should_report!`
+    # reports the 1st, 2nd, 4th, 8th … occurrence instead — O(log N) messages over N solves, and no
+    # point beyond which nothing is ever said again.
+    reset_warning_counts!()
+    @test [should_report!(:probe) for _ in 1:16] ==
+          [true, true, false, true, false, false, false, true,
+        false, false, false, false, false, false, false, true]
+
+    # A *different* diagnosis is reported at once, however late it turns up — its own counter is
+    # still at zero. This is the half of the defect that mattered: a run that was healthy for ten
+    # thousand steps and then was not says so.
+    @test should_report!(:probe_other)
+
+    # Which is why the keys carry the dominant line-search outcome: a solve that starts stagnating
+    # for a new reason is a new diagnosis, not a continuation of the old one.
+    reset_warning_counts!()
+    @test should_report!(Symbol(:stagnated_, LINESEARCH_FLOOR))
+    @test should_report!(Symbol(:stagnated_, LINESEARCH_NO_DESCENT))
+
+    # End to end: the same unattainable solve repeated is not reported every time ...
+    Ffloor(y, x, params) = y .= ((1e8 .+ x) .- 1e8) .- 1e-9
+    function stagnation_reports(n)
+        reset_warning_counts!()
+        count = 0
+        for _ in 1:n
+            x = [1.0]
+            s = NewtonSolver(x, Ffloor, zero(x); f_abstol=1e-20, f_reltol=0.0)
+            logs, _ = Test.collect_test_logs() do
+                solve!(x, s, SolverState(s))
+            end
+            count += any(r -> occursin("stagnated", string(r.message)), logs)
+        end
+        count
+    end
+    @test stagnation_reports(1) == 1
+    @test stagnation_reports(16) == 5      # solves 1, 2, 4, 8, 16
+    @test stagnation_reports(4) == 3       # solves 1, 2, 4
+end
+
+@testset "$(rpad("the line-search tally is per solve and covers every step", 80))" begin
+    # The tally lives in the state and is reset by `initialize!`, exactly like `stalls`: what the
+    # line search reported during the *previous* solve says nothing about this one.
+    F(y, x, params) = y .= x .^ 2 .- 2
+    x = [1.0, 1.0]
+    s = NewtonSolver(x, F, zero(x); verbosity=0)
+    state = SolverState(s)
+
+    solve!(x, s, state)
+    first = collect(linesearch_outcomes(status(s, state)))
+    @test sum(first) == iteration_number(state)
+
+    x .= 1.0
+    solve!(x, s, state)
+    @test collect(linesearch_outcomes(status(s, state))) == first   # reset, not accumulated
+
+    # A hand-rolled iteration that never initializes keeps it at zero, the same guarantee
+    # `stall_number` gives.
+    fresh = NonlinearSolverState(x)
+    @test all(iszero, linesearch_outcomes(fresh))
+    @test linesearch_failures(fresh) == 0
+
+    # `record_linesearch!` counts by outcome, and `linesearch_failures` counts only the outcomes
+    # that are not benign.
+    record_linesearch!(fresh, LINESEARCH_DECREASED)
+    record_linesearch!(fresh, LINESEARCH_NO_DESCENT)
+    record_linesearch!(fresh, LINESEARCH_NO_DESCENT)
+    record_linesearch!(fresh, LINESEARCH_STATIONARY)
+    @test linesearch_outcomes(fresh)[linesearch_index(LINESEARCH_NO_DESCENT)] == 2
+    @test linesearch_failures(fresh) == 2
+    @test SimpleSolvers.isbenign(LINESEARCH_DECREASED)
+    @test SimpleSolvers.isbenign(LINESEARCH_STATIONARY)
+    @test SimpleSolvers.isbenign(LINESEARCH_UNKNOWN)
+    @test !SimpleSolvers.isbenign(LINESEARCH_FLOOR)
+    @test !SimpleSolvers.isbenign(LINESEARCH_EXHAUSTED)
+    @test !SimpleSolvers.isbenign(LINESEARCH_NO_DESCENT)
+
+    # Ties go to the outcome declared first, i.e. away from the more alarming diagnosis.
+    record_linesearch!(fresh, LINESEARCH_FLOOR)
+    record_linesearch!(fresh, LINESEARCH_FLOOR)
+    st = NonlinearSolverStatus(fresh, Options())
+    @test dominant_linesearch_outcome(st) === LINESEARCH_FLOOR
 end

--- a/test/nonlinear_solver_tests.jl
+++ b/test/nonlinear_solver_tests.jl
@@ -1774,8 +1774,8 @@ end
 
     # Now that the gates live in the reporters rather than at the site that decides to report, pin
     # them: each message fires at its documented verbosity and is silent one below. Neither of the
-    # two below carries `maxlog`, so unlike the line-search messages this is repeatable within a
-    # session.
+    # two below is rate limited, so this is repeatable within a session — unlike the three messages
+    # of `nonlinear_solver_warnings`, which back off through `should_report!`.
     #
     # `report_dogleg_underflow` is not pinned this way: a collapsed trust-region radius needs a
     # merit that is finite and non-decreasing along every direction the method tries, and every
@@ -1923,4 +1923,54 @@ end
     record_linesearch!(fresh, LINESEARCH_FLOOR)
     st = NonlinearSolverStatus(fresh, Options())
     @test dominant_linesearch_outcome(st) === LINESEARCH_FLOOR
+end
+
+@testset "$(rpad("a converged solve reports the line search only when it went wrong", 80))" begin
+    # The last step of a converged solve reaches the merit's round-off floor as a matter of course
+    # — that is *how* it converged — so `LINESEARCH_FLOOR` in the tally of a converged solve is the
+    # healthy case. Reporting on the tally as a whole announced that every textbook solve "did not
+    # go smoothly", which is the noise `linesearch_reason` itself defines: one failure is the last
+    # step, a count is evidence. So the converged report counts the outcomes that are *not* the
+    # expected floor.
+    converged = NonlinearSolverState([1.0])
+    initialize!(converged, [1.0], [0.0])
+    update!(converged, [1.0], [0.0])
+    update!(converged, [1.0], [0.0])
+
+    for _ in 1:3
+        record_linesearch!(converged, LINESEARCH_DECREASED)
+    end
+    record_linesearch!(converged, LINESEARCH_FLOOR)
+    floored = NonlinearSolverStatus(converged, Options(Float64; verbosity=2))
+    @test isconverged(floored)
+    @test linesearch_failures(floored) == 1          # the floor still counts in the tally ...
+    @test !logged_any(() -> nonlinear_solver_warnings(floored, Options(Float64; verbosity=2)),
+        "not every step went smoothly")               # ... but is not news about a converged solve
+
+    # A step the search could not resolve at all is news, however, and it is the only trace of the
+    # line search a solve leaves.
+    record_linesearch!(converged, LINESEARCH_EXHAUSTED)
+    rough = NonlinearSolverStatus(converged, Options(Float64; verbosity=2))
+    @test isconverged(rough)
+    @test logged_any(() -> nonlinear_solver_warnings(rough, Options(Float64; verbosity=2)),
+        "not every step went smoothly")
+    @test logged_any(() -> nonlinear_solver_warnings(rough, Options(Float64; verbosity=2)),
+        "LINESEARCH_EXHAUSTED")
+    # ... at `verbosity ≥ 2` only, the same gate the floor and stationary outcomes use.
+    @test !logged_any(() -> nonlinear_solver_warnings(rough, Options(Float64; verbosity=1)),
+        "not every step went smoothly")
+
+    # End to end, on the solve the package's own doctests use: nothing at all is said about the
+    # line search, at any verbosity, for a solve that simply worked.
+    F(y, x, params) = y .= x .^ 2 .- 2
+    healthy() = function ()
+        x = ones(3)
+        s = NewtonSolver(x, F, zero(x); verbosity=2)
+        state = SolverState(s)
+        solve!(x, s, state)
+        @test linesearch_outcomes(status(s, state))[linesearch_index(LINESEARCH_FLOOR)] > 0
+    end
+    reset_warning_counts!()
+    @test !logged_any(healthy(), "not every step went smoothly")
+    @test !logged_any(healthy(), "line search")
 end


### PR DESCRIPTION
Fixes the two upstream defects [GeometricOptimizers.jl](https://github.com/JuliaGNI/GeometricOptimizers.jl) filed against SimpleSolvers in its CHANGELOG (**D3** and **D4**), plus what reviewing that work turned up. Breaking: `NonlinearSolverStatus` gains a field, a `NonlinearSolver` no longer emits line-search warnings from inside its iteration, and a `LinesearchMethod` implements `solve_with_status` rather than `solve`. Version bumped to `0.12.0`.

## 1. `Bisection` reported success when it could not bracket (D3)

`_bisection_core` returned `converged = true` on the branch that handles *no sign change between the endpoints*:

```julia
if y₀ * y₁ > zero(y₀)                                  # no sign change
    report_bisection_nobracket(α₀, α₁, y₀, y₁, config)
    return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), true, n      # ← converged = true
end
```

The intent was that a flat derivative at a minimum is benign. The effect was that the core could not tell *"found the root"* from *"gave up"*, and the endpoint of a bracket that never existed was handed on as if it were the located line minimiser.

That claim then propagated. `Bisection` bisects φ′ but brackets on φ, so the two disagree exactly when something is wrong — a stale or regularized Jacobian, an inexact linear solve, a non-smooth merit. The returned endpoint then typically does not improve the merit either, and the search classified it as `LINESEARCH_FLOOR`: *"no line search can make progress here"*. The outer iteration acts on that (`flag_stall!`, then `max_stalls`), so a failure to bracket was being read as a property of the problem.

- `_bisection_core` returns a `BisectionOutcome` (`BISECTION_CONVERGED` / `BISECTION_NOBRACKET` / `BISECTION_EXHAUSTED`) in place of the `Bool`. The `α` it returns is unchanged in every case — only the claim about it is.
- The line search classifies a failed bracket **by the merit alone, with `LINESEARCH_FLOOR` disallowed**: `LINESEARCH_DECREASED` when the step still beats φ(0) by more than τ, `LINESEARCH_EXHAUSTED` when it does not. `LINESEARCH_FLOOR` is now reachable only from a bisection that actually converged. The retry from the α = 0 anchor carries its own verdict through for the same reason; it used to be discarded.
- `bisection` dispatches on the outcome, so a spent budget and a failed bracket get the wording that fits each — only the first is fixed by a larger budget. Its no-bracket warning moves to `verbosity ≥ 1`; it sat at 2 only because the line search used to route through `bisection`, which it no longer does.

## 2. `maxlog` was per session, not per solve (D4)

The caps were keyed on the *source location* of the `@warn`, so they were process-global and never reset between `solve!` calls — a genuine line-search failure in the tenth solve of a run was silent because the first had spent the budget. This mattered because the log was the only channel by which a rejected line search was visible.

**The caps were a symptom.** The channel split already existed — `solve_with_status` returns a `LinesearchStatus` and emits nothing, `solve` adds `linesearch_warnings` — but `solver_step!` called `solve_with_status` and then `linesearch_warnings` *anyway*, once per outer iteration. A solve that cannot make progress asks the line search for an impossible decrease at every one of its iterations, so that call is what turned one diagnosis into thousands of identical messages.

- `solver_step!` no longer calls `linesearch_warnings`. A line search reports to its **caller** through `LinesearchStatus`, and to the **user** only when the user called `solve(ls, α)` directly. One direct call yields one message, so the three `maxlog` caps are **deleted rather than reimplemented**.
- `NonlinearSolverState` tallies the outcome of every step; `NonlinearSolverStatus` carries a snapshot, read with `linesearch_outcomes` / `linesearch_failures` / `dominant_linesearch_outcome`. This is the programmatic channel the package lacked — the upstream half of GeometricOptimizers' open **B1**.
- The stagnation and no-progress messages name what the line search reported and how often, so a failed solve names the cause and not only the symptom.
- One deliberate loss: a solver at `verbosity ≥ 2` no longer pays for `curvature_diagnostic` (a full Jacobian) once per iteration.

`nonlinear_solver_warnings` is then the only site still needing a cross-solve cap. It uses `should_report!` — 1st, 2nd, 4th, 8th … occurrence — keyed on the dominant line-search outcome, so a solve that starts failing for a *new* reason is reported at once. The trade is stated rather than glossed: a repeating diagnosis is silent on occurrence 10 and reported on 16.

## Verification

- Full suite green: 1409 line-search and 3017 nonlinear-solver assertions (1398/3006 before the review commit). Docs build clean, doctests pass.
- Allocations unchanged: zero for every line search and for Picard/DogLeg (StrongWolfe's 288 B is the pre-existing documented exception).
- Downstream, in a throwaway environment: **ThreeBody/ImplicitMidpoint goes from 6 messages to 1**, and that one message now carries what the five suppressed line-search warnings used to say, with a count. LotkaVolterra2d/Gauss(2) is bit-identical.
- The GeometricIntegrators suite passes against this branch with Pass/Broken counts identical to registered 0.11.0.

## 3. Review pass (second commit)

A converged solve floors on its last step as a matter of course, and `linesearch_failures` counts `LINESEARCH_FLOOR`, so the new `verbosity ≥ 2` report announced that *every* healthy solve "did not go smoothly" — six iterations on `x² − 2`, one floor, one message. It now counts the outcomes that are **not** the expected floor, and names the one that made it fire rather than the floor it is ignoring (with one of each, the tie rule would otherwise explain the message by the half of it that is expected). `dominant_linesearch_outcome` gains a `count_floor` argument and `linesearch_reason` an outcome to explain.

Two of the **Open Issues** are closed rather than recorded:

- **A `LinesearchMethod` implements `solve_with_status`; `solve` is derived** (breaking). The layering held for the six built-ins only because each wrote the same three-line `solve` on top of its status; the generic fallback ran the other way, so a third-party method implementing only `solve` was reached *through* `solve` from inside every iteration of a solve and emitted its messages there — with no `maxlog` left to bound it. `solve` is now one derived definition, the six copies and the "Solve method missing" stub are gone, `solve(ls, 1)` works, and the generic `solve_with_status` raises with the signature it owes instead of recursing. GeometricOptimizers' `DecayingStatic` implements both and is unaffected; its own `solve` stays more specific than the derived one, verified against a mock of that shape.
- **`Bisection` reports the merit it measured.** Two returns filled `φ` with `φ(0)` — no bracket at all, and a bisection that landed on a non-positive step — so for `φ(α) = 1 − α` the status read `α = 1.0, φ(α) = 1.0` where the value is `0.0`, and `linesearch_exhausted_reason` described a merit that descends forever as not having changed. `check_anchor` keeps `φ(0)` deliberately, and now says so.

The rest of that commit is documentation the first one made untrue: `solve_with_status` claiming only `Backtracking` reports a real outcome, the function-barrier rationale citing the `solver_step!` call the first commit deleted, three `maxlog` references in tests to caps that no longer exist, and a `Bisection` retry comment that reads as replacing the first attempt's verdict when the code keeps the worse of the two — left as it stands, since the two disagree only when φ′ is inconsistent with φ and `LINESEARCH_EXHAUSTED` says exactly that.

## Also in this PR

`CHANGELOG.md` gains an **Open Issues** section recording what surfaced during this work and was *not* fixed: that `Bisection` can still converge onto a *maximum* (the other route into an overclaimed `LINESEARCH_FLOOR`, which needs a change to what the method searches for rather than what it reports), that the trace options have zero readers, and that `should_report!`'s backoff does not promise every occurrence.

Raised in review and deliberately not changed: `flag_stall!` no longer fires for a failed bracket, so such a solve runs to `max_iterations` instead of stopping after `max_stalls` and relies on the step-based `stalled_step` — that is the point of the change, and the downstream check covers it. And `"Solver took N iterations."` still carries no `linesearch_reason`, because appending it re-raises the noise question above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
