### PR TITLE
Bound the step a line search may return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,34 @@ divided by `‖δ‖` — is not something the search can measure.
   `bracket_minimum`, which reports a truncated bracket as an ordinary one — it was the one path in
   the method that could not reach `capped_status`, and would have bisected `φ′` over an interval on
   which it keeps its sign.
+- A ceiling at or *below* the bracketing start is answered without a search. `_triple_point_core`
+  bounds its first probe with `δ = min(δ, αmax - x₀)`, which is not positive when `αmax ≤ x₀`, so
+  every probe landed at or *left* of the start: on `f(α) = 1 - α`, `αmax == x₀` reported `:flat`
+  after two evaluations — that no line search can decrease the merit here, about a search that was
+  never allowed to look — and `αmax < x₀` spent twelve halving a negative `δ` first. It now
+  reports `:capped` for no evaluations at all. `BierlaireQuadratic` guarded this before it called,
+  which is why nothing leaked; the guard belongs where the `αmax` argument is.
+- The two optional `params` fields are read through the same guard. `φ₀` used `haskey` while
+  `αmax` used `hasproperty`, which agree on a `NamedTuple` and on nothing else: a plain struct had
+  its ceiling honoured and then raised a `MethodError` from inside the merit. Both use
+  `hasproperty` now, which is what the rest of the closure requires anyway — it reaches `params.x`
+  and `params.parameters` by property access, so a `Dict`, the one thing `haskey` bought, could
+  never have worked. `NullParameters` and any struct do.
+- `Quadratic` no longer pays a derivative evaluation for a search the ceiling then cancels. It
+  chose its bracketing start — the `φ′(α₀)` of issue #164 — before testing whether the ceiling
+  left anything to search, so a trial step at or beyond the ceiling, which is the common case
+  once a caller supplies one, cost a full `Jacobian` for the ``\|F\|^2`` merit and discarded the
+  answer. The ceiling is tested first; the answer is the same on either side of the minimiser.
+- `trials` counts what the search really spent. The bracketing cores now report their evaluation
+  count alongside their status, and the three searches that bracket carry it into the
+  [`LinesearchStatus`](@ref) — as does `capped_status`, and as do the four returns that measure
+  the merit at the step they hand back. The field was documented as a lower bound for those
+  methods, and on the capped path, where the bracketing *is* the search, the bound was vacuous:
+  `Bisection` reported `1` after eight merit evaluations and `Quadratic` reported `0` after two,
+  which is the value `Static` reports for evaluating nothing at all. `Quadratic`'s fixed `n += 2`
+  per fit round goes with it — it was a proxy for the two endpoint merits from when the
+  bracketer's cost was invisible, and those are exactly the evaluations now counted for real.
+  `Backtracking` and `StrongWolfe` are unchanged and still exact.
 
 #### Changed (behavioural)
 
@@ -1382,54 +1410,6 @@ follows is what is left.
   visible where it previously took a contrived merit to reach. Whether a Wolfe search *should* call
   a step that was never allowed to grow "exhausted" is a question about that method, not about the
   ceiling, so it was left alone.
-
-### Raised while reviewing the step ceiling, not addressed
-
-The review that found the truncation defect (`_bracket_core` reporting a bracket clamped to the
-ceiling as a found one, fixed in 0.12.0) turned up four more, none of which it closed. The
-`LINESEARCH_FLOOR` entry above is a fifth and belongs to this list as much as to the one it sits in.
-
-- **`_triple_point_core` walks the wrong way for a ceiling at or below its start.** It bounds its
-  first probe with `δ = min(δ, αmax - x₀)`, which is not positive when `αmax ≤ x₀`, so `x₁ = x₀ + δ`
-  lands at or *left* of the start and the rest of the routine is nonsense: measured on
-  `f(α) = 1 - α`, `αmax == x₀` reports `:flat` after two evaluations — which
-  `BierlaireQuadratic` would map to `LINESEARCH_FLOOR`, a claim that no line search can progress
-  along the direction — and `αmax < x₀` spends twelve evaluations halving a negative `δ` before
-  reporting `:unbracketable`. Unreachable from a line search, because `BierlaireQuadratic` returns
-  `capped_status` on `start < αmax` failing before it calls the core, and that guard is the reason
-  the core was left without one of its own. Reachable by any other caller of `_triple_point_core`,
-  which is where the `αmax` argument lives. The fix is a `δ > 0` check in the core rather than in
-  its one caller; left because adding it means deciding what a core asked to search a range of zero
-  width should say, and `:capped` — the honest answer — is a status the public
-  `triple_point_finder` cannot express.
-- **The two `params` channels are not read the same way, and only one of them accepts a struct.**
-  `caller_αmax` guards with `hasproperty`, while the merit closure of `linesearch_problem` guards
-  `φ₀` with `haskey`. They agree on a `NamedTuple`, which is what every caller in this package and
-  downstream passes, so nothing is broken today. They do not agree on anything else: for a plain
-  struct with `x`, `αmax` and `φ₀` fields, `hasproperty` finds the ceiling and honours it while
-  `haskey` raises a `MethodError` from inside the merit — verified. So the two halves of what the
-  docstrings describe as one channel impose different requirements on `params`, and the stricter of
-  them is undocumented. `hasproperty` throughout would be the wider contract and is a one-line
-  change; left because widening what `params` may be is a decision about the extension point, not
-  about the ceiling, and it wants its own tests for the `NullParameters` and `Dict` cases.
-- **`Quadratic` pays a derivative evaluation for a search the ceiling then cancels.**
-  `_quadratic_search` picks its bracketing start with `derivative(problem(ls), α₀, params)` and only
-  *then* tests `α < αmax`, so a trial step at or above the ceiling — the common case once a caller
-  supplies one, since the ceiling is what makes the trial step inadmissible — costs a derivative
-  evaluation whose answer is discarded. Measured on `φ(α) = 1 - α` with `params.αmax = 0.5`: two
-  derivative evaluations for a search that returns the ceiling without bracketing. For the
-  ``\|F\|^2`` merit of a `NonlinearSolver` that is a full `Jacobian`. Hoisting the ceiling test
-  above the start selection fixes it; left because the ordering interacts with issue #164's rule
-  for *where* the bracketing starts, and untangling the two is more than the one evaluation is
-  worth on its own.
-- **`trials` says almost nothing about a capped search.** The field is documented as a lower bound
-  for the bracketing searches, since evaluations spent inside a bracketing helper are not counted —
-  but on the capped path the bracketing *is* the whole search, so the bound is vacuous. Measured:
-  `Bisection` reports `trials = 1` after eight merit evaluations, and `Quadratic` reports
-  `trials = 0` after two, which is the same value `Static` reports for a method that evaluates
-  nothing at all. Nothing reads `trials` except the warning messages, which is why this is an
-  entry and not a defect, but a caller sizing the cost of a line search from it is misled exactly
-  where the ceiling made the search cheap.
 
 ### Raised while fixing the `Bisection` maximum, not addressed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1337,6 +1337,46 @@ follows is what is left.
   a step that was never allowed to grow "exhausted" is a question about that method, not about the
   ceiling, so it was left alone.
 
+### Raised while fixing the `Bisection` maximum, not addressed
+
+- **The orientation is not checked on a bracket that `bracket_minimum` flipped.**
+  `_bisect_for_minimum` returns early on `lo ≤ 0`, which covers two different things: the overshoot
+  branch, where `lo = 0` and `ylo` *is* the `φ′(0) < 0` the anchor check established (genuinely
+  nothing to check), and a bracket that the walk flipped leftward, where `lo < 0` and nothing has
+  been established at all. The second is a real hole, and it is demonstrable: on `φ(α) = α²` with
+  `φ′` given the roots `-0.5`, `0.3`, `0.7`, `bracket_minimum` returns `[-1, 1]` with `φ′(-1) > 0`,
+  and the bisection converges to `α = -0.5` — a **maximum**, reached with the check skipped.
+
+  Nothing leaked in that instance, because `-0.5 < 0` and the α > 0 contract rejected it: the
+  negative-step retry fired and the search reported `LINESEARCH_EXHAUSTED`. Whether the same route
+  can select a maximum at *positive* α — the interval spans zero and may contain several `+ → -`
+  crossings, only some of them negative — was **not** established either way. It is hard to arrange
+  because `check_anchor` guarantees `φ′(0) < 0`, so a crossing selected from a positive left
+  endpoint has one candidate at or before zero; it is not ruled out. The clean closure is to bisect
+  `[0, hi]` rather than `[lo, hi]` whenever `lo < 0` — a positive step is all the contract permits
+  anyway, and `φ′(0) < 0` orients it by construction — but that removes the flipped-bracket case the
+  negative-step retry exists to handle, so it wants its own change and its own tests.
+- **The repair throws away the first bisection.** When `ylo > 0`, `_bisect_for_minimum` has already
+  run a complete bisection to a root it then discards, and pays for a second one. Checking the
+  orientation *before* the loop — an argument to `_bisection_core` saying which sign the left
+  endpoint must have, or a two-evaluation pre-flight — would spend two derivative evaluations
+  instead of a whole bisection. Left because the path is the pathological one and the cost on the
+  common path, which is what the fix was careful about, is already zero.
+- **`_bisection_core` decides its root test with `f_abstol`, which is a residual tolerance.** The
+  loop stops early on `≈(y, 0; atol = config.f_abstol)` where `y` is `φ′(α)`, while `Options`
+  documents `f_abstol` as *"an absolute target for ‖F(x)‖"*. Those are incommensurable: `φ′` is the
+  α-derivative of `‖F‖²`, not a residual norm. It is invisible at the default `f_abstol = 0`, where
+  the branch fires only on an exact zero and the loop terminates on its width test instead — but it
+  is not invisible when a caller sets one. Measured on `φ(α) = (α-1)²`: `f_abstol = 0` locates the
+  minimiser to `|φ′| = 8.9e-16`, `1e-6` to `9.5e-7`, and `1e-2` to `7.8e-3`, i.e. raising the
+  residual tolerance for a coarse solve silently coarsens the line minimiser by the same factor.
+  This is the same class of defect as the one 0.10.0 fixed in `BierlaireQuadratic`, where "one
+  absolute constant used to govern three incommensurable quantities"; the fix there was to compare
+  merit differences against `τ` and α-space widths against `ε`. The equivalent here is a tolerance
+  of the bisection's own, defaulting to something derived from `φ′(0)`. Left out because it changes
+  the accuracy of every `Bisection` solve that sets `f_abstol`, which is a behaviour change with no
+  reported symptom behind it.
+
 ### Documentation
 
 - **There is no page for the nonlinear solvers.** 0.12.0 adds `docs/src/convergence.md`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,169 @@ All notable changes to SimpleSolvers.jl are documented here.
 
 ## [0.12.0]
 
-Two defects reported from downstream by
-[GeometricOptimizers.jl](https://github.com/JuliaGNI/GeometricOptimizers.jl), filed there as **D3**
-and **D4**, and the two reporting defects a review of that work turned up. **Breaking**: a
+Three defects reported from downstream by
+[GeometricOptimizers.jl](https://github.com/JuliaGNI/GeometricOptimizers.jl), filed there as **D3**,
+**D4** and **D6**, and the two reporting defects a review of that work turned up. **Breaking**: a
 `NonlinearSolver` no longer emits line-search warnings from inside its iteration,
 `NonlinearSolverStatus` gains a field, and a `LinesearchMethod` now implements `solve_with_status`
 rather than `solve`.
+
+### A line search bounds the step it returns
+
+[Issue D6](https://github.com/JuliaGNI/GeometricOptimizers.jl/blob/main/CHANGELOG.md), the upstream
+half of GeometricOptimizers' **A1b**.
+
+#### The gap
+
+`Quadratic` and `BierlaireQuadratic` fit a polynomial to `φ` and step to its stationary point. The
+fits already confine that point to the bracket — what nothing confined was the **bracket**.
+`bracket_minimum_with_fixed_point` and `_triple_point_core` double their probe step up to
+`DEFAULT_BRACKETING_nmax = 100` times, so from `s = 1e-2` the right endpoint can in principle reach
+`1e28`. Measured downstream on the `St(20,3)²` SVD problem, `Quadratic` returned `α = 4.3e7` on a
+direction of norm 5.54 — a step of `‖αδ‖ = 2.4e8` — and did it again two steps later on a
+steepest-descent direction, so the behaviour belongs to the search and not to its input.
+`bracket_minimum`, and hence `Bisection`, has the same shape.
+
+Why this went unreported for so long is the part worth stating, because it is also what makes it a
+`SimpleSolvers` defect rather than a downstream one. In a Euclidean problem it is self-correcting:
+`f(x + αp)` grows with `α` — as `α²` for a quadratic — so the search's own decrease test throws the
+step out and no one ever sees it. On a **compact** manifold it is not. `φ` is bounded there, and at
+`α = 1e9` it can be genuinely *lower* than at `α = 0`, so the search reports `LINESEARCH_DECREASED`
+on a step that is nine orders of magnitude too long and is telling the truth. **The merit is not a
+bound on the step**, and the bound that does exist — for a manifold solver, the `2π` of a rotation
+divided by `‖δ‖` — is not something the search can measure.
+
+#### Added
+
+- Every `LinesearchMethod` now returns `α ≤ αmax`, a sixth clause of the contract in
+  `LinesearchMethod`, with two ways to set that ceiling. `SimpleSolvers.linesearch_αmax` is the one
+  definition of the policy, as `check_anchor` is of the anchor policy.
+- **The method's own ceiling**, the `αmax` field, is generalised from `StrongWolfe` — which has
+  carried exactly this field, with exactly this meaning, since before the bracketing searches were
+  found to need one — to `Bisection`, `Quadratic` and `BierlaireQuadratic`. All four default to the
+  new `SimpleSolvers.DEFAULT_LINESEARCH_αmax`, which *is* `DEFAULT_WOLFE_αmax = 65536.0`; the latter
+  is now defined as the former so the two cannot drift. An absolute number is the right shape
+  because `α` scales an already-chosen direction and is therefore a step-length *fraction* of order
+  one — the same argument `BierlaireQuadratic` already makes for its bracket-width `ε`.
+- **The caller's ceiling** is an optional `αmax` field of `params`:
+  `solve_with_status(ls, one(T), (x = x, αmax = 2π / norm(δ)))`. It is read through the same
+  compile-time `hasproperty` guard as `params.φ₀`, so a caller that supplies nothing pays nothing,
+  and it is *not* a keyword, so `solve_with_status(ls, α, params)` keeps the signature that the
+  contract names as the extension point — a third-party method (GeometricOptimizers'
+  `DecayingStatic`) is unaffected either way.
+
+  It has to be per call because the scale it comes from changes with `‖δ‖` at every solver step, and
+  it has to be an *input* rather than a clamp on the returned `α`: clamping afterwards yields a step
+  the search never evaluated, whose `LinesearchStatus` then describes a different step than the one
+  taken. As an input, the bracketing stops at the ceiling — so the evaluations beyond it are saved,
+  not merely wasted — the merit is measured there, and the status describes the step handed back.
+- All six methods honour it, including the two with no ceiling of their own: `Backtracking` clamps
+  its trial step and bounds its opt-in expansion phase, and `Static` clamps its fixed `α`.
+  `check_anchor` clamps too, so the ceiling holds on the returns that never search.
+- `SimpleSolvers.capped_status` is what a search reports when the ceiling binds, and it is
+  deliberately **not** a new `LinesearchOutcome`: the merit is evaluated at `αmax` and classified by
+  the same `τ` rule as any other returned step. A ceiling is not a failure — on the compact merit
+  where this arises the step genuinely decreases `φ` — and a caller that supplied a ceiling can
+  compare it against `steplength`. Adding an outcome would have changed `NLINESEARCH_OUTCOMES`, the
+  tally in `NonlinearSolverState`, and every downstream read of it, to say something the caller
+  already knows.
+- The ceiling bounds where the merit is **evaluated**, not only what is returned. Each bracketer's
+  *first* probe is bounded as well as its loop's, so a ceiling smaller than the bracketing step
+  `DEFAULT_BRACKETING_s` is not stepped over before the bound is first tested — one evaluation, but
+  on a problem where a step past the ceiling is meaningless it is precisely the evaluation the
+  ceiling exists to avoid. Asserted for all six methods by recording every `α` the merit is asked
+  for.
+- The bracketing helpers gained cores that report the truncation — `_bracket_core`,
+  `_bracket_minimum_core`, `_bracket_minimum_with_fixed_point_core`, and a `:capped` status
+  alongside `_triple_point_core`'s `:flat`/`:unbracketable`. This is the third use of the
+  split that `bisection`/`_bisection_core` and `triple_point_finder`/`_triple_point_core` already
+  make; the public functions keep the return types they document. The distinction earns its keep:
+  handing a truncated bracket to the fits would be worse than useless, because `Quadratic`'s
+  curvature guard sees a monotone-decreasing interval, falls back to bisecting it, and returns a
+  midpoint strictly worse than the endpoint.
+
+#### Changed (behavioural)
+
+One case changes at default options: a merit that keeps decreasing to the right. It used to exhaust
+the bracketing budget and be reported as `LINESEARCH_EXHAUSTED` with the caller's `α` handed back;
+it now stops at the ceiling and returns it, reported as `LINESEARCH_DECREASED` because the merit
+there really is lower. That is the better answer of the two — `EXHAUSTED` on a merit that descends
+is the least informative outcome the enum has — and it is why `:unbracketable` is now reachable only
+with the ceiling switched off (`αmax = Inf`) or on a leftward, flipped search. One test expectation
+moved with it, and the old behaviour is asserted alongside the new one at `αmax = Inf`.
+
+Nothing else moves unless the ceiling binds: on the `(α-1)²` fixtures the step, the outcome and the
+merit-evaluation count are identical with and without a generous `params.αmax`, and the six
+per-method evaluation canaries and every zero-allocation assertion stand unedited. A ceiling in
+`params` allocates nothing, which is asserted for all six methods.
+
+`Bisection` gains a field and is no longer a singleton, but `Bisection()`, `Bisection(T)`,
+`Bisection{T}()` and `Bisection(T, ::SolverMethod)` all still construct one; `show` and `isapprox`
+report the field, as they already did for `StrongWolfe`.
+
+#### Measured
+
+Downstream, on GeometricOptimizers' SVD problem, `_BFGS` + `Cayley`, over the eight starting points
+of `scripts/retraction_accuracy.jl` (cap 20 000). *On the manifold* means the run ended with
+`check ≤ 1e-12`, that package's own `MANIFOLD_TOLERANCE`; it is the criterion that matters here
+because A1b's failure is a solve that reports success from a point that is no longer on `St(20,3)`:
+
+| search | ceiling | seeds ending on the manifold | worst `check` |
+|---|---|---|---|
+| `Quadratic` | none (before) | 4 of 8 | 1.3 |
+| `Quadratic` | 65536 (the default) | 4 of 8 | 2.8 |
+| `Quadratic` | 100 | 4 of 8 | 1.2 |
+| `Quadratic` | 10 | 7 of 8 | 4.1e-9 |
+| `Quadratic` | 1 | **8 of 8** | **6.2e-14** |
+| `BierlaireQuadratic` | none (before) | 2 of 8 | 0.92 |
+| `BierlaireQuadratic` | 65536 (the default) | 4 of 8 | 0.38 |
+| `BierlaireQuadratic` | 100 | 4 of 8 | 76 |
+| `BierlaireQuadratic` | 10 | 7 of 8 | 4.7e-9 |
+| `BierlaireQuadratic` | 1 | **8 of 8** | **6.4e-14** |
+
+Read that honestly: **the default ceiling does not fix A1b.** At `‖δ‖ ≈ 5.5` a step of `α = 65536`
+is still `‖αδ‖ = 3.6e5`, five orders above the `2π` at which a rotation stops going anywhere, so
+most of the runs that diverged still diverge — and the value they diverge *to* is noise, which is
+why the `check` column moves in both directions across the top three rows of each block and why
+`BierlaireQuadratic`'s 2-of-8 → 4-of-8 at the default is worth no more than that. What the default
+reliably does is remove the unbounded extrapolation (`α = 4.3e7` is gone) and bound the bracketing
+cost for everyone.
+
+What *fixes* A1b is a ceiling of the right **magnitude**, and the bottom row of each block is the
+evidence that one exists and that this is the mechanism for it: at `αmax = 1`, i.e. `‖αδ‖` of a few
+and so of order `2π`, all eight starting points converge cleanly onto the manifold, from 4 and 2.
+Which is exactly why the caller's half is not optional — `2π/‖δ‖` is geometry, it changes at every
+step, and no property of `φ` reveals it. The ceiling GeometricOptimizers should pass is theirs to
+choose; this change is what lets them pass one.
+
+Everything else downstream is unmoved. GeometricIntegrators' Runge-Kutta suite passes (107
+assertions), and `LotkaVolterra2d` over 1000 steps is **bit-identical** for `Gauss(1)`, `Gauss(2)`,
+`Gauss(3)`, `ImplicitMidpoint` and `SRK3`. On the SVD sweep the Euclidean-scaled rows are unchanged
+to the digit; the single exception is `_DFP` + `Bisection` + `Cayley`, which moves from 110 to 111
+iterations — the ceiling binding once, on the same compact merit, in the search the report did not
+name.
+
+### Every convergence and stopping criterion is documented in one place
+
+`docs/src/convergence.md` is a new page. The criteria themselves are unchanged; what did not exist
+was a statement of them that a reader could follow end to end, since they were spread across a
+dozen docstrings on unexported functions.
+
+It covers three things. **The line search**: the round-off resolution ``\tau`` every criterion is
+expressed against, all six `LinesearchOutcome`s with the test that produces each, the anchor policy,
+``\alpha_\mathrm{min}``, the new ``\alpha_\mathrm{max}``, and the six clauses of the contract.
+**The nonlinear solver**: the three residuals, the shared `residual_small` gate that both
+convergence branches require and both give-up branches negate — which is *why* converging and
+stagnating are mutually exclusive — the four flags of `assess_convergence`, the four distinct ways a
+solve ends without converging, and the full `meets_stopping_criteria` disjunction. **The channel
+between them**: how a `LinesearchStatus` becomes a `flag_stall!`, a forced Jacobian refresh, a
+per-solve tally, and finally the clause that names the cause in the solver's own failure message.
+
+Two distinctions get stated outright because conflating either makes a solve report the wrong cause:
+`LINESEARCH_FLOOR` claims that *no* line search can progress here (and the outer iteration acts on
+it) whereas `LINESEARCH_EXHAUSTED` claims only that this one did not; and `LINESEARCH_NO_DESCENT`
+is a Jacobian problem, not a tolerance problem. The page closes with a table of every `Options`
+field that participates, its default, and which criterion it governs.
 
 ### `Bisection` no longer reports success when it cannot bracket
 
@@ -1051,6 +1208,9 @@ section and into the release that fixed it.
 
 ### Reported by GeometricOptimizers.jl, not addressed in 0.12.0
 
+Of their reports, **D3**, **D4** and **D6** are addressed in 0.12.0 and are written up there; what
+follows is what is left.
+
 - **`Bisection` can converge onto a *maximum*.** The 0.12.0 fix closed the route by which a
   *failed* bracket became `LINESEARCH_FLOOR`; it did not touch the route by which a *successful*
   one does. `bracket_minimum` brackets a minimum in **value**, which on a non-convex ray can
@@ -1068,6 +1228,63 @@ section and into the release that fixed it.
   ignored, so a caller who sets one gets silence rather than a trace or an error.
   GeometricOptimizers implements `store_trace` itself for this reason. Either implement them or
   remove them; both are breaking, so neither belongs in a release driven by something else.
+
+### Raised while fixing D6 (the step ceiling), not addressed
+
+- **The default ceiling does not close A1b, and cannot.** `DEFAULT_LINESEARCH_αmax = 65536` removes
+  the unbounded extrapolation and bounds the bracketing cost, but at `‖δ‖ ≈ 5.5` it still permits
+  `‖αδ‖ = 3.6e5`, five orders above the `2π` past which retracting a lift only adds round-off. Four
+  of the eight SVD starting points still diverge under `Cayley` with either polynomial search; the
+  same runs at `αmax = 1` all converge (the table in the 0.12.0 entry). The remaining half is
+  GeometricOptimizers passing `params.αmax = c·2π/‖δ‖`, which is theirs to write — and which they
+  cannot pick up until their `[compat]` moves off `SimpleSolvers = "0.11"`. **A1b stays open until
+  then.** Choosing the constant `c` is a decision about their geometry, not about `φ`, which is
+  exactly why this package does not make it for them.
+- **A binding ceiling leaves no trace in the `LinesearchStatus`.** By design there is no
+  `LINESEARCH_CAPPED` (see the 0.12.0 entry for why), and a caller who set `params.αmax` can
+  compare it against `steplength`. A caller relying on the *method's* ceiling cannot: "the
+  minimiser is at 65536" and "the search stopped because it was not allowed past 65536" are
+  reported identically, both as `LINESEARCH_DECREASED`. A boolean field on the status would close
+  it without touching the outcome enum or its tally; left out because nothing needed it yet and the
+  struct is copied per solver step.
+- **The capped path costs one merit evaluation that was already made.** `BierlaireQuadratic` and
+  `Bisection` reach `capped_status`, which evaluates `φ(αmax)` — the same point the bracketing
+  evaluated on the round it stopped. Carrying the value out of `_triple_point_core` and
+  `_bracket_core` (the fixed-point bracketer already returns its endpoint values) would remove it.
+  One evaluation, on a path that is rare in a Euclidean problem and is a full residual or objective
+  evaluation when it fires, so it is worth doing and was not urgent.
+- **The public bracketers can return a degenerate interval at the ceiling.** When `αmax` lies at or
+  below the bracketing start, `_bracket_core` returns `(a, a, :capped)` and `bracket` /
+  `bracket_minimum` hand that on as the interval `(a, a)` with no signal. Unreachable from a line
+  search — `Quadratic` and `BierlaireQuadratic` return the ceiling instead of bracketing when their
+  start is not strictly below it, and `Bisection` always brackets from `α = 0`, which every valid
+  ceiling is strictly above — but reachable by a standalone caller of the exported
+  `bracket_minimum`, which has no such guard.
+- **`:unbracketable` is now nearly unreachable, and with it the diagnosis it carried.** A rightward
+  search under a finite ceiling always terminates as `:ok` or `:capped`, so `LINESEARCH_EXHAUSTED`
+  from a *failed bracket* now needs `αmax = Inf` or a flipped, leftward search. That is the right
+  behaviour for the case it was measured on — a merit that descends forever is better answered with
+  the largest admissible step than with a failure — but it means a genuinely unbracketable merit is
+  now reported as an ordinary decrease at the ceiling. This is the same gap as the previous entry
+  seen from the other side: the status cannot say "I stopped because you would not let me look
+  further".
+- **`StrongWolfe` classifies the ceiling differently from the minimising searches.** On a merit
+  whose minimiser lies beyond it, the three minimising searches return `αmax` with
+  `LINESEARCH_DECREASED` while `StrongWolfe` returns `αmax` with `LINESEARCH_EXHAUSTED` (observed
+  on `φ(α) = (α - 10^7)²/10^{14}`). Its behaviour is unchanged and internally consistent — the
+  strong curvature condition genuinely was never met, and it has always reported the last
+  Armijo-acceptable step that way — but the ceiling makes the divergence between the two families
+  visible where it previously took a contrived merit to reach. Whether a Wolfe search *should* call
+  a step that was never allowed to grow "exhausted" is a question about that method, not about the
+  ceiling, so it was left alone.
+
+### Documentation
+
+- **There is no page for the nonlinear solvers.** 0.12.0 adds `docs/src/convergence.md`, which
+  documents every line-search outcome, every solver stopping criterion, and the channel between
+  them — but `NewtonSolver`, `PicardSolver` and their caches, states and constructors are still
+  reachable only through docstrings and the `@autodocs` index. The line searches have nine pages
+  and the solvers that call them have none.
 
 ### Introduced or left standing by 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,77 @@ it) whereas `LINESEARCH_EXHAUSTED` claims only that this one did not; and `LINES
 is a Jacobian problem, not a tolerance problem. The page closes with a table of every `Options`
 field that participates, its default, and which criterion it governs.
 
+### `Bisection` converges onto a minimum, never onto a maximum
+
+The sibling of the entry below, and the second of the two routes by which `Bisection` could claim
+`LINESEARCH_FLOOR` without having earned it. That entry closed the route through a *failed* bracket;
+this one closes the route through a **successful** one.
+
+#### The gap
+
+`Bisection` drives on the *sign* of `φ′`, so it converges to whichever crossing the sign of `φ′` at
+its left endpoint selects — and that sign is invariant under the halving. `y₀` is reassigned only on
+the branch where `y₀ * y > 0`, so it never changes sign and `y₁` keeps the opposite one throughout.
+From `φ′(lo) < 0` the interval shrinks onto a `- → +` crossing, which is a minimum; from
+`φ′(lo) > 0` onto a `+ → -` crossing, which is a **maximum**.
+
+Nothing ruled the second out. `bracket_minimum` brackets a minimum in **value** — it samples `φ` and
+never `φ′` — so on a non-convex ray its interval can enclose several stationary points and its left
+endpoint can sit past one of them. Landing on a maximum was not caught: the step was classified by
+the merit like any other, so it came back as `LINESEARCH_DECREASED` when it happened to improve `φ`
+and as `LINESEARCH_FLOOR` when it did not. The second is the overclaim, because `LINESEARCH_FLOOR`
+is a claim about the *direction* — that no line search can progress along it — which the outer
+iteration acts on through `flag_stall!` and `max_stalls`. GeometricOptimizers observed exactly this
+(`_BFGS` + `Bisection` + `Geodesic`: `LINESEARCH_FLOOR` reported with `φ(1) = φ(0)`, and the step
+taken regardless).
+
+#### Fixed
+
+- `_bisection_core` returns the value of `f` at the (sorted) **left endpoint** as a fourth element.
+  It is returned rather than recomputed because its sign is the invariant above, so it names which
+  kind of crossing the bisection is heading for before the bisection has finished heading there.
+- `SimpleSolvers._bisect_for_minimum` is what `Bisection` now bisects through. When
+  `φ′(lo) > 0` it discards the interval and bisects `[0, lo]` instead, which brackets a minimum **by
+  construction**: `check_anchor` has already established `φ′(0) < 0`, and `φ′(lo) > 0` supplies the
+  opposite sign at the other end. The minimum it then finds is the *earlier* one, nearer the anchor,
+  which is the one a line search wants. The same condition also repairs a `BISECTION_NOBRACKET`
+  whose interval ascends at `lo` — there too a minimum lies in `(0, lo)`.
+- The repair's verdict **replaces** the first bisection's rather than being merged with it, unlike
+  the negative-step retry below. The two disagree here because the bracket was in the wrong place,
+  which is precisely what the orientation detected — not because `φ′` is inconsistent with `φ`.
+
+#### Cost
+
+**None on a ray that does not need it.** The orientation is read off a value `_bisection_core`
+computes anyway, so a correctly oriented bracket is recognised without one extra evaluation of `φ′`
+— which for the `‖F‖²` merit of a `NonlinearSolver` is a full Jacobian. Only the pathological ray
+pays, and it pays for one further bisection. Asserted directly: over three intervals the repaired
+path returns the same step, the same verdict and the same evaluation count as the unrepaired one,
+and makes the same number of derivative evaluations.
+
+The overshoot branch is oriented by construction and always was — it bisects `[0, α]` with
+`φ′(0) < 0` at the left end — so it is unaffected; it now says so through the same helper rather
+than by implication.
+
+#### Measured
+
+On `φ(α) = (α-1)²` with `φ′` given its own shape (a minimum at `0.3`, a maximum at `2.0`) — the
+realistic case, since `Bisection` bisects `φ′` while bracketing on `φ` and the two disagree exactly
+when something is wrong — `bracket_minimum` returns `[0.64, 2.56]`, which ascends at `0.64` and
+descends at `2.56`. Bisecting it lands on `α = 2.0`, the maximum, where `φ(2) = φ(0)` exactly:
+`LINESEARCH_FLOOR`, the downstream symptom reproduced. Repaired, the search returns `α = 0.3` with
+`LINESEARCH_DECREASED` and `φ = 0.49` against `φ(0) = 1.0`.
+
+The orientation is not exotic. Over 300 random starting points on the `exp(x)(x³ − 5x² + 2x) + 2`
+root-finding fixture with `Bisection` as the `NewtonSolver` line search — a genuinely non-convex
+merit, so `bracket_minimum`'s interval really can enclose more than one stationary point — **13 of
+the 300 solves now converge to a different root** than before. Not a worse one: all 300 converge in
+both cases, the same eight distinct roots are reached, and the distribution of `|F|` at the returned
+iterate is bit-identical (median `6.7e-16`, 95th percentile `1.4e-13`, worst `2.7e-12`, all 300
+below `1e-10`). Total iterations drop from 698 to 687, with the worst case unchanged at 4. So on a
+merit with one minimum nothing moves at all, and on one with several the search now picks among them
+by orientation rather than by whichever the value-bracket happened to enclose.
+
 ### `Bisection` no longer reports success when it cannot bracket
 
 #### The gap
@@ -1211,18 +1282,6 @@ section and into the release that fixed it.
 Of their reports, **D3**, **D4** and **D6** are addressed in 0.12.0 and are written up there; what
 follows is what is left.
 
-- **`Bisection` can converge onto a *maximum*.** The 0.12.0 fix closed the route by which a
-  *failed* bracket became `LINESEARCH_FLOOR`; it did not touch the route by which a *successful*
-  one does. `bracket_minimum` brackets a minimum in **value**, which on a non-convex ray can
-  enclose several stationary points, and the bisection of ``\varphi'`` inside it may settle on any
-  of them. Landing on a maximum is not caught: the step is classified by the merit like any other,
-  so it is `LINESEARCH_DECREASED` when it happens to improve ``\varphi`` and `LINESEARCH_FLOOR`
-  when it does not — the same overclaim, reached by a different path. GeometricOptimizers observed
-  exactly this (`_BFGS` + `Bisection` + `Geodesic`: `LINESEARCH_FLOOR` with ``\varphi(1) =
-  \varphi(0)``, and the step taken regardless). A second-order check at the located root, or
-  rejecting a root with ``\varphi'' < 0`` and re-bracketing, would close it. Left out because it
-  changes what the method *searches for*, not merely what it *reports*, which is a larger change
-  than the reporting defect that prompted 0.12.0.
 - **`store_trace`, `show_trace` and `extended_trace` have no readers.** `grep` over `src/` finds
   them only in `Options` itself — they are accepted, printed by `show(::Options)`, and then
   ignored, so a caller who sets one gets silence rather than a trace or an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,28 @@ divided by `‖δ‖` — is not something the search can measure.
   handing a truncated bracket to the fits would be worse than useless, because `Quadratic`'s
   curvature guard sees a monotone-decreasing interval, falls back to bisecting it, and returns a
   midpoint strictly worse than the endpoint.
+- A ceiling at or *below* the bracketing step `s` is truncated where it is reached, and not one
+  probe past it. Every bracketer clamps its first probe to `αmax`, so when the ceiling is the
+  smaller of the two that probe *is* the ceiling — and the loop's probe then lands on the same
+  point. Comparing it with itself is a tie, and a tie satisfies `BracketMinimumCriterion`
+  (`yc ≥ yb`), so the truncation was reported as `:ok`: a turning point that is one point counted
+  twice. The `:capped` route was therefore unreachable below `s`, which for `Bisection` — whose
+  `s` is `clamp(|α|, 0.01, 1)`, i.e. `1` for the usual trial step — meant *every* caller ceiling
+  at or below one, the regime a caller with a geometric bound of its own is in and the one the
+  table below identifies as the one that closes A1b. On `φ(α) = 1 - α` under `Bisection`, a
+  ceiling of `1.0` returned `α = 0.32` and one of `0.5` returned `α = 0.16` — a third of the step
+  the caller allowed, on a merit that falls monotonically to it — for 15 merit evaluations, and
+  `LINESEARCH_EXHAUSTED`, a reported *failure*, at `0.005`. All five ceilings now return the
+  ceiling itself as `LINESEARCH_DECREASED` for four evaluations. `_bracket_minimum_core` returns
+  the truncation directly rather than through `_bracket_core` in that case, which also stops the
+  ceiling from being evaluated twice, and `_triple_point_core` — which classified it correctly all
+  along, since it tests `xₖ₊₁ > xₖ` — no longer pays for the value it already has. Nothing on the
+  default path moves: with `αmax = Inf` the branch is dead, and with the method's own `65536` the
+  first probe is never the ceiling.
+- `Bisection`'s negative-step retry brackets through `_bracket_minimum_core` rather than the public
+  `bracket_minimum`, which reports a truncated bracket as an ordinary one — it was the one path in
+  the method that could not reach `capped_status`, and would have bisected `φ′` over an interval on
+  which it keeps its sign.
 
 #### Changed (behavioural)
 
@@ -103,6 +125,15 @@ per-method evaluation canaries and every zero-allocation assertion stand unedite
 `Bisection` gains a field and is no longer a singleton, but `Bisection()`, `Bisection(T)`,
 `Bisection{T}()` and `Bisection(T, ::SolverMethod)` all still construct one; `show` and `isapprox`
 report the field, as they already did for `StrongWolfe`.
+
+The default ceiling is obtained through the new `SimpleSolvers.default_linesearch_αmax(T)`, which
+saturates it at `floatmax(T)`. `DEFAULT_LINESEARCH_αmax` is ``2^{16}`` and `floatmax(Float16)` is
+`65504`, so the plain `T(DEFAULT_LINESEARCH_αmax)` overflowed to `Inf` — a `Float16` line search
+carried no ceiling at all, i.e. the defect the field exists to fix was absent in the one precision
+`armijo_ulps`, `linesearch_iterations` and `default_precision` all special-case. `change_precision`
+saturates a finite ceiling for the same reason through `SimpleSolvers.convert_αmax`, and leaves an
+explicit `Inf` alone: that one is not an overflow but a statement. This was `StrongWolfe`'s alone
+before and is fixed for it too.
 
 #### Measured
 
@@ -1311,7 +1342,22 @@ follows is what is left.
   evaluated on the round it stopped. Carrying the value out of `_triple_point_core` and
   `_bracket_core` (the fixed-point bracketer already returns its endpoint values) would remove it.
   One evaluation, on a path that is rare in a Euclidean problem and is a full residual or objective
-  evaluation when it fires, so it is worth doing and was not urgent.
+  evaluation when it fires, so it is worth doing and was not urgent. The *second* duplicate on that
+  path — the one `_bracket_core` made by re-probing a ceiling `_bracket_minimum_core` had already
+  reached — is gone.
+- **A ceiling that binds can be reported as `LINESEARCH_FLOOR`.** `capped_status` classifies the
+  step at `αmax` by the same `τ` rule as any other returned step, so a merit that is still falling
+  at the ceiling — which is what `:capped` *means* — but has fallen by less than `τ` over the whole
+  admissible range comes back as a floor. That is a claim about the **direction**, that no line
+  search can progress along it, and the outer iteration acts on it through `flag_stall!` and
+  `max_stalls`; what was actually established is only that no step the caller *permits* decreases
+  the merit measurably. It is the same shape as the two unearned floors 0.12.0 removed from
+  `Bisection`, reached through a third door, and it is reachable exactly where the caller's ceiling
+  is tightest — the case the ceiling exists for. Left standing because the alternative is not
+  obviously better: `LINESEARCH_EXHAUSTED` says "no step was found", which is false of a step that
+  was found and returned, and a caller that supplied the ceiling can compare it against
+  `steplength`. Closing it properly means the boolean-on-the-status of the entry above, not a
+  different outcome.
 - **The public bracketers can return a degenerate interval at the ceiling.** When `αmax` lies at or
   below the bracketing start, `_bracket_core` returns `(a, a, :capped)` and `bracket` /
   `bracket_minimum` hand that on as the interval `(a, a)` with no signal. Unreachable from a line
@@ -1336,6 +1382,54 @@ follows is what is left.
   visible where it previously took a contrived merit to reach. Whether a Wolfe search *should* call
   a step that was never allowed to grow "exhausted" is a question about that method, not about the
   ceiling, so it was left alone.
+
+### Raised while reviewing the step ceiling, not addressed
+
+The review that found the truncation defect (`_bracket_core` reporting a bracket clamped to the
+ceiling as a found one, fixed in 0.12.0) turned up four more, none of which it closed. The
+`LINESEARCH_FLOOR` entry above is a fifth and belongs to this list as much as to the one it sits in.
+
+- **`_triple_point_core` walks the wrong way for a ceiling at or below its start.** It bounds its
+  first probe with `δ = min(δ, αmax - x₀)`, which is not positive when `αmax ≤ x₀`, so `x₁ = x₀ + δ`
+  lands at or *left* of the start and the rest of the routine is nonsense: measured on
+  `f(α) = 1 - α`, `αmax == x₀` reports `:flat` after two evaluations — which
+  `BierlaireQuadratic` would map to `LINESEARCH_FLOOR`, a claim that no line search can progress
+  along the direction — and `αmax < x₀` spends twelve evaluations halving a negative `δ` before
+  reporting `:unbracketable`. Unreachable from a line search, because `BierlaireQuadratic` returns
+  `capped_status` on `start < αmax` failing before it calls the core, and that guard is the reason
+  the core was left without one of its own. Reachable by any other caller of `_triple_point_core`,
+  which is where the `αmax` argument lives. The fix is a `δ > 0` check in the core rather than in
+  its one caller; left because adding it means deciding what a core asked to search a range of zero
+  width should say, and `:capped` — the honest answer — is a status the public
+  `triple_point_finder` cannot express.
+- **The two `params` channels are not read the same way, and only one of them accepts a struct.**
+  `caller_αmax` guards with `hasproperty`, while the merit closure of `linesearch_problem` guards
+  `φ₀` with `haskey`. They agree on a `NamedTuple`, which is what every caller in this package and
+  downstream passes, so nothing is broken today. They do not agree on anything else: for a plain
+  struct with `x`, `αmax` and `φ₀` fields, `hasproperty` finds the ceiling and honours it while
+  `haskey` raises a `MethodError` from inside the merit — verified. So the two halves of what the
+  docstrings describe as one channel impose different requirements on `params`, and the stricter of
+  them is undocumented. `hasproperty` throughout would be the wider contract and is a one-line
+  change; left because widening what `params` may be is a decision about the extension point, not
+  about the ceiling, and it wants its own tests for the `NullParameters` and `Dict` cases.
+- **`Quadratic` pays a derivative evaluation for a search the ceiling then cancels.**
+  `_quadratic_search` picks its bracketing start with `derivative(problem(ls), α₀, params)` and only
+  *then* tests `α < αmax`, so a trial step at or above the ceiling — the common case once a caller
+  supplies one, since the ceiling is what makes the trial step inadmissible — costs a derivative
+  evaluation whose answer is discarded. Measured on `φ(α) = 1 - α` with `params.αmax = 0.5`: two
+  derivative evaluations for a search that returns the ceiling without bracketing. For the
+  ``\|F\|^2`` merit of a `NonlinearSolver` that is a full `Jacobian`. Hoisting the ceiling test
+  above the start selection fixes it; left because the ordering interacts with issue #164's rule
+  for *where* the bracketing starts, and untangling the two is more than the one evaluation is
+  worth on its own.
+- **`trials` says almost nothing about a capped search.** The field is documented as a lower bound
+  for the bracketing searches, since evaluations spent inside a bracketing helper are not counted —
+  but on the capped path the bracketing *is* the whole search, so the bound is vacuous. Measured:
+  `Bisection` reports `trials = 1` after eight merit evaluations, and `Quadratic` reports
+  `trials = 0` after two, which is the same value `Static` reports for a method that evaluates
+  nothing at all. Nothing reads `trials` except the warning messages, which is why this is an
+  entry and not a defect, but a caller sizing the cost of a line search from it is misled exactly
+  where the ceiling made the search cheap.
 
 ### Raised while fixing the `Bisection` maximum, not addressed
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,6 +39,7 @@ makedocs(;
             "Quadratic" => "linesearch/quadratic.md",
             "Bierlaire Quadratic" => "linesearch/quadratic_bierlaire.md",
         ],
+        "Convergence and Stopping" => "convergence.md",
         "Trust Region" => ["Trust Region" => "trust_region/trust_region_summary.md",],
         "Linear Solvers" => "linear/linear_solvers.md",
         "References" => "references.md",

--- a/docs/src/convergence.md
+++ b/docs/src/convergence.md
@@ -1,0 +1,287 @@
+# Convergence and Stopping
+
+Two separate verdicts are reached in a solve, and this page documents both, together with the one
+channel that connects them:
+
+1. a **line search** decides, for a single direction, whether it found a step that decreases the
+   merit — and if not, *why not*. Its verdict is a [`LinesearchOutcome`](@ref) carried in a
+   [`LinesearchStatus`](@ref);
+2. the **outer iteration** decides whether the solve has converged, stagnated, or has to be given
+   up on. Its verdict is a [`NonlinearSolverStatus`](@ref).
+
+They are deliberately not the same question. A line search that reports failure does not mean the
+solve failed, and a solve that converged will normally have a line search reporting the merit's
+round-off floor on its last step. Section [How a line search's verdict reaches the
+solver](@ref "How a line search's verdict reaches the solver") is where the two meet.
+
+!!! info "Stopping is not converging"
+    [`SimpleSolvers.meets_stopping_criteria`](@ref) answers *"should the loop end?"* and
+    [`SimpleSolvers.isconverged`](@ref) answers *"is the answer good?"*. Most of the ways a solve
+    ends are not convergence. `solve!` returns the solution either way, so a caller that needs to
+    know which happened uses [`solve_with_status!`](@ref).
+
+## Part 1 — the line search
+
+### The round-off resolution ``\tau``
+
+Every criterion below is expressed against ``\tau``, the resolution of the merit:
+
+```math
+\tau = n \cdot \mathrm{ulp}(\varphi(0)), \qquad n = \texttt{armijo\_ulps}(T),
+```
+
+see [`SimpleSolvers.armijo_tolerance`](@ref) and [`SimpleSolvers.armijo_ulps`](@ref). It exists
+because a decrease smaller than the last bits of ``\varphi(0)`` is not a decrease that was
+*measured* — it is one that rounding produced. ``\tau`` is what separates
+`LINESEARCH_DECREASED` from `LINESEARCH_FLOOR`, and it is precision-aware: the nominal
+[`SimpleSolvers.DEFAULT_ARMIJO_τ_ULPS`](@ref) of 4 is capped so that ``\tau`` can never amount to
+more than [`SimpleSolvers.ARMIJO_τ_DEMAND_FRACTION`](@ref) of the decrease the sufficient decrease
+condition demands, which matters in `Float16`.
+
+### The six outcomes
+
+A [`LinesearchOutcome`](@ref) is what [`solve_with_status`](@ref) reports. In terms of the returned
+step ``\alpha`` and the merit ``\varphi`` there:
+
+| outcome | the test that produced it | benign? |
+|---|---|---|
+| `LINESEARCH_DECREASED` | ``\varphi(\alpha) \leq \varphi(0) - \tau`` | yes |
+| `LINESEARCH_FLOOR` | no trial step changed the merit by more than ``\tau`` | no |
+| `LINESEARCH_EXHAUSTED` | the merit *does* vary by more than ``\tau``, but no acceptable step was found | no |
+| `LINESEARCH_NO_DESCENT` | ``\varphi'(0) > 0``, or ``\varphi(0)``/``\varphi'(0)`` not finite | no |
+| `LINESEARCH_STATIONARY` | ``\varphi'(0) = 0`` | yes |
+| `LINESEARCH_UNKNOWN` | the method evaluated no merit and so established nothing | yes |
+
+"Benign" is [`SimpleSolvers.isbenign`](@ref), and it is what
+[`SimpleSolvers.linesearch_failures`](@ref) counts the complement of. Note that
+`LINESEARCH_FLOOR` counts as a *failure* there even though it is the expected final state of a
+converged solve — whether it matters is the outer iteration's call, and that is the layer that
+makes it.
+
+Two distinctions in that table carry real weight and are worth stating explicitly, because
+conflating either one makes a solve report the wrong cause:
+
+- **`FLOOR` is not `EXHAUSTED`.** `LINESEARCH_FLOOR` asserts that *no* line search can make
+  progress along this direction — the merit is irreducible here. `LINESEARCH_EXHAUSTED` asserts
+  only that *this* search did not find a step, leaving open that one exists. The outer iteration
+  acts on the first (it counts towards `max_stalls`) and not on the second, so a search that
+  reports a floor it has not established makes a healthy solve look stagnant.
+- **`NO_DESCENT` is not a tolerance problem.** It says the direction itself is wrong, which points
+  at the [`Jacobian`](@ref): a stale one under `refactorize > 1`, a nonzero
+  `regularization_factor`, or an inexact linear solve. The remedy is to refresh the Jacobian, and
+  [`SimpleSolvers.solver_step!`](@ref) does exactly that rather than shrinking a step that cannot
+  help.
+
+### The anchor policy
+
+Before any method searches, it validates the ``\alpha = 0`` anchor through the single shared
+[`SimpleSolvers.check_anchor`](@ref):
+
+- ``\varphi(0)`` or ``\varphi'(0)`` not finite, or ``\varphi'(0) > 0`` ⟹ `LINESEARCH_NO_DESCENT`;
+- ``\varphi'(0) = 0`` ⟹ `LINESEARCH_STATIONARY`, which for the ``\|F\|^2`` merit of a
+  [`NonlinearSolver`](@ref) *is* the exact root.
+
+Either way the caller's trial step is handed back — never the ``\alpha = 0`` anchor, which would
+freeze the outer iterate.
+
+### The smallest informative step ``\alpha_\mathrm{min}``
+
+For the shrinking ladder of [`Backtracking`](@ref) there is a floor below which the sufficient
+decrease condition could only be decided by rounding, namely where
+``c_1\alpha|\varphi'(0)|`` falls below an ulp of ``\varphi(0)``. That step is
+[`SimpleSolvers.backtracking_αmin`](@ref), and the ladder stops there rather than at `eps`. It is
+reported in the `αmin` field of the [`LinesearchStatus`](@ref) and is `zero` — meaning *not
+applicable* — for the bracketing and minimising searches, which do not shrink.
+
+### The contract every method keeps
+
+Reaching a method through [`solve`](@ref) or [`solve_with_status`](@ref) guarantees six things; see
+[`LinesearchMethod`](@ref) for the full statement:
+
+1. **it never throws** — a situation it cannot handle is reported, not raised;
+2. **it returns ``\alpha > 0``** — never the anchor, never a negative step;
+3. **it reports through [`SimpleSolvers.linesearch_warnings`](@ref) only**, and only when the
+   *user* called it;
+4. **a non-finite or ascending anchor is reported, not assumed away**;
+5. **cost is bounded independently of the merit's scale** — multiplying ``\varphi`` by a constant
+   must not change the number of evaluations;
+6. **it returns ``\alpha \leq \alpha_\mathrm{max}``** — see [Bounding the
+   step](@ref "Bounding the step").
+
+Clause 3 is the one that decides where the criteria above are *visible*. `solve` runs the search
+and then reports; `solve_with_status` runs it and stays silent. Genuine failures
+(`EXHAUSTED`, `NO_DESCENT`) are reported at `verbosity ≥ 1` and the two benign-but-notable ones
+(`FLOOR`, `STATIONARY`) at `verbosity ≥ 2`, because warning about a round-off floor at the default
+verbosity means warning about success.
+
+## Part 2 — the nonlinear solver
+
+### The three residuals
+
+[`SimpleSolvers.residuals`](@ref) measures, once per iteration:
+
+| symbol | meaning |
+|---|---|
+| ``r^x_s`` | successive residual in ``x``, ``\|x - \bar{x}\|`` |
+| ``r^f_a`` | absolute residual, ``\|F(x)\|`` |
+| ``r^f_s`` | successive residual in ``F``, ``\|F(x) - F(\bar{x})\|`` |
+
+### The residual gate
+
+Everything below turns on one predicate, [`SimpleSolvers.residual_small`](@ref):
+
+```math
+r^f_a \leq \texttt{f\_abstol} + \texttt{f\_reltol}\cdot\|F(x_0)\| .
+```
+
+It is required by both convergence branches and **negated** by both give-up branches, which is what
+makes converging and stagnating mutually exclusive by construction rather than by agreement between
+two tests.
+
+!!! warning "The default `f_abstol` is zero and `f_reltol` tightens with a good guess"
+    With the default `f_abstol = 0` the absolute branch is switched *off*: convergence is decided
+    entirely by the relative and successive branches. And the relative term is anchored at the
+    *initial* residual ``\|F(x_0)\|``, so a better initial guess makes the gate **tighter**, not
+    looser. An `f_abstol` below the round-off floor of your own residual is unsatisfiable, and such
+    a solve is reported as stagnated rather than converged. See [`Options`](@ref).
+
+### Convergence
+
+[`SimpleSolvers.assess_convergence`](@ref) returns four flags:
+
+- `x_converged` ⟺ [`SimpleSolvers.iterate_settled`](@ref) (``r^x_s \leq \|x\|\cdot`` `x_suctol`)
+  **and** `residual_small`;
+- `f_converged` ⟺ (``r^f_s \leq \|F(x)\|\cdot`` `f_suctol` **and** `residual_small`) **or**
+  ``r^f_a \leq`` `f_abstol`;
+- `f_increased` ⟺ ``\|F(x)\| > \|F(\bar{x})\|``;
+- `stalled` ⟺ `iterate_settled` **and not** `residual_small`.
+
+[`SimpleSolvers.isconverged`](@ref) is `x_converged || f_converged`. The `residual_small`
+conjunct on the successive branches is not decoration: a step that stalls makes ``r^x_s`` and
+``r^f_s`` vanish while ``r^f_a`` is still large, and without the gate that would be reported as
+convergence.
+
+### Divergence, stagnation and giving up
+
+Four distinct ways a solve ends without converging:
+
+| predicate | what it detects | controlled by |
+|---|---|---|
+| [`SimpleSolvers.stalled_step`](@ref) | the iterate **froze** while the residual is not small | `max_stalls` (default 2) |
+| [`SimpleSolvers.no_progress`](@ref) | the iterate **moves** but the residual is going nowhere | `f_stall_window` (default 0, **off**) |
+| [`SimpleSolvers.havenonfinite`](@ref) | any residual is not finite — the iteration left the representable region | always on, from iteration 1 |
+| `f_increased` | the residual grew | `allow_f_increases` (default `true`, so off) |
+
+The first two cover disjoint cases and their thresholds differ by orders of magnitude for a reason.
+Two consecutive stalled steps are conclusive because the second one ran with a *freshly evaluated*
+Jacobian (a stall forces one — see below), whereas no number of *moving* steps is conclusive about
+a convergence rate: an iteration converging linearly with rate ``\rho`` improves by ``\rho^W`` over
+a window ``W``, so a window of 50 at the default factor abandons every ``\rho > 0.986``, which a
+[`PicardSolver`](@ref) on a stiff problem is slower than. That is why stalling has a default and
+lack of progress is opt-in — the *diagnosis* of the latter is unconditional (it is consulted only
+about a solve that has already spent its budget) while the *stopping* is the caller's to ask for.
+
+A non-finite direction is not on that list because it is not a stopping criterion at all: it is
+rejected outright by [`SimpleSolvers.solver_step!`](@ref) as a `NonlinearSolverException`. It
+cannot be recovered from — [`SimpleSolvers.nan_recovery!`](@ref) damps by a factor, and
+`Inf * nan_factor` is `Inf` — whereas a non-finite trial *residual* is damped.
+
+### The full stopping test
+
+[`SimpleSolvers.meets_stopping_criteria`](@ref) is the disjunction, tested **before the first step**
+as well as after each one:
+
+- `isconverged` and `iterations ≥ min_iterations`;
+- [`SimpleSolvers.isstalled`](@ref) and `iterations ≥ min_iterations`;
+- [`SimpleSolvers.isnotprogressing`](@ref) and `iterations ≥ min_iterations`;
+- `f_increased` and `!allow_f_increases`;
+- `iterations ≥ max_iterations`;
+- ``r^f_a >`` `f_abstol_break` (default `Inf`);
+- `havenonfinite` and `iterations ≥ 1`.
+
+### What is reported, and when
+
+[`SimpleSolvers.nonlinear_solver_warnings`](@ref) fires **once per solve**, at the end. Its three
+"this solve did not do what you asked" messages are mutually exclusive, most specific first:
+stagnation (the iterate froze) replaces lack of progress (the iterate moves, the residual does
+not), which replaces the bare iteration count. They are rate-limited by
+[`SimpleSolvers.should_report!`](@ref), which reports the 1st, 2nd, 4th, 8th … occurrence of a
+diagnosis — so a caller looping `solve!` per time step over an unattainable tolerance is not
+flooded, while a solve that starts failing for a *new* reason is reported at once.
+
+## How a line search's verdict reaches the solver
+
+This is the connection between the two halves, and it runs entirely through data — a line search
+logs nothing from inside a solve.
+
+Within one [`SimpleSolvers.solver_step!`](@ref):
+
+1. the solver calls `solve_with_status(linesearch(s), one(T), lsparams)`, passing
+   `lsparams = (x = x, parameters = params, φ₀ = ‖F(x)‖²)`. The `φ₀` field is the merit at the
+   anchor, which the solver has *already* computed, so the line search does not re-evaluate it;
+2. the outcome is counted into a per-solve tally by
+   [`SimpleSolvers.record_linesearch!`](@ref);
+3. if the outcome is `LINESEARCH_FLOOR` or `LINESEARCH_NO_DESCENT`, the step is flagged with
+   [`SimpleSolvers.flag_stall!`](@ref) — the line search *knows* the iteration cannot progress
+   along this direction, one iteration before the step-based [`SimpleSolvers.stalled_step`](@ref)
+   would see it;
+4. on `LINESEARCH_NO_DESCENT` the step is **not taken**: moving along a direction that cannot
+   decrease the merit would only make the forced retry start from a worse point. The line search
+   still returned ``\alpha > 0``, as its contract requires — whether to use it is the caller's
+   decision, and here the caller declines.
+
+The flag then has two consumers:
+
+- [`SimpleSolvers.needs_refresh`](@ref) is true for the next step, which
+  [`SimpleSolvers.solver_step!`](@ref) passes to [`SimpleSolvers.maybe_refactorize!`](@ref) as
+  its `stalled` keyword. A quasi-Newton solver therefore rebuilds its [`Jacobian`](@ref)
+  *immediately* rather than waiting for the next `refactorize` multiple — which is what makes
+  `max_stalls = 2` conclusive for every `refactorize` and not only for `refactorize = 1`;
+- [`SimpleSolvers.record_stall!`](@ref) consumes it once per iteration, OR-ed with
+  `iterate_settled` and gated by the *same* `!residual_small` as everything else:
+
+  ```julia
+  stalled = (flagged || iterate_settled(rxₛ, config, state)) && !residual_small(rfₐ, config, state)
+  ```
+
+  That gate is why a converged solve — whose last line search reports the floor as a matter of
+  course — is not counted as stagnating.
+
+The tally is copied into the [`NonlinearSolverStatus`](@ref) and read three ways:
+
+- [`SimpleSolvers.linesearch_outcomes`](@ref) — the raw counts, indexed by
+  [`SimpleSolvers.linesearch_index`](@ref);
+- [`SimpleSolvers.linesearch_failures`](@ref) — how many steps reported a non-benign outcome;
+- [`SimpleSolvers.dominant_linesearch_outcome`](@ref) — the one worth naming, which
+  [`SimpleSolvers.linesearch_reason`](@ref) appends to the solver's own failure message so that a
+  failed solve names the *cause* and not only the symptom ("the line search reported
+  `LINESEARCH_NO_DESCENT` on 194 of the 200 step(s)").
+
+!!! info "Read the tally, do not scrape the log"
+    A program acting on a rejected line search — restarting an approximate Hessian, falling back to
+    steepest descent — should use [`solve_with_status!`](@ref) and read the tally. The log is for
+    the user. This is the whole reason [`solve_with_status`](@ref) is the method extension point
+    and [`solve`](@ref) is derived from it: there is no path by which the package reaches a
+    method's `solve` during a solve, so the guarantee holds by construction.
+
+## The options that participate
+
+| option | default (`Float64`) | governs |
+|---|---|---|
+| `f_abstol` | `0` | the absolute branch of `residual_small` — **off** by default |
+| `f_reltol` | `√eps` | the relative branch, against ``\|F(x_0)\|`` |
+| `x_suctol` | `2eps` | `iterate_settled`, hence `x_converged` and `stalled_step` |
+| `f_suctol` | `2eps` | the successive branch of `f_converged` |
+| `max_stalls` | `2` | consecutive stalled steps before giving up |
+| `f_stall_window` | `0` (**off**) | iterations without progress before giving up |
+| `f_stall_factor` | `0.5` | the residual drop that counts as progress |
+| `f_abstol_break` | `Inf` | a residual so large the solve is abandoned |
+| `allow_f_increases` | `true` | whether a growing residual stops the solve |
+| `min_iterations` | `0` | floor below which convergence and the two give-up tests are ignored |
+| `max_iterations` | `1000` | the **outer** iteration budget |
+| `linesearch_max_iterations` | `60` | the **inner**, one-dimensional budget |
+| `verbosity` | `1` | `0` silences everything; `2` adds the benign line-search outcomes |
+
+`max_iterations` and `linesearch_max_iterations` are deliberately distinct: a one-dimensional
+search inside a single solver step needs a budget on the order of the mantissa width
+([`SimpleSolvers.linesearch_iterations`](@ref)), not thousands of trials.

--- a/docs/src/convergence.md
+++ b/docs/src/convergence.md
@@ -72,6 +72,32 @@ conflating either one makes a solve report the wrong cause:
   [`SimpleSolvers.solver_step!`](@ref) does exactly that rather than shrinking a step that cannot
   help.
 
+!!! info "What a `DECREASED` does and does not claim"
+    It claims a decrease exceeding ``\tau``, and nothing more. [`Backtracking`](@ref) and
+    [`StrongWolfe`](@ref) additionally verify their Wolfe condition before returning; the minimising
+    searches ([`Bisection`](@ref), [`Quadratic`](@ref), [`BierlaireQuadratic`](@ref)) approximate the
+    line minimiser and test no such condition. The ``\tau``-exceeding decrease is the guarantee they
+    all share.
+
+### Which stationary point a minimising search finds
+
+[`Bisection`](@ref) drives on the *sign* of ``\varphi'``, and a bisection converges to whichever
+crossing the sign at its left endpoint selects — a sign that is invariant under the halving. From
+``\varphi'(\mathrm{lo}) < 0`` the interval shrinks onto a ``-\to+`` crossing, a **minimum**; from
+``\varphi'(\mathrm{lo}) > 0`` onto a ``+\to-`` crossing, a **maximum**.
+
+Nothing in [`bracket_minimum`](@ref) rules the second out: it brackets a minimum in *value*,
+sampling ``\varphi`` and never ``\varphi'``, so on a non-convex ray its interval can enclose several
+stationary points and its left endpoint can sit past one of them. The orientation is therefore
+checked, and repaired by bisecting ``[0, \mathrm{lo}]`` instead — an interval that brackets a
+minimum by construction, since [`SimpleSolvers.check_anchor`](@ref) has established
+``\varphi'(0) < 0``. See `SimpleSolvers._bisect_for_minimum`.
+
+This matters for the criteria on this page rather than only for the answer. A step at a maximum is
+classified by the merit like any other, so an unrepaired search reported `LINESEARCH_FLOOR` whenever
+that step failed to improve ``\varphi`` — and `LINESEARCH_FLOOR` is a claim about the *direction*,
+which the outer iteration acts on.
+
 ### The anchor policy
 
 Before any method searches, it validates the ``\alpha = 0`` anchor through the single shared

--- a/docs/src/convergence.md
+++ b/docs/src/convergence.md
@@ -124,7 +124,9 @@ applicable* — for the bracketing and minimising searches, which do not shrink.
 Reaching a method through [`solve`](@ref) or [`solve_with_status`](@ref) guarantees six things; see
 [`LinesearchMethod`](@ref) for the full statement:
 
-1. **it never throws** — a situation it cannot handle is reported, not raised;
+1. **it never throws** — a situation it cannot handle is reported, not raised, the one exception
+   being a `params.αmax` that is not a usable ceiling, which is a caller error and raises before
+   any evaluation;
 2. **it returns ``\alpha > 0``** — never the anchor, never a negative step;
 3. **it reports through [`SimpleSolvers.linesearch_warnings`](@ref) only**, and only when the
    *user* called it;

--- a/docs/src/linesearch/bisections.md
+++ b/docs/src/linesearch/bisections.md
@@ -115,3 +115,9 @@ bracket_root(f2, 30.)
 throw(UnexpectedSuccess()) #hide
 catch e; e isa UnexpectedSuccess ? rethrow(e) : showerror(stderr, e); end  #hide
 ```
+
+!!! info "The bracketing is bounded"
+    [`bracket_minimum`](@ref) grows the interval outward until the merit stops decreasing, which
+    on a merit that keeps falling is bounded only by the bracketing budget. The `αmax` field of
+    [`Bisection`](@ref) stops it, and a caller with a scale of its own can ask for less; see
+    [Bounding the step](@ref "Bounding the step").

--- a/docs/src/linesearch/linesearch.md
+++ b/docs/src/linesearch/linesearch.md
@@ -40,3 +40,33 @@ For solvers the output of ``f:\mathbb{R}^n\to\mathbb{R}^m`` is vector-valued. We
 ```math
 f^\mathrm{ls}(\alpha) = ||f(x_k + \alpha{}p_k)||^2.
 ```
+
+## Bounding the step
+
+Every method returns ``\alpha \leq \alpha_\mathrm{max}``, and there are two ways to set that
+ceiling — see [`SimpleSolvers.linesearch_αmax`](@ref).
+
+The **method's own** ceiling is the `αmax` field of [`Bisection`](@ref), [`Quadratic`](@ref),
+[`BierlaireQuadratic`](@ref) and [`StrongWolfe`](@ref), defaulting to
+[`SimpleSolvers.DEFAULT_LINESEARCH_αmax`](@ref). It exists because a bracketing search grows its bracket outward
+until the merit stops falling, so a nearly flat ``\varphi`` — or one whose minimiser is genuinely
+far away — otherwise bounds the step only by the bracketing budget.
+
+The **caller's** ceiling is an optional `αmax` field of the `params` passed to
+[`solve`](@ref)/[`solve_with_status`](@ref):
+
+```julia
+solve_with_status(ls, one(T), (x = x, αmax = 2π / norm(direction)))
+```
+
+This one has to be per call because the scale it comes from is not a property of the merit. On the
+manifold ``\mathcal{M}`` above, ``\alpha`` parameterizes a curve through a retraction, and past
+about ``2\pi`` of rotation a longer step contributes nothing but round-off — a bound that is
+geometric, and that changes with ``\|p_k\|`` at every step. Nothing the search itself can measure
+sees it: ``f^\mathrm{ls}`` is *bounded* on a compact ``\mathcal{M}``, so ``f^\mathrm{ls}(10^9)``
+can be genuinely lower than ``f^\mathrm{ls}(0)`` and every decrease test the search owns will
+accept the step.
+
+Supplying the ceiling as an input rather than clamping the returned ``\alpha`` is what keeps the
+[`LinesearchStatus`](@ref) honest: the search stops at the ceiling, measures the merit there, and
+reports the outcome of the step it actually hands back.

--- a/docs/src/linesearch/linesearch.md
+++ b/docs/src/linesearch/linesearch.md
@@ -56,7 +56,7 @@ The **caller's** ceiling is an optional `αmax` field of the `params` passed to
 [`solve`](@ref)/[`solve_with_status`](@ref):
 
 ```julia
-solve_with_status(ls, one(T), (x = x, αmax = 2π / norm(direction)))
+solve_with_status(ls, one(T), (x = x, parameters = params, αmax = 2π / norm(direction)))
 ```
 
 This one has to be per call because the scale it comes from is not a property of the merit. On the

--- a/docs/src/linesearch/quadratic.md
+++ b/docs/src/linesearch/quadratic.md
@@ -342,3 +342,10 @@ nothing # hide
 
 ![](f_ls_3_light.png)
 ![](f_ls_3_dark.png)
+
+!!! info "The bracketing is bounded"
+    The fitted ``\alpha_t`` is confined to the bracket, so it is the *bracket* that has to be
+    bounded: [`bracket_minimum_with_fixed_point`](@ref) grows its right end outward until the
+    merit stops decreasing, which on a nearly flat or distantly-minimised ``f^\mathrm{ls}`` is
+    arbitrarily far. The `αmax` field of [`Quadratic`](@ref) stops it, and a caller with a scale
+    of its own can ask for less; see [Bounding the step](@ref "Bounding the step").

--- a/docs/src/linesearch/quadratic_bierlaire.md
+++ b/docs/src/linesearch/quadratic_bierlaire.md
@@ -237,3 +237,10 @@ save("f_ls_bierlaire6_dark.png", fig)
     implementation therefore bisects the wider sub-interval whenever ``\chi`` lands on ``a``,
     ``b`` or ``c``, which makes ``c - a`` decrease strictly every iteration and bounds the search
     at ``O(\log_2((c-a)/\varepsilon))`` steps regardless of the merit's magnitude.
+
+!!! info "The bracketing is bounded"
+    [`SimpleSolvers.triple_point_finder`](@ref) doubles its increment until the merit rises, so
+    without a bound the third point — and hence the fitted ``\chi`` — can be arbitrarily far out
+    on a merit that is nearly flat or whose minimiser is genuinely distant. The `αmax` field of
+    [`BierlaireQuadratic`](@ref) stops it, and a caller with a scale of its own can ask for less;
+    see [Bounding the step](@ref "Bounding the step").

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -198,6 +198,10 @@ The value is [`StrongWolfe`](@ref)'s, which has carried exactly this field since
 methods had one; [`DEFAULT_WOLFE_αmax`](@ref) is now defined as this constant so the two cannot
 drift apart.
 
+Use [`default_linesearch_αmax`](@ref) rather than `T(DEFAULT_LINESEARCH_αmax)` to obtain it in a
+given precision: ``2^{16}`` is *above* `floatmax(Float16)`, so the plain conversion overflows to
+`Inf` and silently removes the ceiling in the precision the package otherwise takes most care over.
+
 !!! info "The ceiling is not a decrease criterion"
     A search stopped by the ceiling has not failed: it returns the largest step it was allowed to
     take, with the merit *measured* there, and classifies it by the usual round-off allowance
@@ -205,6 +209,38 @@ drift apart.
     a ceiling can compare it against the step it got.
 """
 const DEFAULT_LINESEARCH_αmax = 65536.0
+
+"""
+    default_linesearch_αmax(T)
+
+[`DEFAULT_LINESEARCH_αmax`](@ref) in the precision `T`, saturated at `floatmax(T)`.
+
+The saturation is the whole point of the function. `65536` exceeds `floatmax(Float16) = 65504`, so
+`Float16(DEFAULT_LINESEARCH_αmax)` is `Inf` — a `Float16` line search built from the plain
+conversion would carry no ceiling at all, which is precisely the defect the field exists to fix,
+absent in the one precision where every other tolerance in this file is special-cased.
+
+```jldoctest; setup = :(using SimpleSolvers: default_linesearch_αmax)
+default_linesearch_αmax(Float16)
+
+# output
+
+Float16(6.55e4)
+```
+"""
+default_linesearch_αmax(::Type{T}) where {T} = T(min(DEFAULT_LINESEARCH_αmax, floatmax(T)))
+
+"""
+    convert_αmax(T, αmax)
+
+Convert the step-length ceiling `αmax` to the precision `T`, saturating a finite value at
+`floatmax(T)` instead of letting it overflow to `Inf`.
+
+`Inf` is passed through unchanged: it is not an overflow but a statement — "no ceiling of my own"
+(see [`linesearch_αmax`](@ref)) — and turning it into `floatmax(T)` would impose one the caller
+declined. Used by `change_precision` for the `αmax` field of every method that has one.
+"""
+convert_αmax(::Type{T}, αmax) where {T} = isinf(αmax) ? T(αmax) : T(min(αmax, floatmax(T)))
 
 @doc raw"""
     linesearch_iterations(T)

--- a/src/base/options.jl
+++ b/src/base/options.jl
@@ -179,6 +179,34 @@ This lives here rather than next to [`Backtracking`](@ref) because
 armijo_tolerance(φ₀::T, n::Real) where {T} = T(n) * eps(φ₀)
 
 @doc raw"""
+    const DEFAULT_LINESEARCH_αmax
+
+The largest step length a [`LinesearchMethod`](@ref) will try unless a caller asks for less; its
+value is """ * """$(DEFAULT_LINESEARCH_αmax)""" * raw""" (``2^{16}``). See
+[`linesearch_αmax`](@ref) for the two ways the ceiling is set and [`method_αmax`](@ref) for the
+per-method field it defaults.
+
+An *absolute* number is the right shape here, and this is the one place in the package where that
+is worth arguing. ``\alpha`` scales a direction that has already been chosen, so it is a
+step-length *fraction* and of order one — the same reason the bracket-width tolerance of
+[`BierlaireQuadratic`](@ref) is absolute while its merit comparisons are not. A ceiling of
+``2^{16}`` is therefore four to five orders of magnitude of headroom above any step a well-scaled
+direction asks for, and still rules out the ``\alpha \approx 4\cdot10^7`` that an unbounded
+bracketing search can reach on a merit whose minimiser is far away or whose fit is nearly flat.
+
+The value is [`StrongWolfe`](@ref)'s, which has carried exactly this field since before the other
+methods had one; [`DEFAULT_WOLFE_αmax`](@ref) is now defined as this constant so the two cannot
+drift apart.
+
+!!! info "The ceiling is not a decrease criterion"
+    A search stopped by the ceiling has not failed: it returns the largest step it was allowed to
+    take, with the merit *measured* there, and classifies it by the usual round-off allowance
+    ``\tau``. There is no [`LinesearchOutcome`](@ref) for "capped", because a caller that supplied
+    a ceiling can compare it against the step it got.
+"""
+const DEFAULT_LINESEARCH_αmax = 65536.0
+
+@doc raw"""
     linesearch_iterations(T)
 
 Determine the default number of trial steps a line search may take, i.e. the default of the

--- a/src/bracketing/bracket_minimum.jl
+++ b/src/bracketing/bracket_minimum.jl
@@ -90,30 +90,67 @@ maximum rather than a minimum, so it is deliberately skipped.
 Returns `nothing` when no bracket is found within `nmax` steps. A line search must be able to
 report an unbracketable merit rather than abort the enclosing solve, so this is a `nothing`
 rather than an error; see [`bracket_minimum`](@ref).
+
+`αmax` bounds how far to the *right* the search may probe (see [`linesearch_αmax`](@ref)); a
+bracket truncated by it is returned like any other, and only [`_bracket_core`](@ref) distinguishes
+the two.
 """
-function bracket(f::Callable, x::T, bc::BracketingCriterion, s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
+function bracket(f::Callable, x::T, bc::BracketingCriterion, s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    lo, hi, status = _bracket_core(f, x, bc, s, k, nmax, αmax)
+    status === :unbracketable ? nothing : (lo, hi)
+end
+
+"""
+    _bracket_core(f, x, bc, s, k, nmax, αmax)
+
+The loop of [`bracket`](@ref), returning `(lo, hi, status)` with `status` one of `:ok`, `:capped`
+or `:unbracketable`. Splitting the loop from the reporting is what `bisection`/`_bisection_core`
+and [`triple_point_finder`](@ref)/`_triple_point_core` already do, and here it is what lets a
+caller tell a bracket that *ends* at the ceiling `αmax` from one that satisfied the criterion:
+the first says the turning point lies beyond the largest step the caller allows, so the answer is
+`αmax` itself, and the interval is not worth fitting anything to.
+
+Private: [`bracket`](@ref) and [`bracket_minimum`](@ref) are the public entry points.
+"""
+function _bracket_core(f::Callable, x::T, bc::BracketingCriterion, s::T, k::T, nmax::Integer, αmax::T) where {T<:Number}
     a = x
 
-    b = a + s
+    # The *first* probe is bounded too, not just the loop's. A ceiling smaller than the initial
+    # step `s` would otherwise have the merit evaluated outside the range the caller called
+    # admissible before the loop ever tests the bound — one evaluation, but on a problem where a
+    # step beyond `αmax` is meaningless it is exactly the evaluation the ceiling exists to avoid.
+    # `s` is left alone: it is the growth scale, and clamping it would also shrink the loop's steps.
+    b = s > zero(T) ? min(a + s, αmax) : a + s
     yb = f(b)
 
     if bc isa BracketRootCriterion && bc(f(a - s), yb)
-        return (a - s, b)
+        return (a - s, b, :ok)
     end
 
     for _ in 1:nmax
         c = b + s
+        # The ceiling bounds a *step length*, so it applies only while the search runs to the
+        # right. A negative `s` means the caller flipped the search (see `bracket_minimum`), and
+        # the α > 0 contract of the line-search layer is what handles that side.
+        if s > zero(T) && c ≥ αmax
+            # Probe *at* the ceiling rather than past it: it is the last point the caller allows,
+            # and evaluating it is what lets the search report the merit at the step it returns.
+            c = αmax
+            c > a || return (a, a, :capped)
+            yc = f(c)
+            return (a, c, bc(yb, yc) ? :ok : :capped)
+        end
         yc = f(c)
         if bc(yb, yc)
             interval = a < c ? (a, c) : (c, a)
-            return interval
+            return (interval..., :ok)
         end
         a = b
         b = c
         yb = yc
         s *= k
     end
-    nothing
+    (a, b, :unbracketable)
 end
 
 @doc raw"""
@@ -178,11 +215,26 @@ The interval that is returned by `bracket_minimum` is then typically used as a s
     i.e. that a sign change in the function occurs. Also see [`BracketRootCriterion`](@ref).
 
 """
-function bracket_minimum(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
+function bracket_minimum(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    lo, hi, status = _bracket_minimum_core(f, x, s, k, nmax, αmax)
+    status === :unbracketable ? nothing : (lo, hi)
+end
+
+"""
+    _bracket_minimum_core(f, x, s, k, nmax, αmax)
+
+[`bracket_minimum`](@ref) with the `(lo, hi, status)` return of [`_bracket_core`](@ref), so that a
+caller can tell a bracket truncated at the ceiling `αmax` from one that found a turning point.
+Private; see [`_bracket_core`](@ref).
+"""
+function _bracket_minimum_core(f::Callable, x::T, s::T, k::T, nmax::Integer, αmax::T) where {T<:Number}
     a = x
     ya = f(a)
 
-    b = a + s
+    # This probe decides the *direction* and is taken before `_bracket_core` sees the problem at
+    # all, so it needs the same bound `_bracket_core`'s own first probe carries — otherwise a
+    # ceiling below `s` is stepped over here and the bound in the loop never gets the chance.
+    b = s > zero(T) ? min(a + s, αmax) : a + s
     yb = f(b)
 
     # flip a & b if necessary
@@ -192,20 +244,23 @@ function bracket_minimum(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), 
         s = -s
     end
 
-    bracket(f, a, BracketMinimumCriterion(), s, k, nmax)
+    _bracket_core(f, a, BracketMinimumCriterion(), s, k, nmax, αmax)
 end
 
-function bracket_minimum(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
-    bracket_minimum(f, x, s, k, nmax)
+function bracket_minimum(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    bracket_minimum(f, x, s, k, nmax, αmax)
 end
 
-function bracket_minimum(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
-    bracket_minimum(x -> value(prob, x, params), x, s, k, nmax)
+function bracket_minimum(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    bracket_minimum(x -> value(prob, x, params), x, s, k, nmax, αmax)
 end
 
-function bracket_minimum(prob::LinesearchProblem{T}, params, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
-    bracket_minimum(prob, params, x, s, k, nmax)
+function bracket_minimum(prob::LinesearchProblem{T}, params, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    bracket_minimum(prob, params, x, s, k, nmax, αmax)
 end
+
+_bracket_minimum_core(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number} =
+    _bracket_minimum_core(x -> value(prob, x, params), x, s, k, nmax, αmax)
 
 @doc raw"""
     bracket_minimum_with_fixed_point(f, x, s, k, nmax)
@@ -237,10 +292,30 @@ to re-evaluate `f` at the endpoints.
 
 Returns `nothing` if no bracket is found within `nmax` steps — a line search must be able to
 report an unbracketable merit rather than abort the enclosing solve.
+
+`αmax` bounds how far to the right the search may probe; see [`linesearch_αmax`](@ref) and
+[`_bracket_minimum_with_fixed_point_core`](@ref), which is what tells a truncated bracket from a
+genuine one.
 """
-function bracket_minimum_with_fixed_point(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
+function bracket_minimum_with_fixed_point(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    a, b, ya, yb, status = _bracket_minimum_with_fixed_point_core(f, x, s, k, nmax, αmax)
+    status === :unbracketable ? nothing : (a, b, ya, yb)
+end
+
+"""
+    _bracket_minimum_with_fixed_point_core(f, x, s, k, nmax, αmax)
+
+[`bracket_minimum_with_fixed_point`](@ref) with the bracket's `status` appended — `:ok`, `:capped`
+or `:unbracketable`, as [`_bracket_core`](@ref) reports them. Private; the split exists so that
+[`Quadratic`](@ref) can tell a bracket that ends at the ceiling from one that found a turning
+point, and hand back the ceiling instead of fitting a polynomial to an interval over which the
+merit only falls.
+"""
+function _bracket_minimum_with_fixed_point_core(f::Callable, x::T, s::T, k::T, nmax::Integer, αmax::T) where {T<:Number}
     a = x
-    b = a + s
+    # Bounded like the loop's probes below, and for the reason given in `_bracket_core`: a ceiling
+    # smaller than `s` must not be stepped over before the bound is first tested.
+    b = s > zero(T) ? min(a + s, αmax) : a + s
 
     ya = f(a)
     yb = f(b)
@@ -263,30 +338,42 @@ function bracket_minimum_with_fixed_point(f::Callable, x::T, s::T, k::T=T(DEFAUL
     # the minimum just like the moving-anchor `bracket_minimum`.
     ybprev = yb
     for _ in 1:nmax
-        b = b + s
+        bnext = b + s
+        # As in `_bracket_core`: the ceiling bounds a step length, so it binds only while the
+        # search runs rightward, and the ceiling itself is probed rather than skipped over.
+        if s > zero(T) && bnext ≥ αmax
+            αmax > a || return (a, a, ya, ya, :capped)
+            b = αmax
+            yb = f(b)
+            return (a, b, ya, yb, bc(ybprev, yb) ? :ok : :capped)
+        end
+        b = bnext
         yb = f(b)
         if bc(ybprev, yb)
             # return the endpoints (sorted) along with their function values
-            return a < b ? (a, b, ya, yb) : (b, a, yb, ya)
+            return a < b ? (a, b, ya, yb, :ok) : (b, a, yb, ya, :ok)
         end
         ybprev = yb
         s *= k
     end
 
-    nothing
+    (a, b, ya, yb, :unbracketable)
 end
 
-function bracket_minimum_with_fixed_point(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
-    bracket_minimum_with_fixed_point(f, x, s, k, nmax)
+function bracket_minimum_with_fixed_point(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    bracket_minimum_with_fixed_point(f, x, s, k, nmax, αmax)
 end
 
-function bracket_minimum_with_fixed_point(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
-    bracket_minimum_with_fixed_point(x -> value(prob, x, params), x, s, k, nmax)
+function bracket_minimum_with_fixed_point(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    bracket_minimum_with_fixed_point(x -> value(prob, x, params), x, s, k, nmax, αmax)
 end
 
-function bracket_minimum_with_fixed_point(prob::LinesearchProblem{T}, params, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T<:Number}
-    bracket_minimum_with_fixed_point(prob, params, x, s, k, nmax)
+function bracket_minimum_with_fixed_point(prob::LinesearchProblem{T}, params, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
+    bracket_minimum_with_fixed_point(prob, params, x, s, k, nmax, αmax)
 end
+
+_bracket_minimum_with_fixed_point_core(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number} =
+    _bracket_minimum_with_fixed_point_core(x -> value(prob, x, params), x, s, k, nmax, αmax)
 
 """
     bracket_root(f, x)

--- a/src/bracketing/bracket_minimum.jl
+++ b/src/bracketing/bracket_minimum.jl
@@ -96,24 +96,31 @@ bracket truncated by it is returned like any other, and only [`_bracket_core`](@
 the two.
 """
 function bracket(f::Callable, x::T, bc::BracketingCriterion, s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
-    lo, hi, status = _bracket_core(f, x, bc, s, k, nmax, αmax)
+    lo, hi, _, status = _bracket_core(f, x, bc, s, k, nmax, αmax)
     status === :unbracketable ? nothing : (lo, hi)
 end
 
 """
     _bracket_core(f, x, bc, s, k, nmax, αmax)
 
-The loop of [`bracket`](@ref), returning `(lo, hi, status)` with `status` one of `:ok`, `:capped`
-or `:unbracketable`. Splitting the loop from the reporting is what `bisection`/`_bisection_core`
-and [`triple_point_finder`](@ref)/`_triple_point_core` already do, and here it is what lets a
+The loop of [`bracket`](@ref), returning `(lo, hi, n, status)` with `n` the number of evaluations
+of `f` it spent and `status` one of `:ok`, `:capped` or `:unbracketable`. Splitting the loop from
+the reporting is what `bisection`/`_bisection_core` and
+[`triple_point_finder`](@ref)/`_triple_point_core` already do, and here it is what lets a
 caller tell a bracket that *ends* at the ceiling `αmax` from one that satisfied the criterion:
 the first says the turning point lies beyond the largest step the caller allows, so the answer is
 `αmax` itself, and the interval is not worth fitting anything to.
+
+`n` is reported for the same reason the status is: it is the cost of the bracketing, and for the
+searches that bracket it is most of the cost of the whole line search. Without it the `trials` of
+their [`LinesearchStatus`](@ref) could only ever be a lower bound — vacuous on the path where the
+bracketing *is* the search, which is exactly the path a ceiling produces.
 
 Private: [`bracket`](@ref) and [`bracket_minimum`](@ref) are the public entry points.
 """
 function _bracket_core(f::Callable, x::T, bc::BracketingCriterion, s::T, k::T, nmax::Integer, αmax::T) where {T<:Number}
     a = x
+    n = 0
 
     # The *first* probe is bounded too, not just the loop's. A ceiling smaller than the initial
     # step `s` would otherwise have the merit evaluated outside the range the caller called
@@ -122,9 +129,11 @@ function _bracket_core(f::Callable, x::T, bc::BracketingCriterion, s::T, k::T, n
     # `s` is left alone: it is the growth scale, and clamping it would also shrink the loop's steps.
     b = s > zero(T) ? min(a + s, αmax) : a + s
     yb = f(b)
+    n += 1
 
-    if bc isa BracketRootCriterion && bc(f(a - s), yb)
-        return (a - s, b, :ok)
+    if bc isa BracketRootCriterion
+        n += 1
+        bc(f(a - s), yb) && return (a - s, b, n, :ok)
     end
 
     for _ in 1:nmax
@@ -136,7 +145,7 @@ function _bracket_core(f::Callable, x::T, bc::BracketingCriterion, s::T, k::T, n
             # Probe *at* the ceiling rather than past it: it is the last point the caller allows,
             # and evaluating it is what lets the search report the merit at the step it returns.
             c = αmax
-            c > a || return (a, a, :capped)
+            c > a || return (a, a, n, :capped)
             # …unless `b` is already *at* the ceiling, which it is whenever the first probe was
             # clamped to it (`s ≥ αmax - x`, so any caller ceiling at or below the initial step).
             # There is then nothing further to the right to probe, and probing anyway compares the
@@ -144,21 +153,23 @@ function _bracket_core(f::Callable, x::T, bc::BracketingCriterion, s::T, k::T, n
             # truncation would be reported as `:ok` — a turning point that is one point counted
             # twice — and the caller would bisect a derivative, or fit a polynomial, on an interval
             # over which the merit only falls.
-            c > b || return (a, b, :capped)
+            c > b || return (a, b, n, :capped)
             yc = f(c)
-            return (a, c, bc(yb, yc) ? :ok : :capped)
+            n += 1
+            return (a, c, n, bc(yb, yc) ? :ok : :capped)
         end
         yc = f(c)
+        n += 1
         if bc(yb, yc)
             interval = a < c ? (a, c) : (c, a)
-            return (interval..., :ok)
+            return (interval..., n, :ok)
         end
         a = b
         b = c
         yb = yc
         s *= k
     end
-    (a, b, :unbracketable)
+    (a, b, n, :unbracketable)
 end
 
 @doc raw"""
@@ -227,26 +238,28 @@ The interval that is returned by `bracket_minimum` is then typically used as a s
 
 """
 function bracket_minimum(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
-    lo, hi, status = _bracket_minimum_core(f, x, s, k, nmax, αmax)
+    lo, hi, _, status = _bracket_minimum_core(f, x, s, k, nmax, αmax)
     status === :unbracketable ? nothing : (lo, hi)
 end
 
 """
     _bracket_minimum_core(f, x, s, k, nmax, αmax)
 
-[`bracket_minimum`](@ref) with the `(lo, hi, status)` return of [`_bracket_core`](@ref), so that a
-caller can tell a bracket truncated at the ceiling `αmax` from one that found a turning point.
-Private; see [`_bracket_core`](@ref).
+[`bracket_minimum`](@ref) with the `(lo, hi, n, status)` return of [`_bracket_core`](@ref), so that
+a caller can tell a bracket truncated at the ceiling `αmax` from one that found a turning point and
+can charge its cost `n` to the `trials` it reports. Private; see [`_bracket_core`](@ref).
 """
 function _bracket_minimum_core(f::Callable, x::T, s::T, k::T, nmax::Integer, αmax::T) where {T<:Number}
     a = x
     ya = f(a)
+    n = 1
 
     # This probe decides the *direction* and is taken before `_bracket_core` sees the problem at
     # all, so it needs the same bound `_bracket_core`'s own first probe carries — otherwise a
     # ceiling below `s` is stepped over here and the bound in the loop never gets the chance.
     b = s > zero(T) ? min(a + s, αmax) : a + s
     yb = f(b)
+    n += 1
 
     # flip a & b if necessary
     if yb > ya
@@ -259,10 +272,11 @@ function _bracket_minimum_core(f::Callable, x::T, s::T, k::T, nmax::Integer, αm
         # now rather than handing this to `_bracket_core` is what keeps the ceiling from being
         # evaluated twice — this function and `_bracket_core` both probe `a + s`, and clamped to
         # the same ceiling that is the same point.
-        return (a, b, :capped)
+        return (a, b, n, :capped)
     end
 
-    _bracket_core(f, a, BracketMinimumCriterion(), s, k, nmax, αmax)
+    lo, hi, ncore, status = _bracket_core(f, a, BracketMinimumCriterion(), s, k, nmax, αmax)
+    (lo, hi, n + ncore, status)
 end
 
 function bracket_minimum(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
@@ -316,15 +330,16 @@ report an unbracketable merit rather than abort the enclosing solve.
 genuine one.
 """
 function bracket_minimum_with_fixed_point(f::Callable, x::T, s::T, k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}
-    a, b, ya, yb, status = _bracket_minimum_with_fixed_point_core(f, x, s, k, nmax, αmax)
+    a, b, ya, yb, _, status = _bracket_minimum_with_fixed_point_core(f, x, s, k, nmax, αmax)
     status === :unbracketable ? nothing : (a, b, ya, yb)
 end
 
 """
     _bracket_minimum_with_fixed_point_core(f, x, s, k, nmax, αmax)
 
-[`bracket_minimum_with_fixed_point`](@ref) with the bracket's `status` appended — `:ok`, `:capped`
-or `:unbracketable`, as [`_bracket_core`](@ref) reports them. Private; the split exists so that
+[`bracket_minimum_with_fixed_point`](@ref) with the number of evaluations of `f` it spent and the
+bracket's `status` appended — `:ok`, `:capped` or `:unbracketable`, as [`_bracket_core`](@ref)
+reports them. Private; the split exists so that
 [`Quadratic`](@ref) can tell a bracket that ends at the ceiling from one that found a turning
 point, and hand back the ceiling instead of fitting a polynomial to an interval over which the
 merit only falls.
@@ -337,6 +352,7 @@ function _bracket_minimum_with_fixed_point_core(f::Callable, x::T, s::T, k::T, n
 
     ya = f(a)
     yb = f(b)
+    n = 2
 
     # flip a & b if necessary
     if yb > ya
@@ -360,27 +376,29 @@ function _bracket_minimum_with_fixed_point_core(f::Callable, x::T, s::T, k::T, n
         # As in `_bracket_core`: the ceiling bounds a step length, so it binds only while the
         # search runs rightward, and the ceiling itself is probed rather than skipped over.
         if s > zero(T) && bnext ≥ αmax
-            αmax > a || return (a, a, ya, ya, :capped)
+            αmax > a || return (a, a, ya, ya, n, :capped)
             # `b` is already at the ceiling whenever the first probe was clamped to it, and then
             # `yb` (which equals `ybprev` here — every iteration ends by copying one into the
             # other) *is* the merit at `αmax`. Re-evaluating it would tie with itself, and a tie
             # reads as a turning point; see the same guard in `_bracket_core`.
-            αmax > b || return (a, b, ya, yb, :capped)
+            αmax > b || return (a, b, ya, yb, n, :capped)
             b = αmax
             yb = f(b)
-            return (a, b, ya, yb, bc(ybprev, yb) ? :ok : :capped)
+            n += 1
+            return (a, b, ya, yb, n, bc(ybprev, yb) ? :ok : :capped)
         end
         b = bnext
         yb = f(b)
+        n += 1
         if bc(ybprev, yb)
             # return the endpoints (sorted) along with their function values
-            return a < b ? (a, b, ya, yb, :ok) : (b, a, yb, ya, :ok)
+            return a < b ? (a, b, ya, yb, n, :ok) : (b, a, yb, ya, n, :ok)
         end
         ybprev = yb
         s *= k
     end
 
-    (a, b, ya, yb, :unbracketable)
+    (a, b, ya, yb, n, :unbracketable)
 end
 
 function bracket_minimum_with_fixed_point(f::Callable, x::T; s::T=T(DEFAULT_BRACKETING_s), k::T=T(DEFAULT_BRACKETING_k), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T<:Number}

--- a/src/bracketing/bracket_minimum.jl
+++ b/src/bracketing/bracket_minimum.jl
@@ -73,7 +73,7 @@ struct BracketRootCriterion <: BracketingCriterion end
 (::BracketRootCriterion)(yb::T, yc::T) where {T<:Number} = yc * yb ≤ zero(T)
 
 """
-    bracket(f, x, bc, s, k, nmax)
+    bracket(f, x, bc, s, k, nmax, αmax)
 
 Grow a bracket outward from `x` (in steps scaled by `k`, starting from `s`) until
 the [`BracketingCriterion`](@ref) `bc` is satisfied. Used by [`bracket_minimum`](@ref)
@@ -137,6 +137,14 @@ function _bracket_core(f::Callable, x::T, bc::BracketingCriterion, s::T, k::T, n
             # and evaluating it is what lets the search report the merit at the step it returns.
             c = αmax
             c > a || return (a, a, :capped)
+            # …unless `b` is already *at* the ceiling, which it is whenever the first probe was
+            # clamped to it (`s ≥ αmax - x`, so any caller ceiling at or below the initial step).
+            # There is then nothing further to the right to probe, and probing anyway compares the
+            # point with itself: `yc == yb` satisfies `BracketMinimumCriterion` (`yc ≥ yb`), so the
+            # truncation would be reported as `:ok` — a turning point that is one point counted
+            # twice — and the caller would bisect a derivative, or fit a polynomial, on an interval
+            # over which the merit only falls.
+            c > b || return (a, b, :capped)
             yc = f(c)
             return (a, c, bc(yb, yc) ? :ok : :capped)
         end
@@ -168,7 +176,10 @@ This bracketing algorithm is taken from [kochenderfer2019algorithms](@cite). Als
 - `x`: the starting point,
 - `s`: by default [`DEFAULT_BRACKETING_s`](@ref),
 - `k`: by default [`DEFAULT_BRACKETING_k`](@ref),
-- `nmax`: by default [`DEFAULT_BRACKETING_nmax`](@ref).
+- `nmax`: by default [`DEFAULT_BRACKETING_nmax`](@ref),
+- `αmax`: how far to the *right* the search may probe, by default `Inf` (see
+  [`linesearch_αmax`](@ref)). A bracket truncated by it is returned like any other, so a caller
+  that has to tell the two apart uses `_bracket_minimum_core`.
 
 # Extended help
 
@@ -242,6 +253,13 @@ function _bracket_minimum_core(f::Callable, x::T, s::T, k::T, nmax::Integer, αm
         a, b = b, a
         ya, yb = yb, ya
         s = -s
+    elseif s > zero(T) && b ≥ αmax && b > a
+        # The direction probe was clamped to the ceiling *and* the merit fell to it, so there is
+        # nothing further to the right that the caller allows: the bracket ends here. Returning
+        # now rather than handing this to `_bracket_core` is what keeps the ceiling from being
+        # evaluated twice — this function and `_bracket_core` both probe `a + s`, and clamped to
+        # the same ceiling that is the same point.
+        return (a, b, :capped)
     end
 
     _bracket_core(f, a, BracketMinimumCriterion(), s, k, nmax, αmax)
@@ -263,7 +281,7 @@ _bracket_minimum_core(prob::LinesearchProblem{T}, params, x::T, s::T, k::T=T(DEF
     _bracket_minimum_core(x -> value(prob, x, params), x, s, k, nmax, αmax)
 
 @doc raw"""
-    bracket_minimum_with_fixed_point(f, x, s, k, nmax)
+    bracket_minimum_with_fixed_point(f, x, s, k, nmax, αmax)
 
 Find a bracket while keeping the left side (i.e. `x`) fixed.
 
@@ -343,6 +361,11 @@ function _bracket_minimum_with_fixed_point_core(f::Callable, x::T, s::T, k::T, n
         # search runs rightward, and the ceiling itself is probed rather than skipped over.
         if s > zero(T) && bnext ≥ αmax
             αmax > a || return (a, a, ya, ya, :capped)
+            # `b` is already at the ceiling whenever the first probe was clamped to it, and then
+            # `yb` (which equals `ybprev` here — every iteration ends by copying one into the
+            # other) *is* the merit at `αmax`. Re-evaluating it would tie with itself, and a tie
+            # reads as a turning point; see the same guard in `_bracket_core`.
+            αmax > b || return (a, b, ya, yb, :capped)
             b = αmax
             yb = f(b)
             return (a, b, ya, yb, bc(ybprev, yb) ? :ok : :capped)

--- a/src/bracketing/triple_point_finder.jl
+++ b/src/bracketing/triple_point_finder.jl
@@ -62,7 +62,7 @@ julia> round10.((f(a), f(b), f(c)))
 The algorithm is taken from [bierlaire2015optimization; Chapter 11.2.1](@cite).
 """
 function triple_point_finder(f::Callable, x₀::T, δ::T, nmax::Integer=DEFAULT_BRACKETING_nmax, adjust_constant_iteration::Integer=1) where {T}
-    a, b, c, status = _triple_point_core(f, x₀, δ, nmax, adjust_constant_iteration)
+    a, b, c, _, status = _triple_point_core(f, x₀, δ, nmax, adjust_constant_iteration)
     status === :ok ? (a, b, c) : status
 end
 
@@ -71,22 +71,37 @@ function triple_point_finder(f::Callable, x₀::T; δ::T=T(DEFAULT_BRACKETING_s)
 end
 
 function triple_point_finder(prob::LinesearchProblem{T}, params, x₀::T; δ::T=T(DEFAULT_BRACKETING_s), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T}
-    a, b, c, status = _triple_point_core(prob, params, x₀; δ=δ, nmax=nmax)
+    a, b, c, _, status = _triple_point_core(prob, params, x₀; δ=δ, nmax=nmax)
     status === :ok ? (a, b, c) : status
 end
 
-# The bracketing loop, returning `(a, b, c, status)` with `status` one of `:ok`, `:flat` or
-# `:unbracketable` and the three points meaningful only for `:ok`. Splitting the loop from the
-# reporting is what the `Bisection` line search does with `bisection`/`_bisection_core`, and here it
+# The bracketing loop, returning `(a, b, c, n, status)` with `n` the number of evaluations of `f`
+# it spent, `status` one of `:ok`, `:flat`, `:capped` or `:unbracketable`, and the three points
+# meaningful only for `:ok`. `n` is what lets `BierlaireQuadratic` report the true cost of a search
+# whose bracketing *is* the search, which is what a binding ceiling produces.
+#
+# Splitting the loop from the reporting is what the `Bisection` line search does with
+# `bisection`/`_bisection_core`, and here it
 # also keeps the return type concrete: the `Union{Symbol,Tuple}` handed back by
 # `triple_point_finder` has to be boxed, and `BierlaireQuadratic` brackets once per line search.
 function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_constant_iteration::Integer, αmax::T=T(Inf)) where {T}
+    # A ceiling at or below the start leaves no admissible range to search at all. Without this
+    # the clamp below would make `δ` zero or negative, every probe would land at or *left* of
+    # `x₀`, and the rise test would fire on the start itself — reporting `:flat`, i.e. that no
+    # line search can decrease the merit here, about a search that was never allowed to look.
+    # The ceiling is the answer instead, and saying so costs no evaluation. `BierlaireQuadratic`
+    # guards this before it calls, but the guard belongs here, where the `αmax` argument is.
+    αmax > x₀ || return (x₀, x₀, x₀, 0, :capped)
     fx₀ = f(x₀)
+    n = 1
     # The first probe has to stay inside the ceiling too, or a caller whose ceiling is smaller
-    # than the default `δ` would have its whole search happen outside the range it allows.
+    # than the default `δ` would have its whole search happen outside the range it allows. Only
+    # a rightward `δ` is clamped: a negative one is not a step length and the guard above has
+    # already established that there is room to the right.
     δ = min(δ, αmax - x₀)
     x₁ = x₀ + δ
     fx₁ = f(x₁)
+    n += 1
 
     if fx₁ ≥ fx₀
         # Halving δ is the right answer to an *overshoot* — the merit rose because the probe
@@ -94,9 +109,11 @@ function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_c
         # the wrong answer when the rise is within round-off of `f(x₀)`: the merit then simply
         # does not resolve a decrease here, and a *smaller* δ is strictly less informative, so
         # the remaining halvings are wasted evaluations that end in the same failure.
-        fx₁ ≤ fx₀ + armijo_tolerance(fx₀, armijo_ulps(typeof(fx₀))) && return (x₀, x₀, x₁, :flat)
-        adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return (x₀, x₀, x₁, :unbracketable)
-        return _triple_point_core(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1, αmax)
+        fx₁ ≤ fx₀ + armijo_tolerance(fx₀, armijo_ulps(typeof(fx₀))) && return (x₀, x₀, x₁, n, :flat)
+        adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return (x₀, x₀, x₁, n, :unbracketable)
+        # The halvings are rounds of this same search, so their evaluations are this search's too.
+        a, b, c, nretry, status = _triple_point_core(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1, αmax)
+        return (a, b, c, n + nretry, status)
     end
 
     local xₖ₋₁ = x₀
@@ -121,20 +138,22 @@ function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_c
             # A ceiling at or below `xₖ` cannot order a triple, and when it is *equal* to `xₖ` —
             # which it is whenever the first probe was clamped to it — `fxₖ` already is the merit
             # there, so evaluating again would only pay for a value in hand.
-            xₖ₊₁ > xₖ || return (xₖ₋₁, xₖ, xₖ₊₁, :capped)
+            xₖ₊₁ > xₖ || return (xₖ₋₁, xₖ, xₖ₊₁, n, :capped)
             fxₖ₊₁ = f(xₖ₊₁)
-            return (xₖ₋₁, xₖ, xₖ₊₁, fxₖ₊₁ > fxₖ ? :ok : :capped)
+            n += 1
+            return (xₖ₋₁, xₖ, xₖ₊₁, n, fxₖ₊₁ > fxₖ ? :ok : :capped)
         end
         fxₖ₊₁ = f(xₖ₊₁)
+        n += 1
         if fxₖ₊₁ > fxₖ
-            return (xₖ₋₁, xₖ, xₖ₊₁, :ok)
+            return (xₖ₋₁, xₖ, xₖ₊₁, n, :ok)
         end
     end
 
     # `nmax` doublings without a turning point: the merit is still descending at
     # `x₀ + δ(2^(nmax+1) - 1)`. That is the opposite of `:flat` — there is a decrease here, it
     # just cannot be bracketed — so the caller must not report it as a round-off floor.
-    (xₖ₋₁, xₖ, xₖ₊₁, :unbracketable)
+    (xₖ₋₁, xₖ, xₖ₊₁, n, :unbracketable)
 end
 
 function _triple_point_core(prob::LinesearchProblem{T}, params, x₀::T; δ::T=T(DEFAULT_BRACKETING_s), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T}

--- a/src/bracketing/triple_point_finder.jl
+++ b/src/bracketing/triple_point_finder.jl
@@ -33,7 +33,9 @@ Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)
 
     A third status, `:capped`, is not a failure at all: the search reached the ceiling `αmax` (see
     [`linesearch_αmax`](@ref)) while `f` was still falling, so the turning point lies beyond the
-    largest step the caller allows and that ceiling *is* the answer.
+    largest step the caller allows and that ceiling *is* the answer. It is reachable only through
+    `_triple_point_core`, which is where the `αmax` argument lives; `triple_point_finder` itself
+    takes no ceiling and therefore never reports it.
 
 # Implementation
 
@@ -116,8 +118,12 @@ function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_c
         # — with `xₖ₊₁ > xₖ` alongside it, since a ceiling at or below `xₖ` cannot order one.
         if xₖ₊₁ ≥ αmax
             xₖ₊₁ = αmax
+            # A ceiling at or below `xₖ` cannot order a triple, and when it is *equal* to `xₖ` —
+            # which it is whenever the first probe was clamped to it — `fxₖ` already is the merit
+            # there, so evaluating again would only pay for a value in hand.
+            xₖ₊₁ > xₖ || return (xₖ₋₁, xₖ, xₖ₊₁, :capped)
             fxₖ₊₁ = f(xₖ₊₁)
-            return (xₖ₋₁, xₖ, xₖ₊₁, (xₖ₊₁ > xₖ && fxₖ₊₁ > fxₖ) ? :ok : :capped)
+            return (xₖ₋₁, xₖ, xₖ₊₁, fxₖ₊₁ > fxₖ ? :ok : :capped)
         end
         fxₖ₊₁ = f(xₖ₊₁)
         if fxₖ₊₁ > fxₖ

--- a/src/bracketing/triple_point_finder.jl
+++ b/src/bracketing/triple_point_finder.jl
@@ -31,6 +31,10 @@ Find three points `a < b < c` (strictly ordered in position) with `f(a) ≥ f(b)
       doublings never reached a turning point, or `f` rose at every probe down to the smallest
       `δ` tried. This is a genuine failure to report (`LINESEARCH_EXHAUSTED`), not a floor.
 
+    A third status, `:capped`, is not a failure at all: the search reached the ceiling `αmax` (see
+    [`linesearch_αmax`](@ref)) while `f` was still falling, so the turning point lies beyond the
+    largest step the caller allows and that ceiling *is* the answer.
+
 # Implementation
 
 For `δ` we take [`DEFAULT_BRACKETING_s`](@ref) as default. For `nmax` we take [`DEFAULT_BRACKETING_nmax`](@ref) as default.
@@ -74,8 +78,11 @@ end
 # reporting is what the `Bisection` line search does with `bisection`/`_bisection_core`, and here it
 # also keeps the return type concrete: the `Union{Symbol,Tuple}` handed back by
 # `triple_point_finder` has to be boxed, and `BierlaireQuadratic` brackets once per line search.
-function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_constant_iteration::Integer) where {T}
+function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_constant_iteration::Integer, αmax::T=T(Inf)) where {T}
     fx₀ = f(x₀)
+    # The first probe has to stay inside the ceiling too, or a caller whose ceiling is smaller
+    # than the default `δ` would have its whole search happen outside the range it allows.
+    δ = min(δ, αmax - x₀)
     x₁ = x₀ + δ
     fx₁ = f(x₁)
 
@@ -87,7 +94,7 @@ function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_c
         # the remaining halvings are wasted evaluations that end in the same failure.
         fx₁ ≤ fx₀ + armijo_tolerance(fx₀, armijo_ulps(typeof(fx₀))) && return (x₀, x₀, x₁, :flat)
         adjust_constant_iteration > MAX_NUMBER_ADJUST_CONSTANT_ITERATIONS && return (x₀, x₀, x₁, :unbracketable)
-        return _triple_point_core(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1)
+        return _triple_point_core(f, x₀, δ / 2, nmax, adjust_constant_iteration + 1, αmax)
     end
 
     local xₖ₋₁ = x₀
@@ -103,6 +110,15 @@ function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_c
         fxₖ = fxₖ₊₁
         increment = 2 * increment
         xₖ₊₁ = xₖ + increment
+        # Probe *at* the ceiling rather than past it, and stop there: `f` was still falling at
+        # `xₖ`, so a turning point (if any) lies beyond the largest step the caller allows. The
+        # rise can still happen exactly at the ceiling, which is a genuine triple, hence the test
+        # — with `xₖ₊₁ > xₖ` alongside it, since a ceiling at or below `xₖ` cannot order one.
+        if xₖ₊₁ ≥ αmax
+            xₖ₊₁ = αmax
+            fxₖ₊₁ = f(xₖ₊₁)
+            return (xₖ₋₁, xₖ, xₖ₊₁, (xₖ₊₁ > xₖ && fxₖ₊₁ > fxₖ) ? :ok : :capped)
+        end
         fxₖ₊₁ = f(xₖ₊₁)
         if fxₖ₊₁ > fxₖ
             return (xₖ₋₁, xₖ, xₖ₊₁, :ok)
@@ -115,6 +131,6 @@ function _triple_point_core(f::Callable, x₀::T, δ::T, nmax::Integer, adjust_c
     (xₖ₋₁, xₖ, xₖ₊₁, :unbracketable)
 end
 
-function _triple_point_core(prob::LinesearchProblem{T}, params, x₀::T; δ::T=T(DEFAULT_BRACKETING_s), nmax::Integer=DEFAULT_BRACKETING_nmax) where {T}
-    _triple_point_core(x -> value(prob, x, params), x₀, δ, nmax, 1)
+function _triple_point_core(prob::LinesearchProblem{T}, params, x₀::T; δ::T=T(DEFAULT_BRACKETING_s), nmax::Integer=DEFAULT_BRACKETING_nmax, αmax::T=T(Inf)) where {T}
+    _triple_point_core(x -> value(prob, x, params), x₀, δ, nmax, 1, αmax)
 end

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -85,7 +85,10 @@ const DEFAULT_BACKTRACKING_NEXPAND = 3
 
 The trial step ``\alpha`` is *not* a key: it is the argument of [`solve`](@ref), which is its only
 source. (A `Backtracking` used to carry an `α₀` field for it, which the algorithm never read — see
-issue #174.)
+issue #174.) Neither is `αmax`: this search *shrinks*, so the trial step is already its ceiling and
+the expansion phase carries its own in ``q^{\mathrm{nexpand}}``. A `params.αmax` still binds — on
+the trial step itself as well as on the expansion — since a caller that says no step above a given
+length is admissible means the first trial too. See [`SimpleSolvers.linesearch_αmax`](@ref).
 
 The keys are:
 - `c₁`=""" * string(DEFAULT_WOLFE_c₁) * raw""": the constant ``c_1`` in the [`SufficientDecreaseCondition`](@ref) (Armijo condition). Also see [`DEFAULT_WOLFE_c₁`](@ref).

--- a/src/linesearch/backtracking.jl
+++ b/src/linesearch/backtracking.jl
@@ -365,9 +365,13 @@ end
 # `n` is passed and returned rather than captured: a counter captured by this function and mutated
 # by its caller would be boxed, which makes the `trials` of the status built from it inferred-`Any`
 # (the same reason `_wolfe_zoom`'s caller passes its `n`).
-function backtracking_expand(f, sdc::SufficientDecreaseCondition{T}, φ₀::T, d₀::T, α::T, φα::T, n::Int, q::T, nexpand::Int) where {T}
+function backtracking_expand(f, sdc::SufficientDecreaseCondition{T}, φ₀::T, d₀::T, α::T, φα::T, n::Int, q::T, nexpand::Int, αmax::T=T(Inf)) where {T}
     for _ in 1:nexpand
-        αₙ = backtracking_extrapolation(φ₀, d₀, α, φα, q)
+        # `min(…, αmax)` and not "stop at the ceiling": the model's step may overshoot a caller's
+        # ceiling that the *current* step is still comfortably inside, and the point on the
+        # boundary is then worth the one evaluation it costs. It is tried at most once, since the
+        # `αₙ > α` test fails on the round after.
+        αₙ = min(backtracking_extrapolation(φ₀, d₀, α, φα, q), αmax)
         αₙ > α || break
         φₙ = f(αₙ)
         n += 1
@@ -389,13 +393,22 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
     f(a) = value(problem(ls), a, params)
     d(a) = derivative(problem(ls), a, params)
 
+    # Before any merit evaluation, so that an unusable caller-supplied ceiling costs none. This
+    # search has no ceiling of its own (`method_αmax` is `Inf` for it): it *shrinks* the caller's
+    # trial step, so that step is already its bound, and the opt-in expansion phase carries its
+    # own in `q^nexpand`. Only `params.αmax` binds here — and it binds on the trial step itself,
+    # not only on the expansion, because a caller that says "no step above this is admissible"
+    # means the first trial too.
+    αmax = linesearch_αmax(m, params)
+    α = min(α, αmax)
+
     # note that we anchor at α = 0 here as this is the base point of the linesearch problem.
     φ₀ = f(zero(T))
     d₀ = d(zero(T))
 
     # No α can satisfy the SufficientDecreaseCondition unless the merit is finite and actually
     # decreasing at the anchor, so report that instead of shrinking α fifty times to find out.
-    anchor = check_anchor(φ₀, d₀, α)
+    anchor = check_anchor(φ₀, d₀, α, αmax)
     isnothing(anchor) || return anchor
 
     τ = armijo_tolerance(φ₀, m.τ_ulps)
@@ -435,7 +448,7 @@ function solve_with_status(ls::Linesearch{T,<:Backtracking}, α::T, params=NullP
             # or less; at the default of 60 against 3 it never does.
             if m.expand && i == 1
                 budget = min(m.nexpand, config(ls).linesearch_max_iterations - n)
-                α, φₐ, n = backtracking_expand(f, sdc, φ₀, d₀, α, φₐ, n, m.q, budget)
+                α, φₐ, n = backtracking_expand(f, sdc, φ₀, d₀, α, φₐ, n, m.q, budget, αmax)
             end
             oc = φₐ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR
             return LinesearchStatus{T}(α, oc, n, φ₀, d₀, φₐ, τ, αmin)

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -95,12 +95,20 @@ This is internal: it is the return type of a private function, like the `Symbol`
     BISECTION_EXHAUSTED
 end
 
-# The bisection loop, returning `(α, outcome, n)` so a caller can report the failure itself
+# The bisection loop, returning `(α, outcome, n, ylo)` so a caller can report the failure itself
 # instead of having this function log it, and report the evaluation count `n` as the `trials` of
-# a `LinesearchStatus`. The `Bisection` *line search* needs all three: it reports through
+# a `LinesearchStatus`. The `Bisection` *line search* needs all of them: it reports through
 # `linesearch_warnings` like every other line search, so a message emitted from here would
 # duplicate it and bypass the shared verbosity policy. The public `bisection` above keeps
 # warning, since it is also used standalone as a root finder.
+#
+# `ylo` is `f` at the *left* endpoint of the (sorted) interval, and it is returned because its
+# **sign is invariant under the whole bisection**: `y₀` is reassigned only on the branch where
+# `y₀ * y > 0`, so it never changes sign, and `y₁` keeps the opposite sign throughout. The interval
+# therefore shrinks onto a crossing whose direction was decided by the interval it started from, and
+# `sign(ylo)` names that direction — which is the difference between a minimum and a maximum when
+# `f` is a derivative. `Bisection` uses it for exactly that; see `_bisect_for_minimum`. A caller
+# root-finding through the public `bisection` can ignore it, and does.
 #
 # The outcome is a `BisectionOutcome` and not a `Bool` because "no sign change" used to be folded
 # into `converged = true` — the endpoint with the smallest |f| was returned and *claimed* as a
@@ -123,8 +131,12 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
     n += 2
     y = zero(y₀)
 
+    # `f` at the *left* endpoint, kept because its sign is what identifies which kind of crossing
+    # was located and is therefore worth reporting; see the fourth element of the return.
+    ylo = y₀
+
     if y₀ * y₁ > zero(y₀)
-        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), BISECTION_NOBRACKET, n
+        return (abs(y₀) ≤ abs(y₁) ? α₀ : α₁), BISECTION_NOBRACKET, n, ylo
     end
 
     outcome = BISECTION_EXHAUSTED
@@ -153,7 +165,7 @@ function _bisection_core(f::Callable, αmin::T, αmax::T, params, config::Option
         end
     end
 
-    α, outcome, n
+    α, outcome, n, ylo
 end
 
 function bisection(f::Callable, α::T, params=NullParameters(), config::Options=Options(float(T))) where {T<:Number}
@@ -196,6 +208,28 @@ via one extra derivative evaluation (see issue #164):
 This keeps the safe ``\\alpha = 0`` anchor while letting the caller's `α` set the
 search scale and, when it overshoots, serve directly as the upper bracket bound.
 
+## What it converges to is a minimum, not a maximum
+
+Bisection drives on the *sign* of ``\\varphi'``, so it converges to whichever crossing the sign at
+its left endpoint selects — and that sign is invariant under the halving. From
+``\\varphi'(\\mathrm{lo}) < 0`` the interval shrinks onto a ``-\\to+`` crossing, a **minimum**; from
+``\\varphi'(\\mathrm{lo}) > 0`` onto a ``+\\to-`` crossing, a **maximum**.
+
+Nothing in [`bracket_minimum`](@ref) rules the second out. It brackets a minimum in *value*,
+sampling ``\\varphi`` and never ``\\varphi'``, so on a non-convex ray its interval can enclose
+several stationary points and its left endpoint can sit past one of them. Landing on a maximum used
+not to be caught: the step was classified by the merit like any other step, so it was
+`LINESEARCH_DECREASED` when it happened to improve ``\\varphi`` and `LINESEARCH_FLOOR` when it did
+not — the same overclaim the previous section describes, reached by a different route, and
+GeometricOptimizers observed exactly it (`LINESEARCH_FLOOR` reported with
+``\\varphi(1) = \\varphi(0)``, and the step taken regardless).
+
+The orientation is now checked and repaired: when ``\\varphi'(\\mathrm{lo}) > 0`` the search bisects
+``[0, \\mathrm{lo}]`` instead, which brackets a minimum *by construction* — the anchor check has
+established ``\\varphi'(0) < 0`` — and finds the earlier one, nearer the anchor. The check costs
+nothing on a ray that does not need it, because it reads a value the bisection computes anyway.
+See `SimpleSolvers._bisect_for_minimum`.
+
 ## A bracket that fails is never a floor
 
 Bisection drives on the *sign* of ``\\varphi'``, so it can only work on an interval whose
@@ -233,6 +267,49 @@ method_αmax(m::Bisection) = m.αmax
 _bisect_on(ls::Linesearch{T,<:Bisection}, α₀::T, α₁::T, params) where {T} =
     _bisection_core(problem(ls).D, α₀, α₁, params, config(ls))
 
+@doc raw"""
+    _bisect_for_minimum(ls, lo, hi, params)
+
+Bisect ``\varphi'`` on `[lo, hi]` for a **minimum**, returning `(α, outcome, n)` as
+`_bisection_core` does without its `ylo`.
+
+A bisection converges to whichever crossing the sign of ``\varphi'`` at its left endpoint selects,
+and that sign is invariant under the halving (see `_bisection_core`): from ``\varphi'(lo) < 0`` the
+interval shrinks onto a ``- \to +`` crossing, which is a minimum, and from ``\varphi'(lo) > 0`` onto
+a ``+ \to -`` crossing, which is a **maximum**. Nothing in [`bracket_minimum`](@ref) rules the
+second out — it brackets a minimum in *value*, sampling ``\varphi`` and never ``\varphi'``, so on a
+non-convex ray its interval can enclose several stationary points and its left endpoint can sit past
+one of them.
+
+So when ``\varphi'(lo) > 0`` this bisects `[0, lo]` instead, which brackets a minimum *by
+construction*: [`check_anchor`](@ref) has established ``\varphi'(0) < 0``, and ``\varphi'(lo) > 0``
+gives the opposite sign at the other end, so the crossing between them is a ``- \to +`` one. It is
+also the *earlier* minimum, the one nearer the anchor, which is the one a line search wants.
+
+The repair costs nothing on the path that does not need it: `ylo` is a value `_bisection_core`
+computes anyway, so a correctly oriented bracket is recognised without a single extra evaluation of
+``\varphi'`` — which for the ``\|F\|^2`` merit of a [`NonlinearSolver`](@ref) is a full
+[`Jacobian`](@ref). Only the pathological ray pays for a second bisection.
+
+The same condition covers the case where `[lo, hi]` has no crossing at all *and* ascends at `lo`
+(`BISECTION_NOBRACKET` with `ylo > 0`): there too a minimum lies in ``(0, lo)`` and there too the
+bisection of `[0, lo]` finds it. The retry's verdict then replaces the first one rather than being
+merged with it, unlike the negative-step retry in [`solve_with_status`](@ref) — the two disagree
+here because the first bracket was in the wrong place, which is precisely what `ylo` detected, and
+not because ``\varphi'`` is inconsistent with ``\varphi``.
+
+Private; [`solve_with_status`](@ref) is the public entry point.
+"""
+function _bisect_for_minimum(ls::Linesearch{T,<:Bisection}, lo::T, hi::T, params) where {T}
+    αres, bres, n, ylo = _bisect_on(ls, lo, hi, params)
+    # `lo ≤ 0` covers the intervals that are anchored at (or left of) zero already: the overshoot
+    # branch bisects `[0, α]`, whose `ylo` *is* the `φ′(0) < 0` the anchor check established, and a
+    # bracket that `bracket_minimum` flipped leftward is handled by the α > 0 contract instead.
+    (ylo ≤ zero(ylo) || lo ≤ zero(T)) && return (αres, bres, n)
+    αret, bret, nret, _ = _bisect_on(ls, zero(T), lo, params)
+    (αret, bret, n + nret)
+end
+
 """
     solve_with_status(ls::Linesearch{T,<:Bisection}, α, params)
 
@@ -260,8 +337,10 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # merit (φ′(0) < 0, now guaranteed by `check_anchor`). Probe the caller's trial step α (one
     # extra derivative evaluation) to decide how to fold it in; see the docstring and #164.
     αres, bres, n = if α > zero(T) && derivative(prob, α, params) ≥ zero(T)
-        # α overshot the minimum: [0, α] already brackets the stationary point.
-        _bisect_on(ls, zero(T), α, params)
+        # α overshot the minimum: [0, α] already brackets the stationary point, and brackets it
+        # with the right orientation — `φ′(0) < 0` at the left end, `φ′(α) ≥ 0` at the right — so
+        # what it converges to is a minimum and not a maximum. See `_bisect_for_minimum`.
+        _bisect_for_minimum(ls, zero(T), α, params)
     else
         # α is on the descent side: grow the bracket from 0, seeding the step scale from |α|
         # (clamped) instead of the fixed default.
@@ -284,7 +363,9 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # returns do fill `φ` with `φ₀`, deliberately: the whole point of an ascent or stationary
         # anchor is that no trial step is worth an evaluation.)
         bstatus === :unbracketable && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, α, params), τ, zero(T))
-        _bisect_on(ls, lo, hi, params)
+        # `_bisect_for_minimum` and not `_bisect_on`: this bracket is the one that can be oriented
+        # for a *maximum*, because `bracket_minimum` samples φ and never φ′.
+        _bisect_for_minimum(ls, lo, hi, params)
     end
     # A spent budget is reported through the status rather than logged here, so that
     # `linesearch_warnings` remains the only place a line search emits messages. Note that this
@@ -300,7 +381,7 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     if αres ≤ zero(T)
         bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s), T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
         if !isnothing(bracket)
-            αres, bretry, nretry = _bisect_on(ls, bracket..., params)
+            αres, bretry, nretry = _bisect_for_minimum(ls, bracket..., params)
             n += nretry
             # The retry's own verdict counts too: a retry that could not bracket either must not
             # be allowed to claim the floor below, for exactly the reason the first one may not.

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -345,13 +345,13 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # α is on the descent side: grow the bracket from 0, seeding the step scale from |α|
         # (clamped) instead of the fixed default.
         s = clamp(abs(α), T(DEFAULT_BRACKETING_s), one(T))
-        lo, hi, bstatus = _bracket_minimum_core(prob, params, zero(T), s, T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        lo, hi, nb, bstatus = _bracket_minimum_core(prob, params, zero(T), s, T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
         # The bracket ends at the ceiling with the merit still falling across it, so the minimiser
         # lies beyond the largest step the caller allows and that step is the best admissible one.
         # There is nothing to bisect: the derivative keeps its sign on `[0, αmax]` by construction,
         # so bisection would report `BISECTION_NOBRACKET` and hand back an endpoint chosen by
         # `|φ′|` rather than by the merit.
-        bstatus === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ)
+        bstatus === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ, nb)
         # `_bracket_minimum_core` reports `:unbracketable` only when `nmax` steps found no bracket
         # in either direction, i.e. for a merit that keeps decreasing. There is then no interval to
         # bisect — but that is a failure to *report*, not a round-off floor: calling it a floor
@@ -362,17 +362,19 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # message — and for a merit that descends forever it is exactly wrong. (The `check_anchor`
         # returns do fill `φ` with `φ₀`, deliberately: the whole point of an ascent or stationary
         # anchor is that no trial step is worth an evaluation.)
-        bstatus === :unbracketable && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, α, params), τ, zero(T))
+        bstatus === :unbracketable && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, nb + 1, φ₀, d₀, value(prob, α, params), τ, zero(T))
         # `_bisect_for_minimum` and not `_bisect_on`: this bracket is the one that can be oriented
         # for a *maximum*, because `bracket_minimum` samples φ and never φ′.
-        _bisect_for_minimum(ls, lo, hi, params)
+        # The bracketing's evaluations are this search's own, so they are carried into `trials`.
+        αb, bb, nbis = _bisect_for_minimum(ls, lo, hi, params)
+        (αb, bb, nb + nbis)
     end
     # A spent budget is reported through the status rather than logged here, so that
     # `linesearch_warnings` remains the only place a line search emits messages. Note that this
     # is *only* the budget case: a failed bracket carries on below, because the endpoint it
     # returns may still improve the merit and there is no reason to throw that away.
     bres === BISECTION_EXHAUSTED &&
-        return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, n, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
+        return LinesearchStatus{T}(αres > zero(T) ? αres : α, LINESEARCH_EXHAUSTED, n + 1, φ₀, d₀, value(prob, αres > zero(T) ? αres : α, params), τ, zero(T))
 
     # `bracket_minimum` flips direction when the merit rises to the right of its start, so the
     # bracket — and hence the bisected result — can lie left of zero. A negative step is not a
@@ -383,8 +385,9 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # bracket truncated at the ceiling as an ordinary one, so this retry would bisect an
         # interval over which φ′ keeps its sign — the one path in this method that could not reach
         # `capped_status`.
-        rlo, rhi, rstatus = _bracket_minimum_core(prob, params, zero(T), T(DEFAULT_BRACKETING_s), T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
-        rstatus === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ)
+        rlo, rhi, nrb, rstatus = _bracket_minimum_core(prob, params, zero(T), T(DEFAULT_BRACKETING_s), T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        rstatus === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ, n + nrb)
+        n += nrb
         if rstatus !== :unbracketable
             αres, bretry, nretry = _bisect_for_minimum(ls, rlo, rhi, params)
             n += nretry
@@ -414,13 +417,15 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # anchor *does* descend. As on the no-bracket path above, `φ` is the merit at the step handed
     # back and not `φ₀`: the caller's `α` is what is returned here, and nothing has measured the
     # merit there.
-    αres > zero(T) || return LinesearchStatus{T}(α, nodecrease, n, φ₀, d₀, value(prob, α, params), τ, zero(T))
+    αres > zero(T) || return LinesearchStatus{T}(α, nodecrease, n + 1, φ₀, d₀, value(prob, α, params), τ, zero(T))
 
     # The bracketing stops at the ceiling and bisection only narrows the interval it is given, so
     # this cannot bind; it is here so that the α ≤ αmax half of the contract is guaranteed by this
     # function rather than inferred from the helpers that feed it.
     αres = min(αres, αmax)
+    # Counted like every other evaluation at a trial step α > 0; see the `trials` field.
     φres = value(prob, αres, params)
+    n += 1
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : nodecrease,
         n, φ₀, d₀, φres, τ, zero(T))
 end

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -250,13 +250,13 @@ from a bisection that actually converged.
 struct Bisection{T} <: LinesearchMethod{T}
     αmax::T
 
-    function Bisection{T}(αmax::T=T(DEFAULT_LINESEARCH_αmax)) where {T}
+    function Bisection{T}(αmax::T=default_linesearch_αmax(T)) where {T}
         @assert αmax > 0 "The maximum step length must be positive, it is $(αmax)."
         new{T}(αmax)
     end
 end
 
-Bisection(::Type{T}=Float64; αmax=T(DEFAULT_LINESEARCH_αmax)) where {T} = Bisection{T}(T(αmax))
+Bisection(::Type{T}=Float64; αmax=default_linesearch_αmax(T)) where {T} = Bisection{T}(T(αmax))
 Bisection(::Type{T}, ::SolverMethod) where {T} = Bisection(T)
 
 method_αmax(m::Bisection) = m.αmax
@@ -379,9 +379,14 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # meaningful step length along a direction (see the α > 0 contract), so retry once from the
     # α = 0 anchor, which `check_anchor` has established is decreasing.
     if αres ≤ zero(T)
-        bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s), T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
-        if !isnothing(bracket)
-            αres, bretry, nretry = _bisect_for_minimum(ls, bracket..., params)
+        # `_bracket_minimum_core` and not the public `bracket_minimum`: the latter reports a
+        # bracket truncated at the ceiling as an ordinary one, so this retry would bisect an
+        # interval over which φ′ keeps its sign — the one path in this method that could not reach
+        # `capped_status`.
+        rlo, rhi, rstatus = _bracket_minimum_core(prob, params, zero(T), T(DEFAULT_BRACKETING_s), T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        rstatus === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ)
+        if rstatus !== :unbracketable
+            αres, bretry, nretry = _bisect_for_minimum(ls, rlo, rhi, params)
             n += nretry
             # The retry's own verdict counts too: a retry that could not bracket either must not
             # be allowed to claim the floor below, for exactly the reason the first one may not.
@@ -424,7 +429,7 @@ Base.show(io::IO, ls::Bisection) = print(io, "Bisection with αmax = $(ls.αmax)
 
 function change_precision(::Type{T}, method::Bisection) where {T}
     T ≠ eltype(method) || return method
-    Bisection{T}(T(method.αmax))
+    Bisection{T}(convert_αmax(T, method.αmax))
 end
 
 Base.isapprox(b₁::Bisection{T}, b₂::Bisection{T}; kwargs...) where {T} = isapprox(b₁.αmax, b₂.αmax; kwargs...)

--- a/src/linesearch/bisection.jl
+++ b/src/linesearch/bisection.jl
@@ -170,6 +170,12 @@ bisection(f::Callable, αmin::T, αmax::T, config::Options) where {T<:Number} = 
 
 See [`bisection`](@ref) for the implementation of the algorithm.
 
+# Keywords
+
+- `αmax`: the largest step the bracketing will try, by default
+  [`DEFAULT_LINESEARCH_αmax`](@ref). See [`linesearch_αmax`](@ref), which is also how a caller
+  imposes a smaller ceiling of its own.
+
 # Extended help
 
 When invoked with a single trial step `α` (i.e. `solve(ls, α)`), the bracket is
@@ -207,10 +213,19 @@ establishes nothing of the kind. So the outcome is now classified by the merit a
 ``\\tau``, and `LINESEARCH_EXHAUSTED` when it does not. `LINESEARCH_FLOOR` is reachable only
 from a bisection that actually converged.
 """
-struct Bisection{T} <: LinesearchMethod{T} end
+struct Bisection{T} <: LinesearchMethod{T}
+    αmax::T
 
-Bisection(::Type{T}=Float64) where {T} = Bisection{T}()
+    function Bisection{T}(αmax::T=T(DEFAULT_LINESEARCH_αmax)) where {T}
+        @assert αmax > 0 "The maximum step length must be positive, it is $(αmax)."
+        new{T}(αmax)
+    end
+end
+
+Bisection(::Type{T}=Float64; αmax=T(DEFAULT_LINESEARCH_αmax)) where {T} = Bisection{T}(T(αmax))
 Bisection(::Type{T}, ::SolverMethod) where {T} = Bisection(T)
+
+method_αmax(m::Bisection) = m.αmax
 
 
 # Bisect the derivative on a known bracket. Private: `solve`/`solve_with_status` is the public
@@ -227,13 +242,19 @@ Bisect the derivative of the merit to approximate the line minimiser and return 
 """
 function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullParameters()) where {T}
     prob = problem(ls)
+    # Before any merit evaluation, so that an unusable caller-supplied ceiling costs none.
+    αmax = linesearch_αmax(method(ls), params)
     φ₀ = value(prob, zero(T), params)
     d₀ = derivative(prob, zero(T), params)
 
-    anchor = check_anchor(φ₀, d₀, α)
+    anchor = check_anchor(φ₀, d₀, α, αmax)
     isnothing(anchor) || return anchor
 
     τ = armijo_tolerance(φ₀, armijo_ulps(T))
+
+    # Every step this function can hand back is derived from the trial step or from the bracketing,
+    # and both are bounded here rather than at each of the five returns below.
+    α = min(α, αmax)
 
     # Lower-anchor the bracket at α = 0, where a genuine descent direction has a decreasing
     # merit (φ′(0) < 0, now guaranteed by `check_anchor`). Probe the caller's trial step α (one
@@ -245,19 +266,25 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
         # α is on the descent side: grow the bracket from 0, seeding the step scale from |α|
         # (clamped) instead of the fixed default.
         s = clamp(abs(α), T(DEFAULT_BRACKETING_s), one(T))
-        bracket = bracket_minimum(prob, params, zero(T), s)
-        # `bracket_minimum` returns `nothing` only when `nmax` steps found no bracket in either
-        # direction, i.e. for a merit that keeps decreasing. There is then no interval to bisect —
-        # but that is a failure to *report*, not a round-off floor: calling it a floor would make
-        # the outer iteration count a descending merit as stagnation.
+        lo, hi, bstatus = _bracket_minimum_core(prob, params, zero(T), s, T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        # The bracket ends at the ceiling with the merit still falling across it, so the minimiser
+        # lies beyond the largest step the caller allows and that step is the best admissible one.
+        # There is nothing to bisect: the derivative keeps its sign on `[0, αmax]` by construction,
+        # so bisection would report `BISECTION_NOBRACKET` and hand back an endpoint chosen by
+        # `|φ′|` rather than by the merit.
+        bstatus === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ)
+        # `_bracket_minimum_core` reports `:unbracketable` only when `nmax` steps found no bracket
+        # in either direction, i.e. for a merit that keeps decreasing. There is then no interval to
+        # bisect — but that is a failure to *report*, not a round-off floor: calling it a floor
+        # would make the outer iteration count a descending merit as stagnation.
         # The merit *is* evaluated at the step handed back, at the cost of one evaluation on a path
         # that has already failed. Filling `φ` with `φ₀` instead would be a claim that the merit did
         # not change, which is what `linesearch_exhausted_reason` would then interpolate into its
         # message — and for a merit that descends forever it is exactly wrong. (The `check_anchor`
         # returns do fill `φ` with `φ₀`, deliberately: the whole point of an ascent or stationary
         # anchor is that no trial step is worth an evaluation.)
-        isnothing(bracket) && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, α, params), τ, zero(T))
-        _bisect_on(ls, bracket..., params)
+        bstatus === :unbracketable && return LinesearchStatus{T}(α, LINESEARCH_EXHAUSTED, 0, φ₀, d₀, value(prob, α, params), τ, zero(T))
+        _bisect_on(ls, lo, hi, params)
     end
     # A spent budget is reported through the status rather than logged here, so that
     # `linesearch_warnings` remains the only place a line search emits messages. Note that this
@@ -271,7 +298,7 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # meaningful step length along a direction (see the α > 0 contract), so retry once from the
     # α = 0 anchor, which `check_anchor` has established is decreasing.
     if αres ≤ zero(T)
-        bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s))
+        bracket = bracket_minimum(prob, params, zero(T), T(DEFAULT_BRACKETING_s), T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
         if !isnothing(bracket)
             αres, bretry, nretry = _bisect_on(ls, bracket..., params)
             n += nretry
@@ -303,16 +330,20 @@ function solve_with_status(ls::Linesearch{T,<:Bisection}, α::T, params=NullPara
     # merit there.
     αres > zero(T) || return LinesearchStatus{T}(α, nodecrease, n, φ₀, d₀, value(prob, α, params), τ, zero(T))
 
+    # The bracketing stops at the ceiling and bisection only narrows the interval it is given, so
+    # this cannot bind; it is here so that the α ≤ αmax half of the contract is guaranteed by this
+    # function rather than inferred from the helpers that feed it.
+    αres = min(αres, αmax)
     φres = value(prob, αres, params)
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : nodecrease,
         n, φ₀, d₀, φres, τ, zero(T))
 end
 
-Base.show(io::IO, ::Bisection) = print(io, "Bisection")
+Base.show(io::IO, ls::Bisection) = print(io, "Bisection with αmax = $(ls.αmax).")
 
 function change_precision(::Type{T}, method::Bisection) where {T}
     T ≠ eltype(method) || return method
-    Bisection(T)
+    Bisection{T}(T(method.αmax))
 end
 
-Base.isapprox(::Bisection{T}, ::Bisection{T}; kwargs...) where {T} = true
+Base.isapprox(b₁::Bisection{T}, b₂::Bisection{T}; kwargs...) where {T} = isapprox(b₁.αmax, b₂.αmax; kwargs...)

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -20,7 +20,9 @@ Every method reached through [`solve`](@ref) or [`solve_with_status`](@ref) guar
 1. **It never throws.** A situation it cannot handle is *reported*, never raised — a line
    search must not abort the enclosing solve. Bracketing helpers signal failure with `nothing`
    (see [`bracket_minimum`](@ref), [`triple_point_finder`](@ref)) and the method maps that onto
-   a [`LinesearchOutcome`](@ref).
+   a [`LinesearchOutcome`](@ref). The one deliberate exception is a caller error rather than a
+   situation arising from the merit: a `params.αmax` that is not a usable ceiling raises an
+   `ArgumentError` before any evaluation — see [`linesearch_αmax`](@ref).
 2. **It returns ``\\alpha > 0``.** Never the ``\\alpha = 0`` anchor, which would freeze the
    outer iterate (`x .+= 0 .* d`), and never a negative step: ``\\alpha`` scales a direction
    that has already been chosen, so its sign is not the line search's to decide.
@@ -103,8 +105,11 @@ resolved at compile time, so a caller that supplies nothing pays nothing.
 # Example
 
 ```julia
-solve_with_status(ls, one(T), (x = x, state = state, αmax = 2π / norm(direction)))
+solve_with_status(ls, one(T), (x = x, parameters = params, αmax = 2π / norm(direction)))
 ```
+
+The other fields are the ones the merit closures of [`linesearch_problem`](@ref) read; `αmax` is
+additional and independent of them.
 
 !!! info "A ceiling is not a failure"
     A search that stops at the ceiling returns it, with the merit *measured* there and classified

--- a/src/linesearch/linesearch.jl
+++ b/src/linesearch/linesearch.jl
@@ -36,6 +36,8 @@ Every method reached through [`solve`](@ref) or [`solve_with_status`](@ref) guar
    [`check_anchor`](@ref).
 5. **It terminates in a bounded number of merit evaluations, independently of the merit's
    scale.** Multiplying ``\\varphi`` by a constant must not change the cost.
+6. **It returns ``\\alpha \\leq \\alpha_\\mathrm{max}``** — see [`linesearch_αmax`](@ref) for the
+   two ways that ceiling is set and why one of them has to be per call.
 
 # The two families
 
@@ -55,6 +57,93 @@ guarantees about the step, because there are two distinct kinds:
 abstract type LinesearchMethod{T} <: SolverMethod end
 
 Base.eltype(::LinesearchMethod{T}) where {T} = T
+
+@doc raw"""
+    method_αmax(method)
+
+The largest step length the [`LinesearchMethod`](@ref) `method` will try of its own accord, i.e.
+its `αmax` field where it has one. The fallback is `Inf`, which is what [`Backtracking`](@ref)
+returns: it *shrinks* the caller's trial step, so the trial step is already its ceiling, and its
+opt-in expansion phase carries its own bound (`q^nexpand`).
+
+[`Bisection`](@ref), [`Quadratic`](@ref), [`BierlaireQuadratic`](@ref) and [`StrongWolfe`](@ref)
+each have the field, defaulting to [`DEFAULT_LINESEARCH_αmax`](@ref). Use [`linesearch_αmax`](@ref)
+rather than this, which is only half of the ceiling.
+"""
+method_αmax(::LinesearchMethod{T}) where {T} = T(Inf)
+
+@doc raw"""
+    linesearch_αmax(method, params)
+
+The ceiling on the step length a [`LinesearchMethod`](@ref) may return: the smaller of the
+method's own [`method_αmax`](@ref) and the caller's `params.αmax`, if the caller supplied one.
+This is the single definition of that policy, as [`check_anchor`](@ref) is of the anchor policy,
+and every built-in method calls it once before it searches.
+
+# Why the caller's half has to be per call
+
+A bracketing search grows its bracket outward until the merit stops falling, so where ``\varphi``
+is nearly flat — or its minimiser genuinely far away — the step it returns is bounded only by the
+bracketing budget: ``2^{100}`` times the initial step, in principle. In a Euclidean problem that is
+self-correcting, since ``\varphi`` grows with ``\alpha`` and the search's own decrease test throws
+such a step out. On a *compact* manifold it is not: ``\varphi`` is bounded there and can be
+genuinely lower at ``\alpha = 10^9`` than at ``\alpha = 0``, so nothing the search can measure
+calls the step too large. **The merit is not a bound on the step**, and the bound that does exist
+belongs to the caller — for a manifold solver, the ``2\pi`` of a rotation, divided by the norm of
+the direction, which changes at every solver step.
+
+Hence the two halves. `method_αmax` is a backstop that costs nothing and needs no knowledge of the
+problem; `params.αmax` is how a caller with a scale of its own imposes it, and it is read from
+`params` rather than taken as a keyword so that the extension point
+[`solve_with_status`](@ref)`(ls, α, params)` keeps its signature — a third-party method that does
+not know about the ceiling still compiles, and one that does needs only this call. It is the same
+channel `params.φ₀` uses (see [`linesearch_problem`](@ref)), and the `hasproperty` guard is
+resolved at compile time, so a caller that supplies nothing pays nothing.
+
+# Example
+
+```julia
+solve_with_status(ls, one(T), (x = x, state = state, αmax = 2π / norm(direction)))
+```
+
+!!! info "A ceiling is not a failure"
+    A search that stops at the ceiling returns it, with the merit *measured* there and classified
+    by the usual round-off allowance ``\tau``. It is a `LINESEARCH_DECREASED` if the merit really
+    did fall; see [`DEFAULT_LINESEARCH_αmax`](@ref).
+
+!!! warning "An invalid ceiling raises"
+    A `params.αmax` that is not positive, or is `NaN`, is a caller error rather than a situation
+    arising from the merit, and raises an `ArgumentError` before a single evaluation is spent — as
+    the method constructors do for their own parameters. This is the one deliberate exception to
+    the never-throws clause of [`LinesearchMethod`](@ref), which is about the problem and not about
+    the call. `Inf` is *not* an error: it says the caller has no scale of its own, and leaves the
+    method's ceiling in place.
+"""
+linesearch_αmax(m::LinesearchMethod{T}, params) where {T} = min(method_αmax(m), caller_αmax(T, params))
+
+# The caller's half of `linesearch_αmax`. `hasproperty` on a `NamedTuple` (and on the
+# `NullParameters` singleton, where it is `false`) is resolved from the type, so this whole call
+# constant-folds away for a caller that supplies no ceiling — which is what keeps a solve
+# allocation-free and its merit-evaluation counts unchanged.
+function caller_αmax(::Type{T}, params) where {T}
+    hasproperty(params, :αmax) || return T(Inf)
+    αmax = T(params.αmax)
+    # `Inf` is accepted and means "no ceiling of my own", which leaves the method's in place — it
+    # cannot produce an unbounded step by itself, and a caller deriving its ceiling from a scale
+    # (`2π / ‖δ‖`, say) should not have to special-case a vanishing direction. `NaN` and a
+    # non-positive value are neither: the first makes every comparison below it false, the second
+    # asks for a step that violates the α > 0 contract, and silently ignoring either would hand
+    # back exactly the unbounded step the caller was trying to rule out.
+    αmax > zero(T) || invalid_αmax(αmax)
+    αmax
+end
+
+# Behind a barrier for the same reason the reporting sites are: `caller_αmax` is specialized on the
+# parameter type, and the message must not be compiled once per caller.
+@noinline invalid_αmax(αmax) = throw(ArgumentError(
+    "params.αmax = $(αmax) is not a usable ceiling on the step length; it has to be positive " *
+    "(`Inf` is allowed and means the method's own ceiling stands). It bounds the α a line search " *
+    "may return — see `linesearch_αmax`; omit the field entirely to say the same thing."))
 
 """
     change_precision(T, method::LinesearchMethod)

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -90,13 +90,17 @@ answer, or it may be all that is left after the merit turned out to be irreducib
 
 - `α`: the returned step length (the value [`solve`](@ref) returns),
 - `outcome::`[`LinesearchOutcome`](@ref),
-- `trials`: the number of trial steps ``\alpha > 0`` at which the method actually evaluated the
-  problem in its own iteration — *not* the `linesearch_max_iterations` budget. That is the merit
-  for every method except [`Bisection`](@ref), which drives on the derivative it bisects.
-  Evaluations spent inside a bracketing helper ([`bracket_minimum`](@ref),
-  [`triple_point_finder`](@ref)) are not included, so for the bracketing searches this is a
-  lower bound on the total cost; for [`Backtracking`](@ref) and [`StrongWolfe`](@ref) it is
-  exact, and every merit evaluation is either the ``\alpha = 0`` anchor or a counted trial,
+- `trials`: what the search cost, as the number of times it evaluated the problem — *not* the
+  `linesearch_max_iterations` budget. That is the merit for every method except
+  [`Bisection`](@ref), which drives on the derivative it bisects and brackets on the merit, so
+  its count is of both. For [`Backtracking`](@ref) and [`StrongWolfe`](@ref) it is exactly the
+  number of trial steps ``\alpha > 0``: every merit evaluation is either the ``\alpha = 0``
+  anchor or a counted trial. For the searches that *bracket* it includes what the bracketing
+  spent ([`bracket_minimum`](@ref), [`triple_point_finder`](@ref)) — that is where those searches
+  do their work, and on the path where a ceiling binds it is the whole of it, so a count omitting
+  it reported one evaluation, or none at all, for a search of any size. One of the evaluations it
+  then counts is the bracketing's own re-evaluation of the anchor, so for those methods the
+  number is the cost rather than exactly the number of distinct positive steps,
 - `φ₀`, `d₀`: the merit and its derivative at the anchor ``\alpha = 0``,
 - `φ`: the merit at the returned step,
 - `τ`: the round-off resolution of the merit (see [`armijo_tolerance`](@ref)), against which
@@ -224,7 +228,7 @@ function check_anchor(φ₀::T, d₀::T, α::T, αmax::T=T(Inf)) where {T}
 end
 
 @doc raw"""
-    capped_status(prob, params, αmax, φ₀, d₀, τ)
+    capped_status(prob, params, αmax, φ₀, d₀, τ, n=0)
 
 The [`LinesearchStatus`](@ref) of a search whose bracketing reached the ceiling `αmax` (see
 [`linesearch_αmax`](@ref)) with the merit still falling. The turning point then lies beyond the
@@ -238,11 +242,16 @@ evaluated at `αmax` and classified by exactly the rule every other returned ste
 this case arises, ``\varphi(\alpha_\mathrm{max})`` is genuinely lower and the step genuinely
 decreases the merit — and a caller that wants to know whether its ceiling bound the search can
 compare the ceiling it supplied against [`steplength`](@ref).
+
+`n` is what the bracketing that reached the ceiling spent, which the caller gets from the
+bracketing core (see [`_bracket_core`](@ref)). It has to be passed in rather than assumed, because
+on this path the bracketing *is* the search: reporting only the single evaluation made here would
+make [`trials`](@ref) say a capped search cost one step whatever it actually cost.
 """
-function capped_status(prob, params, αmax::T, φ₀::T, d₀::T, τ::T) where {T}
+function capped_status(prob, params, αmax::T, φ₀::T, d₀::T, τ::T, n::Int=0) where {T}
     φ = value(prob, αmax, params)
     LinesearchStatus{T}(αmax, φ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
-        1, φ₀, d₀, φ, τ, zero(T))
+        n + 1, φ₀, d₀, φ, τ, zero(T))
 end
 
 @doc raw"""

--- a/src/linesearch/linesearch_status.jl
+++ b/src/linesearch/linesearch_status.jl
@@ -177,7 +177,7 @@ Base.show(io::IO, s::LinesearchStatus) = print(io,
     "(φ(0) = $(s.φ₀), φ(α) = $(s.φ), φ'(0) = $(s.d₀), τ = $(s.τ), αmin = $(s.αmin)).")
 
 @doc raw"""
-    check_anchor(φ₀, d₀, α)
+    check_anchor(φ₀, d₀, α, αmax=Inf)
 
 Validate the ``\alpha = 0`` anchor of a line search problem. Return a
 [`LinesearchStatus`](@ref) that the caller should return *immediately*, or `nothing` if the
@@ -205,18 +205,44 @@ step (see [`needs_refresh`](@ref) and [`maybe_refactorize!`](@ref)) and gives up
 `max_stalls` if that does not help.
 
 The step handed back is therefore still positive, as the contract requires — whether to *use*
-it is the caller's decision, not the line search's.
+it is the caller's decision, not the line search's. It also respects `αmax` (see
+[`linesearch_αmax`](@ref)), so that the ceiling holds on *every* return of a line search and not
+only on the ones that searched.
 """
-function check_anchor(φ₀::T, d₀::T, α::T) where {T}
+function check_anchor(φ₀::T, d₀::T, α::T, αmax::T=T(Inf)) where {T}
     # A non-positive trial step is not a step the caller can be handed back, so substitute the
     # unit step — the same convention `StrongWolfe` uses for its initial trial. This is what
-    # makes the α > 0 guarantee hold even when the caller passes α ≤ 0.
-    αout = α > zero(T) ? α : one(T)
+    # makes the α > 0 guarantee hold even when the caller passes α ≤ 0. The substitute is bounded
+    # by the ceiling like any other step, which matters when a caller both passes α ≤ 0 and asks
+    # for an αmax below one.
+    αout = min(α > zero(T) ? α : one(T), αmax)
     if !isfinite(φ₀) || !isfinite(d₀) || d₀ > zero(T)
         LinesearchStatus{T}(αout, LINESEARCH_NO_DESCENT, 0, φ₀, d₀, φ₀, zero(T), zero(T))
     elseif iszero(d₀)
         LinesearchStatus{T}(αout, LINESEARCH_STATIONARY, 0, φ₀, d₀, φ₀, zero(T), zero(T))
     end
+end
+
+@doc raw"""
+    capped_status(prob, params, αmax, φ₀, d₀, τ)
+
+The [`LinesearchStatus`](@ref) of a search whose bracketing reached the ceiling `αmax` (see
+[`linesearch_αmax`](@ref)) with the merit still falling. The turning point then lies beyond the
+largest step the caller allows, so `αmax` *is* the best admissible step, and this is the shared
+definition of what to report about it.
+
+It is deliberately not a failure and not a distinct [`LinesearchOutcome`](@ref). The merit is
+evaluated at `αmax` and classified by exactly the rule every other returned step is classified by:
+`LINESEARCH_DECREASED` when it beats ``\varphi(0)`` by more than the round-off allowance ``\tau``,
+`LINESEARCH_FLOOR` when it does not. That is honest in both directions — on a compact merit, where
+this case arises, ``\varphi(\alpha_\mathrm{max})`` is genuinely lower and the step genuinely
+decreases the merit — and a caller that wants to know whether its ceiling bound the search can
+compare the ceiling it supplied against [`steplength`](@ref).
+"""
+function capped_status(prob, params, αmax::T, φ₀::T, d₀::T, τ::T) where {T}
+    φ = value(prob, αmax, params)
+    LinesearchStatus{T}(αmax, φ ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
+        1, φ₀, d₀, φ, τ, zero(T))
 end
 
 @doc raw"""

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -101,7 +101,11 @@ function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullP
     # function rather than inferred from the two that feed it, and so that the merit reported
     # below is the merit at the step handed back whichever of them produced it.
     αres = min(αres, αmax)
+    # Counted: this is a merit evaluation at a trial step α > 0 like any other, and on the path
+    # where the ceiling answers the question without a search it is the *only* one — reporting
+    # zero there would be the value `Static` reports for evaluating nothing at all.
     φres = value(problem(ls), αres, params)
+    n += 1
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
         n, φ₀, d₀, φres, τ, zero(T))
 end
@@ -111,22 +115,29 @@ end
 # Private: `solve`/`solve_with_status` is the public entry point.
 function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params, αmax::T) where {T}
     n = 0
+    # A trial step at or beyond the ceiling leaves nothing to search: the whole admissible range
+    # lies left of where the bracketing could start, so the ceiling itself is the answer. Tested
+    # *before* the start is chosen, because the answer is the same on either side of the
+    # minimiser and the derivative below only decides *where* to start — for the ‖F‖² merit of a
+    # `NonlinearSolver` that derivative is a full `Jacobian`, and a caller who supplies a ceiling
+    # is precisely the caller whose trial step it exceeds.
+    α₀ < αmax || return (αmax, n)
     # Start the bracketing at the caller's α₀ when it lies on the descent side
     # (φ′(α₀) < 0, so the minimiser is to its right); otherwise keep the α = 0 anchor,
     # where a descent direction is guaranteed decreasing. `bracket_minimum_with_fixed_point`
     # searches rightward from a fixed left point, so that point must be on the descent
-    # side. See issue #164.
+    # side. See issue #164. Either way the result is below the ceiling — `α₀` by the test above
+    # and `0` because a ceiling is positive — so the bracketing always has room to run.
     α = (α₀ > zero(T) && derivative(problem(ls), α₀, params) < zero(T)) ? α₀ : zero(T)
-    # A trial step at or beyond the ceiling leaves nothing to search: the whole admissible range
-    # lies left of where the bracketing would start, so the ceiling itself is the answer.
-    α < αmax || return (αmax, n)
     s = method(ls).s
 
     for _ in 1:config(ls).linesearch_max_iterations
         # fit p(α) = p₀ + p₁(α - a) + p₂(α - a)² with p₀ = y₀, p₁ = d₀ and
         # p₂ = (y₁ - y₀ - d₀(b - a)) / (b - a)²; the endpoint merits y₀, y₁ come
         # from the bracketing, so no re-evaluation is needed here.
-        a, b, y₀, y₁, bracket = _bracket_minimum_with_fixed_point_core(problem(ls), params, α, s, T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        a, b, y₀, y₁, nb, bracket = _bracket_minimum_with_fixed_point_core(problem(ls), params, α, s, T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        # The bracketing's evaluations are this search's own, so they are carried into `trials`.
+        n += nb
         # The merit could not be bracketed from here (see `bracket_minimum`).
         bracket === :unbracketable && return (nothing, n)
         # The bracket ends at the ceiling with the merit still falling across it, so the turning
@@ -135,7 +146,10 @@ function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params, αma
         # curvature over a monotone-decreasing interval is non-positive, so the guard below falls
         # back to bisecting it and hands back a midpoint strictly above the endpoint's merit.
         bracket === :capped && return (αmax, n)
-        n += 2   # this round of the fit; the bracketer’s own evaluations are not counted
+        # No `n` of its own for this round: the fit interpolates `y₀`, `y₁` at the bracket
+        # endpoints, and those *are* evaluations the bracketing made and `nb` has counted. The
+        # fixed `n += 2` that stood here was a proxy for them from when the bracketer's cost was
+        # invisible, and adding it now would count them twice.
         d₀ = derivative(problem(ls), a, params)
         # `d₀` is the derivative at the bracket's left endpoint `a`; return that point
         # (not the loop's start `α`), which differ when the bracketer flipped because

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -35,7 +35,7 @@ struct Quadratic{T} <: LinesearchMethod{T}
     s_reduction::T
     αmax::T
 
-    function Quadratic{T}(ε::T, s::T, s_reduction::T, αmax::T=T(DEFAULT_LINESEARCH_αmax)) where {T}
+    function Quadratic{T}(ε::T, s::T, s_reduction::T, αmax::T=default_linesearch_αmax(T)) where {T}
         @assert ε > 0 "Precision ε must be positive."
         @assert s > 0 "Bracketing step s must be positive."
         @assert 0 < s_reduction < 1 "Bracketing step reduction factor must satisfy 0 < s_reduction < 1."
@@ -48,7 +48,7 @@ function Quadratic(::Type{T}=Float64;
     ε=default_precision(T),
     s=T(DEFAULT_BRACKETING_s),
     s_reduction=T(DEFAULT_s_REDUCTION),
-    αmax=T(DEFAULT_LINESEARCH_αmax)
+    αmax=default_linesearch_αmax(T)
 ) where {T}
     Quadratic{T}(ε, s, s_reduction, αmax)
 end
@@ -162,7 +162,7 @@ Base.show(io::IO, ls::Quadratic) = print(io, "Quadratic Polynomial with ε = $(l
 
 function change_precision(::Type{T}, method::Quadratic) where {T}
     T ≠ eltype(method) || return method
-    Quadratic{T}(T(method.ε), T(method.s), T(method.s_reduction), T(method.αmax))
+    Quadratic{T}(T(method.ε), T(method.s), T(method.s_reduction), convert_αmax(T, method.αmax))
 end
 
 function Base.isapprox(qu₁::Quadratic{T}, qu₂::Quadratic{T}; kwargs...) where {T}

--- a/src/linesearch/quadratic.jl
+++ b/src/linesearch/quadratic.jl
@@ -20,6 +20,10 @@ The iteration may also stop after it reaches the maximum number of iterations, t
 - `ε`: A constant that checks the *precision*/*tolerance*.
 - `s`: A constant that determines the initial interval for bracketing. By default this is [`DEFAULT_BRACKETING_s`](@ref).
 - `s_reduction:` A constant that determines the factor by which `s` is decreased in each new *bracketing iteration*.
+- `αmax`: the largest step the bracketing will try, by default [`DEFAULT_LINESEARCH_αmax`](@ref).
+  Without it the bracket grows outward until the merit stops falling, which for a nearly flat or
+  distantly-minimised ``\varphi`` is arbitrarily far; see [`linesearch_αmax`](@ref), which is also
+  how a caller imposes a *smaller* ceiling of its own.
 
 # Extended help
 
@@ -29,22 +33,27 @@ struct Quadratic{T} <: LinesearchMethod{T}
     ε::T
     s::T
     s_reduction::T
+    αmax::T
 
-    function Quadratic{T}(ε::T, s::T, s_reduction::T) where {T}
+    function Quadratic{T}(ε::T, s::T, s_reduction::T, αmax::T=T(DEFAULT_LINESEARCH_αmax)) where {T}
         @assert ε > 0 "Precision ε must be positive."
         @assert s > 0 "Bracketing step s must be positive."
         @assert 0 < s_reduction < 1 "Bracketing step reduction factor must satisfy 0 < s_reduction < 1."
-        new{T}(ε, s, s_reduction)
+        @assert αmax > 0 "The maximum step length must be positive, it is $(αmax)."
+        new{T}(ε, s, s_reduction, αmax)
     end
 end
 
 function Quadratic(::Type{T}=Float64;
     ε=default_precision(T),
     s=T(DEFAULT_BRACKETING_s),
-    s_reduction=T(DEFAULT_s_REDUCTION)
+    s_reduction=T(DEFAULT_s_REDUCTION),
+    αmax=T(DEFAULT_LINESEARCH_αmax)
 ) where {T}
-    Quadratic{T}(ε, s, s_reduction)
+    Quadratic{T}(ε, s, s_reduction, αmax)
 end
+
+method_αmax(m::Quadratic) = m.αmax
 
 Quadratic(::Type{T}, ::SolverMethod) where {T} = Quadratic(T)
 
@@ -56,14 +65,19 @@ Fit successive quadratics to approximate the line minimiser and return the
 [`Quadratic`](@ref).
 """
 function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullParameters()) where {T}
+    # Before any merit evaluation, so that an unusable caller-supplied ceiling costs none.
+    αmax = linesearch_αmax(method(ls), params)
     φ₀ = value(problem(ls), zero(T), params)
     d₀ = derivative(problem(ls), zero(T), params)
 
-    anchor = check_anchor(φ₀, d₀, α₀)
+    anchor = check_anchor(φ₀, d₀, α₀, αmax)
     isnothing(anchor) || return anchor
 
     τ = armijo_tolerance(φ₀, armijo_ulps(T))
-    αres, n = _quadratic_search(ls, α₀, params)
+    # Every step this function can hand back is derived from the trial step or from the bracketing,
+    # and both are bounded here rather than at each of the returns below.
+    α₀ = min(α₀, αmax)
+    αres, n = _quadratic_search(ls, α₀, params, αmax)
 
     # `bracket_minimum_with_fixed_point` flips direction when the merit rises to the right of
     # the bracketing *start* — which is α₀, not 0 — so even a decreasing anchor can yield a
@@ -71,7 +85,7 @@ function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullP
     # meaningful step length along a direction (see the α > 0 contract), so retry once from the
     # α = 0 anchor, which `check_anchor` has established is decreasing.
     if isnothing(αres) || αres ≤ zero(T)
-        αres, nretry = _quadratic_search(ls, zero(T), params)
+        αres, nretry = _quadratic_search(ls, zero(T), params, αmax)
         n += nretry
     end
     # `bracket_minimum_with_fixed_point` fails only by exhausting `nmax` in both directions, i.e.
@@ -82,6 +96,11 @@ function solve_with_status(ls::Linesearch{T,<:Quadratic}, α₀::T, params=NullP
     # which is the floor — `check_anchor` established above that the anchor itself descends.
     αres > zero(T) || return LinesearchStatus{T}(α₀, LINESEARCH_FLOOR, n, φ₀, d₀, φ₀, τ, zero(T))
 
+    # The bracketing already stops at the ceiling and the fit is confined to the bracket, so this
+    # cannot bind; it is here so that the α ≤ αmax half of the contract is guaranteed by this
+    # function rather than inferred from the two that feed it, and so that the merit reported
+    # below is the merit at the step handed back whichever of them produced it.
+    αres = min(αres, αmax)
     φres = value(problem(ls), αres, params)
     LinesearchStatus{T}(αres, φres ≤ φ₀ - τ ? LINESEARCH_DECREASED : LINESEARCH_FLOOR,
         n, φ₀, d₀, φres, τ, zero(T))
@@ -90,7 +109,7 @@ end
 # The quadratic-fit iteration itself. Returns `(α, n)` with `n` the number of merit evaluations,
 # or `(nothing, n)` if the merit cannot be bracketed.
 # Private: `solve`/`solve_with_status` is the public entry point.
-function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) where {T}
+function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params, αmax::T) where {T}
     n = 0
     # Start the bracketing at the caller's α₀ when it lies on the descent side
     # (φ′(α₀) < 0, so the minimiser is to its right); otherwise keep the α = 0 anchor,
@@ -98,16 +117,24 @@ function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) wher
     # searches rightward from a fixed left point, so that point must be on the descent
     # side. See issue #164.
     α = (α₀ > zero(T) && derivative(problem(ls), α₀, params) < zero(T)) ? α₀ : zero(T)
+    # A trial step at or beyond the ceiling leaves nothing to search: the whole admissible range
+    # lies left of where the bracketing would start, so the ceiling itself is the answer.
+    α < αmax || return (αmax, n)
     s = method(ls).s
 
     for _ in 1:config(ls).linesearch_max_iterations
         # fit p(α) = p₀ + p₁(α - a) + p₂(α - a)² with p₀ = y₀, p₁ = d₀ and
         # p₂ = (y₁ - y₀ - d₀(b - a)) / (b - a)²; the endpoint merits y₀, y₁ come
         # from the bracketing, so no re-evaluation is needed here.
-        bracket = bracket_minimum_with_fixed_point(problem(ls), params, α, s)
-        # `nothing` means the merit could not be bracketed from here (see `bracket_minimum`).
-        isnothing(bracket) && return (nothing, n)
-        a, b, y₀, y₁ = bracket
+        a, b, y₀, y₁, bracket = _bracket_minimum_with_fixed_point_core(problem(ls), params, α, s, T(DEFAULT_BRACKETING_k), DEFAULT_BRACKETING_nmax, αmax)
+        # The merit could not be bracketed from here (see `bracket_minimum`).
+        bracket === :unbracketable && return (nothing, n)
+        # The bracket ends at the ceiling with the merit still falling across it, so the turning
+        # point lies beyond the largest step the caller allows and `αmax` is the best admissible
+        # step. Fitting the truncated bracket instead would be worse than useless: the fitted
+        # curvature over a monotone-decreasing interval is non-positive, so the guard below falls
+        # back to bisecting it and hands back a midpoint strictly above the endpoint's merit.
+        bracket === :capped && return (αmax, n)
         n += 2   # this round of the fit; the bracketer’s own evaluations are not counted
         d₀ = derivative(problem(ls), a, params)
         # `d₀` is the derivative at the bracket's left endpoint `a`; return that point
@@ -131,13 +158,13 @@ function _quadratic_search(ls::Linesearch{T,<:Quadratic}, α₀::T, params) wher
     (α, n)
 end
 
-Base.show(io::IO, ls::Quadratic) = print(io, "Quadratic Polynomial with ε = $(ls.ε), s = $(ls.s) and s_reduction = $(ls.s_reduction).")
+Base.show(io::IO, ls::Quadratic) = print(io, "Quadratic Polynomial with ε = $(ls.ε), s = $(ls.s), s_reduction = $(ls.s_reduction) and αmax = $(ls.αmax).")
 
 function change_precision(::Type{T}, method::Quadratic) where {T}
     T ≠ eltype(method) || return method
-    Quadratic{T}(T(method.ε), T(method.s), T(method.s_reduction))
+    Quadratic{T}(T(method.ε), T(method.s), T(method.s_reduction), T(method.αmax))
 end
 
 function Base.isapprox(qu₁::Quadratic{T}, qu₂::Quadratic{T}; kwargs...) where {T}
-    isapprox(qu₁.ε, qu₂.ε; kwargs...) && isapprox(qu₁.s, qu₂.s; kwargs...) && isapprox(qu₁.s_reduction, qu₂.s_reduction; kwargs...)
+    isapprox(qu₁.ε, qu₂.ε; kwargs...) && isapprox(qu₁.s, qu₂.s; kwargs...) && isapprox(qu₁.s_reduction, qu₂.s_reduction; kwargs...) && isapprox(qu₁.αmax, qu₂.αmax; kwargs...)
 end

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -204,10 +204,10 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     start = (α₀ > zero(T) && derivative(prob, α₀, params) < zero(T)) ? α₀ : zero(T)
     # A start at or beyond the ceiling leaves nothing to bracket; the ceiling is the answer, and
     # `capped_status` is what says so with the merit measured there.
-    start < αmax || return capped_status(prob, params, αmax, φ₀, d₀, τ)
+    start < αmax || return capped_status(prob, params, αmax, φ₀, d₀, τ)  # nothing bracketed yet
     # `_triple_point_core` rather than `triple_point_finder`: its concrete return type costs no
     # allocation, and this runs once per line search.
-    a, b, c, bracket = _triple_point_core(prob, params, start; αmax=αmax)
+    a, b, c, nb, bracket = _triple_point_core(prob, params, start; αmax=αmax)
     # The two failures mean opposite things and must not be conflated: `:flat` says the merit does
     # not resolve a decrease from here, so no line search can improve on this point (a floor, which
     # the outer iteration counts as a stalled step), while `:unbracketable` says there *is* a
@@ -215,21 +215,24 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     # merit as stagnation.
     if bracket === :flat || bracket === :unbracketable
         oc = bracket === :flat ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
-        return LinesearchStatus{T}(α₀, oc, 0, φ₀, d₀, φ₀, τ, zero(T))
+        return LinesearchStatus{T}(α₀, oc, nb, φ₀, d₀, φ₀, τ, zero(T))
     end
 
     # `:capped` is neither: the merit was still falling when the bracketing reached the largest
     # step the caller allows, so that step is the best admissible one and there is no triple to
     # fit.
-    bracket === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ)
+    bracket === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ, nb)
 
-    αres, φres, n = _bierlaire_fit(ls, a, b, c, params, τ)
+    αres, φres, nfit = _bierlaire_fit(ls, a, b, c, params, τ)
+    # The bracketing's evaluations are this search's own, so they are carried into `trials`.
+    n = nb + nfit
     # The fit is confined to `[a, c] ⊆ [0, αmax]`, so this cannot bind; it is here so that the
     # α ≤ αmax half of the contract is guaranteed by this function rather than inferred from the
     # bracketing.
     if αres > αmax
         αres = αmax
         φres = value(prob, αres, params)
+        n += 1
     end
     # The fit works inside a bracket whose left end is ≥ 0, so a non-positive result means the
     # arithmetic collapsed rather than that the anchor ascends (`check_anchor` ruled that out):

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -40,28 +40,43 @@ function shift_χ_to_avoid_stalling(χ::T, a::T, b::T, c::T, ε::T) where {T}
 end
 
 
-"""
+@doc raw"""
     BierlaireQuadratic <: LinesearchMethod
 
 Algorithm taken from [bierlaire2015optimization](@cite).
+
+# Keywords
+
+- `ε`: the bracket-width tolerance of the fit.
+- `ξ`: the threshold below which ``|\varphi'(\alpha_0)|`` counts as stationary.
+- `αmax`: the largest step the triple-point bracketing will try, by default
+  [`DEFAULT_LINESEARCH_αmax`](@ref). Without it the bracketing doubles its increment until the
+  merit stops falling, which for a nearly flat or distantly-minimised ``\varphi`` is arbitrarily
+  far; see [`linesearch_αmax`](@ref), which is also how a caller imposes a smaller ceiling of its
+  own.
 """
 struct BierlaireQuadratic{T} <: LinesearchMethod{T}
     ε::T
     ξ::T
+    αmax::T
 
-    function BierlaireQuadratic{T}(ε::T, ξ::T) where {T}
+    function BierlaireQuadratic{T}(ε::T, ξ::T, αmax::T=T(DEFAULT_LINESEARCH_αmax)) where {T}
         @assert ε > 0 "Precision ε must be positive."
         @assert ξ > 0 "Derivative threshold ξ must be positive."
-        new{T}(ε, ξ)
+        @assert αmax > 0 "The maximum step length must be positive, it is $(αmax)."
+        new{T}(ε, ξ, αmax)
     end
 end
 
 function BierlaireQuadratic(::Type{T}=Float64;
     ε=default_precision(T),
-    ξ=default_precision(T)
+    ξ=default_precision(T),
+    αmax=T(DEFAULT_LINESEARCH_αmax)
 ) where {T}
-    BierlaireQuadratic{T}(ε, ξ)
+    BierlaireQuadratic{T}(ε, ξ, αmax)
 end
+
+method_αmax(m::BierlaireQuadratic) = m.αmax
 
 BierlaireQuadratic(::Type{T}, ::SolverMethod) where {T} = BierlaireQuadratic(T)
 
@@ -161,6 +176,8 @@ report; see [`BierlaireQuadratic`](@ref).
 """
 function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, params=NullParameters()) where {T}
     prob = problem(ls)
+    # Before any merit evaluation, so that an unusable caller-supplied ceiling costs none.
+    αmax = linesearch_αmax(method(ls), params)
     φ₀ = value(prob, zero(T), params)
     d₀ = derivative(prob, zero(T), params)
 
@@ -169,10 +186,13 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     # flipping. Checking the anchor here is what keeps it from being handed an impossible
     # problem — the α = 0 anchor is *not* guaranteed decreasing when the direction came from a
     # stale or regularized Jacobian.
-    anchor = check_anchor(φ₀, d₀, α₀)
+    anchor = check_anchor(φ₀, d₀, α₀, αmax)
     isnothing(anchor) || return anchor
 
     τ = armijo_tolerance(φ₀, armijo_ulps(T))
+    # Every step this function can hand back is derived from the trial step or from the bracketing,
+    # and both are bounded here rather than at each of the returns below.
+    α₀ = min(α₀, αmax)
 
     # Near-stationarity shortcut: the minimum along this direction has already been reached.
     l2norm(derivative(prob, α₀, params)) < method(ls).ξ &&
@@ -182,20 +202,35 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     # (φ′(α₀) < 0, so the minimiser is to its right), otherwise at the α = 0 anchor, which
     # `check_anchor` has established is decreasing. See issue #164.
     start = (α₀ > zero(T) && derivative(prob, α₀, params) < zero(T)) ? α₀ : zero(T)
+    # A start at or beyond the ceiling leaves nothing to bracket; the ceiling is the answer, and
+    # `_capped_status` is what says so with the merit measured there.
+    start < αmax || return capped_status(prob, params, αmax, φ₀, d₀, τ)
     # `_triple_point_core` rather than `triple_point_finder`: its concrete return type costs no
     # allocation, and this runs once per line search.
-    a, b, c, bracket = _triple_point_core(prob, params, start)
+    a, b, c, bracket = _triple_point_core(prob, params, start; αmax=αmax)
     # The two failures mean opposite things and must not be conflated: `:flat` says the merit does
     # not resolve a decrease from here, so no line search can improve on this point (a floor, which
     # the outer iteration counts as a stalled step), while `:unbracketable` says there *is* a
     # decrease that could not be bracketed — reporting that as a floor would count a descending
     # merit as stagnation.
-    if bracket !== :ok
+    if bracket === :flat || bracket === :unbracketable
         oc = bracket === :flat ? LINESEARCH_FLOOR : LINESEARCH_EXHAUSTED
         return LinesearchStatus{T}(α₀, oc, 0, φ₀, d₀, φ₀, τ, zero(T))
     end
 
+    # `:capped` is neither: the merit was still falling when the bracketing reached the largest
+    # step the caller allows, so that step is the best admissible one and there is no triple to
+    # fit.
+    bracket === :capped && return capped_status(prob, params, αmax, φ₀, d₀, τ)
+
     αres, φres, n = _bierlaire_fit(ls, a, b, c, params, τ)
+    # The fit is confined to `[a, c] ⊆ [0, αmax]`, so this cannot bind; it is here so that the
+    # α ≤ αmax half of the contract is guaranteed by this function rather than inferred from the
+    # bracketing.
+    if αres > αmax
+        αres = αmax
+        φres = value(prob, αres, params)
+    end
     # The fit works inside a bracket whose left end is ≥ 0, so a non-positive result means the
     # arithmetic collapsed rather than that the anchor ascends (`check_anchor` ruled that out):
     # no positive step improves the merit as far as this search can tell, which is the floor.
@@ -207,17 +242,17 @@ end
 
 
 
-Base.show(io::IO, ls::BierlaireQuadratic) = print(io, "Bierlaire Quadratic with ε = " * string(ls.ε) * ", and ξ = " * string(ls.ξ) * ".")
+Base.show(io::IO, ls::BierlaireQuadratic) = print(io, "Bierlaire Quadratic with ε = " * string(ls.ε) * ", ξ = " * string(ls.ξ) * ", and αmax = " * string(ls.αmax) * ".")
 
 function change_precision(::Type{T}, method::BierlaireQuadratic{AT}) where {T,AT}
     T ≠ AT || return method
     if method.ε == default_precision(AT) && method.ξ == default_precision(AT)
-        BierlaireQuadratic{T}(default_precision(T), default_precision(T))
+        BierlaireQuadratic{T}(default_precision(T), default_precision(T), T(method.αmax))
     else
-        BierlaireQuadratic{T}(T(method.ε), T(method.ξ))
+        BierlaireQuadratic{T}(T(method.ε), T(method.ξ), T(method.αmax))
     end
 end
 
 function Base.isapprox(bq₁::BierlaireQuadratic{T}, bq₂::BierlaireQuadratic{T}; kwargs...) where {T}
-    isapprox(bq₁.ε, bq₂.ε; kwargs...) && isapprox(bq₁.ξ, bq₂.ξ; kwargs...)
+    isapprox(bq₁.ε, bq₂.ε; kwargs...) && isapprox(bq₁.ξ, bq₂.ξ; kwargs...) && isapprox(bq₁.αmax, bq₂.αmax; kwargs...)
 end

--- a/src/linesearch/quadratic_bierlaire.jl
+++ b/src/linesearch/quadratic_bierlaire.jl
@@ -60,7 +60,7 @@ struct BierlaireQuadratic{T} <: LinesearchMethod{T}
     ξ::T
     αmax::T
 
-    function BierlaireQuadratic{T}(ε::T, ξ::T, αmax::T=T(DEFAULT_LINESEARCH_αmax)) where {T}
+    function BierlaireQuadratic{T}(ε::T, ξ::T, αmax::T=default_linesearch_αmax(T)) where {T}
         @assert ε > 0 "Precision ε must be positive."
         @assert ξ > 0 "Derivative threshold ξ must be positive."
         @assert αmax > 0 "The maximum step length must be positive, it is $(αmax)."
@@ -71,7 +71,7 @@ end
 function BierlaireQuadratic(::Type{T}=Float64;
     ε=default_precision(T),
     ξ=default_precision(T),
-    αmax=T(DEFAULT_LINESEARCH_αmax)
+    αmax=default_linesearch_αmax(T)
 ) where {T}
     BierlaireQuadratic{T}(ε, ξ, αmax)
 end
@@ -203,7 +203,7 @@ function solve_with_status(ls::Linesearch{T,<:BierlaireQuadratic}, α₀::T, par
     # `check_anchor` has established is decreasing. See issue #164.
     start = (α₀ > zero(T) && derivative(prob, α₀, params) < zero(T)) ? α₀ : zero(T)
     # A start at or beyond the ceiling leaves nothing to bracket; the ceiling is the answer, and
-    # `_capped_status` is what says so with the merit measured there.
+    # `capped_status` is what says so with the merit measured there.
     start < αmax || return capped_status(prob, params, αmax, φ₀, d₀, τ)
     # `_triple_point_core` rather than `triple_point_finder`: its concrete return type costs no
     # allocation, and this runs once per line search.
@@ -247,9 +247,9 @@ Base.show(io::IO, ls::BierlaireQuadratic) = print(io, "Bierlaire Quadratic with 
 function change_precision(::Type{T}, method::BierlaireQuadratic{AT}) where {T,AT}
     T ≠ AT || return method
     if method.ε == default_precision(AT) && method.ξ == default_precision(AT)
-        BierlaireQuadratic{T}(default_precision(T), default_precision(T), T(method.αmax))
+        BierlaireQuadratic{T}(default_precision(T), default_precision(T), convert_αmax(T, method.αmax))
     else
-        BierlaireQuadratic{T}(T(method.ε), T(method.ξ), T(method.αmax))
+        BierlaireQuadratic{T}(T(method.ε), T(method.ξ), convert_αmax(T, method.αmax))
     end
 end
 

--- a/src/linesearch/static.jl
+++ b/src/linesearch/static.jl
@@ -30,8 +30,13 @@ Static(::Type{T}, ::SolverMethod) where {T} = Static(T)
 # evaluated and hence no decrease has been established. `linesearch_warnings` passes
 # `LINESEARCH_UNKNOWN` over in silence, so the derived `solve` returns `method(ls).α` and says
 # nothing — which is what the hand-written `solve` this replaced did.
+#
+# The ceiling still applies: `Static` establishes nothing about its step, which is all the more
+# reason for a caller that knows its step is inadmissible above `αmax` to be able to say so. It has
+# no ceiling of its own — the whole point of the method is that `α` is the caller's to fix — so
+# only `params.αmax` can bind here.
 solve_with_status(ls::Linesearch{T,<:Static}, α::T, params=NullParameters()) where {T} =
-    LinesearchStatus(method(ls).α, LINESEARCH_UNKNOWN)
+    LinesearchStatus(min(method(ls).α, linesearch_αmax(method(ls), params)), LINESEARCH_UNKNOWN)
 
 Base.show(io::IO, alg::Static) = print(io, "Static with α = " * string(alg.α) * ".")
 

--- a/src/linesearch/static.jl
+++ b/src/linesearch/static.jl
@@ -17,6 +17,12 @@ Static()
 
 Static with α = 1.0.
 ```
+
+!!! info "The caller's ceiling still binds"
+    `Static` has no `αmax` field — the whole point of the method is that `α` is the caller's to
+    fix — but a `params.αmax` clamps the step it hands back, since a caller that says no step
+    above a given length is admissible means this one too. See
+    [`SimpleSolvers.linesearch_αmax`](@ref).
 """
 struct Static{T<:Number} <: LinesearchMethod{T}
     α::T

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -2,9 +2,12 @@
     const DEFAULT_WOLFE_αmax
 
 Default upper bound on the step length for the bracketing phase of
-[`StrongWolfe`](@ref). Its value is `65536.0`.
+[`StrongWolfe`](@ref). This is [`DEFAULT_LINESEARCH_αmax`](@ref), which every method's ceiling now
+defaults to: the field was `StrongWolfe`'s alone until the bracketing searches were found to
+extrapolate without one, and defining this as that constant is what keeps the two from drifting
+apart.
 """
-const DEFAULT_WOLFE_αmax = 65536.0
+const DEFAULT_WOLFE_αmax = DEFAULT_LINESEARCH_αmax
 
 @doc raw"""
     StrongWolfe{T} <: LinesearchMethod
@@ -64,6 +67,8 @@ function StrongWolfe(::Type{T}=Float64;
 end
 
 StrongWolfe(::Type{T}, ::SolverMethod) where {T} = StrongWolfe(T)
+
+method_αmax(m::StrongWolfe) = m.αmax
 
 Base.show(io::IO, ls::StrongWolfe) = print(io, "StrongWolfe with c₁ = $(ls.c₁), c₂ = $(ls.c₂) and αmax = $(ls.αmax).")
 
@@ -130,7 +135,10 @@ function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullPa
     m = method(ls)
     c₁ = m.c₁
     c₂ = m.c₂
-    αmax = m.αmax
+    # `StrongWolfe` has had this ceiling since before the other methods did; all that is new is
+    # that a caller can ask for a smaller one. Everything downstream — the clamp of the initial
+    # trial and the stop of the expansion loop — already respects it.
+    αmax = linesearch_αmax(m, params)
     prob = problem(ls)
 
     # One-slot memoisation of the merit φ and its derivative φ′: the bracketing /
@@ -158,8 +166,11 @@ function solve_with_status(ls::Linesearch{T,<:StrongWolfe}, α::T, params=NullPa
     # former test was `d0 ≥ zero(T)`, which a `NaN` derivative slips past (`NaN ≥ 0` is false)
     # only to trip `SufficientDecreaseCondition`'s `@assert !isnan(d₀)` below and abort the
     # enclosing solve; `check_anchor` covers the non-finite case too.
-    anchor = check_anchor(φ0, d0, α)
+    anchor = check_anchor(φ0, d0, α, αmax)
     isnothing(anchor) || return anchor
+    # The three tail returns hand back the caller's trial step, so it is bounded here rather than
+    # at each of them; the searching returns are bounded by `αi ≤ αmax` already.
+    α = min(α, αmax)
 
     # The strong Wolfe conditions are the Armijo (sufficient decrease) condition
     # plus the strong curvature condition. `StrongWolfe` keeps the *exact* Armijo test (τ = 0

--- a/src/linesearch/wolfe.jl
+++ b/src/linesearch/wolfe.jl
@@ -5,7 +5,8 @@ Default upper bound on the step length for the bracketing phase of
 [`StrongWolfe`](@ref). This is [`DEFAULT_LINESEARCH_αmax`](@ref), which every method's ceiling now
 defaults to: the field was `StrongWolfe`'s alone until the bracketing searches were found to
 extrapolate without one, and defining this as that constant is what keeps the two from drifting
-apart.
+apart. The constructor obtains it through [`default_linesearch_αmax`](@ref), which saturates it at
+`floatmax(T)` rather than overflowing to `Inf` in `Float16`.
 """
 const DEFAULT_WOLFE_αmax = DEFAULT_LINESEARCH_αmax
 
@@ -61,7 +62,7 @@ end
 function StrongWolfe(::Type{T}=Float64;
     c₁=T(DEFAULT_WOLFE_c₁),
     c₂=T(DEFAULT_WOLFE_c₂),
-    αmax=T(DEFAULT_WOLFE_αmax)
+    αmax=default_linesearch_αmax(T)
 ) where {T}
     StrongWolfe{T}(c₁, c₂, αmax)
 end
@@ -74,7 +75,7 @@ Base.show(io::IO, ls::StrongWolfe) = print(io, "StrongWolfe with c₁ = $(ls.c�
 
 function change_precision(::Type{T}, method::StrongWolfe) where {T}
     T ≠ eltype(method) || return method
-    StrongWolfe{T}(T(method.c₁), T(method.c₂), T(method.αmax))
+    StrongWolfe{T}(T(method.c₁), T(method.c₂), convert_αmax(T, method.αmax))
 end
 
 function Base.isapprox(w₁::StrongWolfe{T}, w₂::StrongWolfe{T}; kwargs...) where {T}

--- a/src/nonlinear/linesearch_problem.jl
+++ b/src/nonlinear/linesearch_problem.jl
@@ -22,9 +22,10 @@ a state whose `value` is stale must not supply it.
 
 It may carry an optional `αmax` field too, the caller's ceiling on the step length; see
 [`linesearch_αmax`](@ref), which documents why that one has to be per call. That one is read by
-the *method* rather than by these closures, through a `hasproperty` guard, as `φ₀` is read here
-through a `haskey` one. Both are resolved from the parameter type at compile time, so supplying
-neither costs nothing.
+the *method* rather than by these closures, but through the same `hasproperty` guard, resolved
+from the parameter type at compile time, so supplying neither costs nothing. `params` therefore
+has to answer *property* access throughout — a `NamedTuple` or any struct, which is what the
+required `x` and `parameters` fields already demanded.
 """
 function linesearch_problem(nlp::NonlinearProblem, jacobian::Jacobian{T}, cache::Union{NonlinearSolverCache{T},DogLegCache{T}}) where {T}
     # private scratch buffers for the line search (see the docstring for why)
@@ -33,9 +34,14 @@ function linesearch_problem(nlp::NonlinearProblem, jacobian::Jacobian{T}, cache:
     jₜ = zero(jacobianmatrix(cache))
 
     function f(α::Number, params)
-        # `haskey` on a `NamedTuple` is resolved at compile time, so the guard costs nothing
-        # and the closure stays usable with the bare `(x, parameters)` form.
-        (iszero(α) && haskey(params, :φ₀)) && return convert(T, params.φ₀)
+        # `hasproperty` is resolved from the parameter type at compile time, so the guard costs
+        # nothing and the closure stays usable with the bare `(x, parameters)` form. It is the
+        # same guard `linesearch_αmax` reads `params.αmax` through, and it has to be: this
+        # closure reaches its other two fields by *property* access (`params.x`,
+        # `params.parameters`), so a `params` that only answers `haskey` — a `Dict` — could never
+        # have worked here anyway, while one that only answers `hasproperty` — any struct, and
+        # `NullParameters` among them — used to raise a `MethodError` from inside the merit.
+        (iszero(α) && hasproperty(params, :φ₀)) && return convert(T, params.φ₀)
         compute_new_iterate!(xₜ, params.x, α, direction(cache))
         value!(yₜ, nlp, xₜ, params.parameters)
         L2norm(yₜ)

--- a/src/nonlinear/linesearch_problem.jl
+++ b/src/nonlinear/linesearch_problem.jl
@@ -21,8 +21,10 @@ single operation for a large residual. A caller who drives `solver_step!` by han
 a state whose `value` is stale must not supply it.
 
 It may carry an optional `αmax` field too, the caller's ceiling on the step length; see
-[`linesearch_αmax`](@ref), which documents why that one has to be per call. Both are read
-through a `hasproperty` guard resolved at compile time, so supplying neither costs nothing.
+[`linesearch_αmax`](@ref), which documents why that one has to be per call. That one is read by
+the *method* rather than by these closures, through a `hasproperty` guard, as `φ₀` is read here
+through a `haskey` one. Both are resolved from the parameter type at compile time, so supplying
+neither costs nothing.
 """
 function linesearch_problem(nlp::NonlinearProblem, jacobian::Jacobian{T}, cache::Union{NonlinearSolverCache{T},DogLegCache{T}}) where {T}
     # private scratch buffers for the line search (see the docstring for why)

--- a/src/nonlinear/linesearch_problem.jl
+++ b/src/nonlinear/linesearch_problem.jl
@@ -19,6 +19,10 @@ the solver has *already* computed at the current iterate, so [`solver_step!`](@r
 passes it along and saves one `F` evaluation per solver step — the most expensive
 single operation for a large residual. A caller who drives `solver_step!` by hand from
 a state whose `value` is stale must not supply it.
+
+It may carry an optional `αmax` field too, the caller's ceiling on the step length; see
+[`linesearch_αmax`](@ref), which documents why that one has to be per call. Both are read
+through a `hasproperty` guard resolved at compile time, so supplying neither costs nothing.
 """
 function linesearch_problem(nlp::NonlinearProblem, jacobian::Jacobian{T}, cache::Union{NonlinearSolverCache{T},DogLegCache{T}}) where {T}
     # private scratch buffers for the line search (see the docstring for why)

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -830,10 +830,20 @@ end
     # bracket at all and the true value is as far from φ(0) as the step is long.
     @test stbad.φ == (α -> (α + 1.0)^2)(steplength(stbad))
     forever = LinesearchProblem{Float64}((α, _) -> 1.0 - α, (α, _) -> -1.0)
+    # A merit that descends forever is now answered by the ceiling rather than by a failure: the
+    # bracketing stops at `αmax`, and the step it hands back really does decrease the merit — by
+    # 65535 here — so it is a decrease and not an exhausted search.  Reaching `:unbracketable` at
+    # all needs the ceiling switched off, and that is the case the `φ` field was fixed for.
     stf = solve_with_status(Linesearch(forever, Bisection(); verbosity=0), 1.0)
-    @test outcome(stf) === LINESEARCH_EXHAUSTED
-    @test stf.φ == 1.0 - steplength(stf)   # was φ₀ = 1.0, i.e. "the merit did not change"
+    @test outcome(stf) === LINESEARCH_DECREASED
+    @test steplength(stf) == SimpleSolvers.DEFAULT_LINESEARCH_αmax
+    @test stf.φ == 1.0 - steplength(stf)
     @test stf.φ < stf.φ₀
+
+    stfu = solve_with_status(Linesearch(forever, Bisection(; αmax=Inf); verbosity=0), 1.0)
+    @test outcome(stfu) === LINESEARCH_EXHAUSTED
+    @test stfu.φ == 1.0 - steplength(stfu)   # was φ₀ = 1.0, i.e. "the merit did not change"
+    @test stfu.φ < stfu.φ₀
 end
 
 @testset "$(rpad("bisection interval/config disambiguation", 80))" begin
@@ -932,6 +942,144 @@ end
     @test_throws AssertionError BierlaireQuadratic(Float64; ξ=-1.0)
     @test Quadratic() isa Quadratic                      # defaults are valid
     @test BierlaireQuadratic() isa BierlaireQuadratic    # defaults are valid
+    @test_throws AssertionError Quadratic(Float64; αmax=0.0)
+    @test_throws AssertionError BierlaireQuadratic(Float64; αmax=-1.0)
+    @test_throws AssertionError Bisection(Float64; αmax=0.0)
+    @test Bisection() isa Bisection                      # defaults are valid
+end
+
+# The bracketing searches used to grow their bracket outward until the merit stopped falling, and
+# nothing bounded how far that was: `bracket_minimum_with_fixed_point` and `_triple_point_core`
+# double their probe step up to `DEFAULT_BRACKETING_nmax = 100` times, so from `s = 1e-2` the right
+# endpoint can reach 1e28.  Measured downstream (GeometricOptimizers issue D6, the upstream half of
+# their A1b), `Quadratic` returned α = 4.3e7 on a direction of norm 5.5.
+#
+# In a Euclidean problem that is self-correcting — φ grows like α², so the search's own decrease
+# test throws the step out — which is why it went unreported for so long.  On a *compact* manifold
+# it is not: φ is bounded there and can be genuinely lower at α = 1e9 than at α = 0, so nothing the
+# search can measure calls the step too large.  The merit is not a bound on the step.
+@testset "$(rpad("no search extrapolates past its ceiling", 80))" begin
+    αmax = SimpleSolvers.DEFAULT_LINESEARCH_αmax
+    minimising = (Bisection(), Quadratic(), BierlaireQuadratic())
+    every = (Static(), Backtracking(), Backtracking(; expand=true), StrongWolfe(), minimising...)
+
+    # A genuine minimiser, ten million steps away.  Scaled by 1e-14 so the merit stays of order one
+    # over the whole range and the outcome turns on the ceiling rather than on any tolerance.
+    far = LinesearchProblem{Float64}((α, _) -> (α - 1.0e7)^2 / 1.0e14, (α, _) -> 2(α - 1.0e7) / 1.0e14)
+
+    # Switching the ceiling off recovers the old behaviour, which is what says the defect was real
+    # and that this is what fixes it rather than some tolerance change alongside.
+    for m in (Bisection(; αmax=Inf), Quadratic(; αmax=Inf), BierlaireQuadratic(; αmax=Inf))
+        @test steplength(solve_with_status(Linesearch(far, m; verbosity=0), 1.0)) > 1.0e6
+    end
+
+    # With it, every minimising search stops exactly there — and reports a *decrease*, because the
+    # merit at the ceiling really is lower.  A ceiling is not a failure.
+    for m in minimising
+        st = solve_with_status(Linesearch(far, m; verbosity=0), 1.0)
+        @test steplength(st) == αmax
+        @test outcome(st) === LINESEARCH_DECREASED
+        @test st.φ == (α -> (α - 1.0e7)^2 / 1.0e14)(steplength(st))   # the merit at the step handed back
+        @test st.φ ≤ st.φ₀ - st.τ
+    end
+
+    # The caller's ceiling binds for *every* method, including the two that have none of their own.
+    # This is the half GeometricOptimizers needs: its bound is the 2π of a rotation divided by the
+    # norm of the direction, so it changes at every solver step and cannot live in a struct field.
+    for m in every, ceiling in (10.0, 0.25)
+        st = solve_with_status(Linesearch(far, m; verbosity=0), 1.0, (αmax=ceiling,))
+        @test steplength(st) ≤ ceiling
+        @test steplength(st) > 0.0                       # the α > 0 contract still holds
+    end
+
+    # It binds below the natural minimiser too, i.e. it is a ceiling and not just a backstop.
+    near = LinesearchProblem{Float64}((α, _) -> (α - 1.0)^2, (α, _) -> 2(α - 1.0))
+    for m in every
+        st = solve_with_status(Linesearch(near, m; verbosity=0), 1.0, (αmax=0.5,))
+        @test 0.0 < steplength(st) ≤ 0.5
+    end
+
+    # A ceiling that does not bind changes nothing at all — not the step, not the outcome, not the
+    # number of merit evaluations.  This is the assertion that the default path is untouched.
+    for m in every
+        ls = Linesearch(near, m; verbosity=0)
+        plain = solve_with_status(ls, 1.0)
+        roomy = solve_with_status(ls, 1.0, (αmax=1.0e6,))
+        @test steplength(roomy) === steplength(plain)
+        @test outcome(roomy) === outcome(plain)
+        @test trials(roomy) == trials(plain)
+    end
+
+    # `check_anchor` respects it too, so the ceiling holds on the returns that never search: an
+    # ascent anchor hands back the caller's trial step, and a caller that asked for less gets less.
+    ascent = LinesearchProblem{Float64}((α, _) -> (α + 1.0)^2, (α, _) -> 2(α + 1.0))
+    for m in every
+        st = solve_with_status(Linesearch(ascent, m; verbosity=0), 4.0, (αmax=0.5,))
+        @test 0.0 < steplength(st) ≤ 0.5
+    end
+
+    # The ceiling bounds where the merit is *evaluated*, not only what is returned.  A ceiling below
+    # the bracketing step `DEFAULT_BRACKETING_s` used to be stepped over by the first probe, before
+    # the loop tested the bound for the first time — one evaluation outside the range the caller
+    # called admissible, which on a problem where such a step is meaningless is exactly the
+    # evaluation the ceiling exists to avoid.
+    for m in every
+        probed = Float64[]
+        watched = LinesearchProblem{Float64}((α, _) -> (push!(probed, α); (α - 1.0)^2),
+            (α, _) -> (push!(probed, α); 2(α - 1.0)))
+        st = solve_with_status(Linesearch(watched, m; verbosity=0), 1.0, (αmax=0.005,))
+        @test isempty(probed) || maximum(probed) ≤ 0.005     # `Static` evaluates nothing at all
+        @test 0.0 < steplength(st) ≤ 0.005
+    end
+
+    # A ceiling that is not a usable step length is a caller error, and is reported as one before a
+    # single merit evaluation is spent — not silently ignored, which would hand back exactly the
+    # unbounded step the caller was trying to rule out.
+    for bad in (0.0, -1.0, NaN)
+        n = Ref(0)
+        counted = LinesearchProblem{Float64}((α, _) -> (n[] += 1; (α - 1.0)^2), (α, _) -> (n[] += 1; 2(α - 1.0)))
+        for m in every
+            @test_throws ArgumentError solve_with_status(Linesearch(counted, m; verbosity=0), 1.0, (αmax=bad,))
+        end
+        @test n[] == 0
+    end
+    # `Inf` is not one of them: it says the caller has no scale of its own, which is what a bound
+    # derived from one (2π / ‖δ‖, say) degenerates to for a vanishing direction. The method's own
+    # ceiling then stands, so it cannot produce an unbounded step either.
+    @test steplength(solve_with_status(Linesearch(far, Quadratic(); verbosity=0), 1.0, (αmax=Inf,))) == αmax
+end
+
+# The bracketing helpers report a truncated bracket as such rather than as a found one: the fits
+# would otherwise be handed an interval over which the merit only falls, where `Quadratic`'s
+# curvature guard bisects and returns a midpoint strictly worse than the endpoint.
+@testset "$(rpad("the bracketing helpers report a bracket truncated at the ceiling", 80))" begin
+    descending(x) = 1.0 - x                    # never turns, so only the ceiling can stop it
+    turning(x) = (x - 1.0)^2                   # turns at 1, well inside the ceilings below
+
+    a, b, ya, yb, st = SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, 0.01, 2.0, 100, 5.0)
+    @test st === :capped
+    @test b == 5.0 && yb == descending(5.0)
+    @test SimpleSolvers._bracket_minimum_with_fixed_point_core(turning, 0.0, 0.01, 2.0, 100, 5.0)[end] === :ok
+    # …and without a ceiling the same merit is what it always was: unbracketable.
+    @test SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, 0.01, 2.0, 100, Inf)[end] === :unbracketable
+
+    lo, hi, stm = SimpleSolvers._bracket_minimum_core(descending, 0.0, 0.01, 2.0, 100, 5.0)
+    @test stm === :capped && hi == 5.0
+    @test SimpleSolvers._bracket_minimum_core(turning, 0.0, 0.01, 2.0, 100, 5.0)[end] === :ok
+
+    _, _, c, stt = SimpleSolvers._triple_point_core(descending, 0.0, 0.01, 100, 1, 5.0)
+    @test stt === :capped && c == 5.0
+    @test SimpleSolvers._triple_point_core(turning, 0.0, 0.01, 100, 1, 5.0)[end] === :ok
+    # A ceiling below the initial probe still keeps every evaluation inside the admissible range.
+    @test SimpleSolvers._triple_point_core(descending, 0.0, 0.01, 100, 1, 0.005)[3] ≤ 0.005
+
+    # The public wrappers keep the return type they document; only the cores carry the status.
+    @test SimpleSolvers.bracket_minimum_with_fixed_point(descending, 0.0, 0.01, 2.0, 100, 5.0) == (0.0, 5.0, 1.0, -4.0)
+    @test isnothing(SimpleSolvers.bracket_minimum_with_fixed_point(descending, 0.0, 0.01, 2.0, 100, Inf))
+    # `bracket_minimum` moves its left endpoint as it walks (unlike the fixed-point variant above),
+    # so only the right end is pinned to the ceiling.
+    @test bracket_minimum(descending, 0.0, 0.01, 2.0, 100, 5.0)[2] == 5.0
+    @test isnothing(bracket_minimum(descending, 0.0, 0.01, 2.0, 100, Inf))
 end
 
 # Check that `bracket_minimum_with_fixed_point` returns the
@@ -1421,6 +1569,10 @@ end
     # pin that too: the `trials` of a `LinesearchStatus` and the `Symbol` a bracketing attempt reports.
     probe(a) = (a - 0.5)^2 + 1.0
     @test (@inferred SimpleSolvers._triple_point_core(probe, 0.0, 0.01, 100, 1)) isa Tuple{Float64,Float64,Float64,Symbol}
+    # The ceiling adds a third status but must not add a type: `:capped` travels the same slot.
+    @test (@inferred SimpleSolvers._triple_point_core(probe, 0.0, 0.01, 100, 1, 0.2)) isa Tuple{Float64,Float64,Float64,Symbol}
+    @test (@inferred SimpleSolvers._bracket_minimum_with_fixed_point_core(probe, 0.0, 0.01, 2.0, 100, 0.2)) isa Tuple{Float64,Float64,Float64,Float64,Symbol}
+    @test (@inferred SimpleSolvers._bracket_minimum_core(probe, 0.0, 0.01, 2.0, 100, 0.2)) isa Tuple{Float64,Float64,Symbol}
     let ls = Linesearch(make_linesearch_problem(2.0), BierlaireQuadratic(); verbosity=0)
         a, b, c = SimpleSolvers._triple_point_core(problem(ls), NullParameters(), 0.0)
         @test (@inferred SimpleSolvers._bierlaire_fit(ls, a, b, c, NullParameters(), 1.0e-16)) isa Tuple{Float64,Float64,Int}
@@ -1438,6 +1590,20 @@ end
     end
     for ls in (Static(), Backtracking(), Backtracking(; expand=true), Bisection(), Quadratic(), BierlaireQuadratic())
         @test solve_allocations(ls) == 0 skip = !AS_A_CALLER_COMPILES_IT
+    end
+
+    # A caller that supplies no ceiling pays nothing for the one it could have: `hasproperty` on the
+    # parameter type is resolved at compile time, so `caller_αmax` folds to `Inf` and the solve above
+    # is the proof. A caller that *does* supply one must not pay either — `params` gains a field, not
+    # an allocation — which is what this asserts on the line search directly.
+    function ceiling_allocations(m, params)
+        ls = Linesearch(make_linesearch_problem(2.0), m; verbosity=0)
+        solve_with_status(ls, 1.0, params)
+        @allocated solve_with_status(ls, 1.0, params)
+    end
+    for m in (Static(), Backtracking(), Backtracking(; expand=true), Bisection(), Quadratic(), BierlaireQuadratic())
+        @test ceiling_allocations(m, (x=2.0, αmax=10.0)) == 0 skip = !AS_A_CALLER_COMPILES_IT
+        @test ceiling_allocations(m, (x=2.0,)) == 0 skip = !AS_A_CALLER_COMPILES_IT
     end
 
     function wolfe_allocations()

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -788,7 +788,83 @@ end
 
     # And the outcome is inferred, not boxed — it is on the line search's hot path.
     @test (@inferred SimpleSolvers._bisection_core(froot, 0.0, 2.0, NullParameters(), Options())) isa
-          Tuple{Float64,SimpleSolvers.BisectionOutcome,Int}
+          Tuple{Float64,SimpleSolvers.BisectionOutcome,Int,Float64}
+
+    # The fourth element is `f` at the *left* endpoint, and it is there because its sign is
+    # invariant under the halving: the interval shrinks onto a crossing whose direction the
+    # starting interval already fixed. It is reported after the endpoint flip, i.e. it belongs to
+    # the smaller endpoint whichever order the caller passed them in.
+    @test SimpleSolvers._bisection_core(froot, 0.0, 2.0, NullParameters(), Options())[4] == froot(0.0, nothing)
+    @test SimpleSolvers._bisection_core(froot, 2.0, 0.0, NullParameters(), Options())[4] == froot(0.0, nothing)
+    @test SimpleSolvers._bisection_core(fpos, 0.0, 1.0, NullParameters(), Options())[4] == fpos(0.0, nothing)
+end
+
+@testset "$(rpad("a Bisection converges onto a minimum, never onto a maximum", 80))" begin
+    # `bracket_minimum` brackets a minimum in *value*: it samples φ and never φ′, so on a
+    # non-convex ray its interval can enclose several stationary points and its left endpoint can
+    # sit past one of them. The bisection inside it then converges to whichever crossing the sign
+    # of φ′ at that left endpoint selects — and from φ′(lo) > 0 that crossing is a *maximum*.
+    #
+    # This was not caught: the step was classified by the merit like any other, so it came back as
+    # `LINESEARCH_DECREASED` when it happened to improve φ and `LINESEARCH_FLOOR` when it did not.
+    # The second is the overclaim — `LINESEARCH_FLOOR` asserts that *no* line search can progress
+    # along this direction, and the outer iteration acts on it via `flag_stall!` and `max_stalls`.
+    # GeometricOptimizers observed exactly that (`_BFGS` + `Bisection` + `Geodesic`:
+    # `LINESEARCH_FLOOR` with φ(1) = φ(0), and the step taken regardless).
+    #
+    # φ has its minimum at α = 1; φ′ is given its own shape, with a minimum at α = 0.3 and a
+    # maximum at α = 2 — the realistic case, since `Bisection` bisects φ′ while bracketing on φ and
+    # the two disagree exactly when something is wrong (a stale or regularized Jacobian, an inexact
+    # linear solve, a non-smooth merit).
+    φ(a) = (a - 1.0)^2
+    D(a) = -(a - 0.3) * (a - 2.0)
+    prob = LinesearchProblem{Float64}((a, _) -> φ(a), (a, _) -> D(a))
+    ls = Linesearch(prob, Bisection(); verbosity=0)
+
+    # The bracket really is the pathological one: it ascends at its left endpoint and descends at
+    # its right, so the sign change it contains belongs to the maximum.
+    lo, hi = SimpleSolvers.bracket_minimum(φ, 0.0, 0.01)
+    @test (lo, hi) == (0.64, 2.56)
+    @test D(0.0) < 0.0 && D(lo) > 0.0 && D(hi) < 0.0
+
+    # Bisecting it as such lands on the maximum at α = 2, where the merit equals φ(0) exactly — the
+    # step that used to be handed back and claimed as the line minimiser.
+    αmax_root, ocmax, _, ylo = SimpleSolvers._bisect_on(ls, lo, hi, NullParameters())
+    @test ocmax === SimpleSolvers.BISECTION_CONVERGED
+    @test αmax_root ≈ 2.0 atol = 1e-8
+    @test ylo > 0.0                       # the orientation that gives it away
+    @test φ(αmax_root) == φ(0.0)          # no decrease at all, yet a "located root"
+
+    # Repaired, it bisects [0, lo] instead — oriented for a minimum by construction, since
+    # `check_anchor` has established φ′(0) < 0 — and finds the *earlier* minimum at α = 0.3.
+    αmin_root, ocmin, _ = SimpleSolvers._bisect_for_minimum(ls, lo, hi, NullParameters())
+    @test ocmin === SimpleSolvers.BISECTION_CONVERGED
+    @test αmin_root ≈ 0.3 atol = 1e-8
+
+    # End to end: a genuine decrease, reported as one.
+    st = solve_with_status(ls, 0.01)
+    @test steplength(st) ≈ 0.3 atol = 1e-8
+    @test outcome(st) === LINESEARCH_DECREASED
+    @test !isfloor(st)
+    @test st.φ ≤ st.φ₀ - st.τ
+
+    # A correctly oriented bracket is left exactly as it was, and — the reason the check is
+    # affordable at all — without one extra evaluation of φ′, which for the ‖F‖² merit of a
+    # `NonlinearSolver` is a full Jacobian. `ylo` is a value the bisection computes anyway.
+    convex = LinesearchProblem{Float64}((a, _) -> (a - 1.0)^2, (a, _) -> 2(a - 1.0))
+    lsc = Linesearch(convex, Bisection(); verbosity=0)
+    for (a, b) in ((0.0, 3.0), (0.5, 4.0), (0.64, 2.56))
+        probed = Ref(0)
+        counted = LinesearchProblem{Float64}((a, _) -> (a - 1.0)^2, (a, _) -> (probed[] += 1; 2(a - 1.0)))
+        lscount = Linesearch(counted, Bisection(); verbosity=0)
+        plain = SimpleSolvers._bisect_on(lscount, a, b, NullParameters())
+        n_plain = probed[]
+        probed[] = 0
+        repaired = SimpleSolvers._bisect_for_minimum(lscount, a, b, NullParameters())
+        @test repaired == plain[1:3]      # same step, same verdict, same evaluation count
+        @test probed[] == n_plain         # and the orientation check itself costs nothing
+    end
+    @test solve(lsc, 1.0) ≈ 1.0 atol = ∛(2eps())
 end
 
 @testset "$(rpad("a Bisection that cannot bracket never reports a floor", 80))" begin

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -1151,6 +1151,56 @@ end
         @test n[] ≤ 6
     end
     @test steplength(solve_with_status(Linesearch(descending, Static(); verbosity=0), 1.0, (αmax=0.5,))) == 0.5
+
+    # A ceiling that cancels the search cancels the *derivative* evaluation that would only have
+    # decided where to start it. `Quadratic` chose its bracketing start first and tested the
+    # ceiling after, so it paid for an answer it discarded — and for the ‖F‖² merit of a
+    # `NonlinearSolver` that derivative is a full `Jacobian`, on the one path a caller-supplied
+    # ceiling makes common. Only the anchor's own `φ′(0)` is left.
+    for ceiling in (1.0, 0.5, 0.005)
+        nd = Ref(0)
+        watched = LinesearchProblem{Float64}((α, _) -> 1.0 - α, (α, _) -> (nd[] += 1; -1.0))
+        st = solve_with_status(Linesearch(watched, Quadratic(); verbosity=0), 1.0, (αmax=ceiling,))
+        @test steplength(st) == ceiling
+        @test nd[] == 1
+    end
+end
+
+# `params` carries two optional fields — `φ₀` for the merit at the anchor and `αmax` for the
+# caller's ceiling — and they used to be read through different guards: `haskey` in the merit
+# closure and `hasproperty` in `linesearch_αmax`. Those agree on a `NamedTuple` and on nothing
+# else, so a plain struct had its ceiling honoured and then raised a `MethodError` from inside the
+# merit. `hasproperty` is the one that matches the rest of the closure, which reaches `params.x`
+# and `params.parameters` by property access and so could never have taken a `Dict` anyway.
+@testset "$(rpad("both optional params fields are read the same way", 80))" begin
+    F(y, x, p) = y .= (x .- 1.0) .^ 2
+    x = [0.5]
+    nl = NewtonSolver(x, similar(x); F=F)
+    SimpleSolvers.direction!(nl, x, NullParameters(), 1)
+    prob = SimpleSolvers.linesearch_problem(nl)
+
+    plain = (x=x, parameters=NullParameters())
+    supplied = (x=x, parameters=NullParameters(), φ₀=7.0)
+    @test value(prob, 0.0, supplied) == 7.0                       # the field is used …
+    @test value(prob, 0.0, plain) == SimpleSolvers.L2norm(F(similar(x), x, nothing))   # … and optional
+
+    struct LSParams
+        x::Vector{Float64}
+        parameters::Any
+        φ₀::Float64
+        αmax::Float64
+    end
+    st = LSParams(x, NullParameters(), 7.0, 0.5)
+    @test value(prob, 0.0, st) == 7.0
+    @test SimpleSolvers.linesearch_αmax(Bisection(), st) == 0.5
+    # and a struct without the field falls back, rather than raising, on both channels
+    struct BareParams
+        x::Vector{Float64}
+        parameters::Any
+    end
+    bare = BareParams(x, NullParameters())
+    @test value(prob, 0.0, bare) == value(prob, 0.0, plain)
+    @test SimpleSolvers.linesearch_αmax(Bisection(), bare) == Bisection().αmax
 end
 
 # `DEFAULT_LINESEARCH_αmax` is 2^16, which is *above* `floatmax(Float16) = 65504`, so the plain
@@ -1183,18 +1233,18 @@ end
     descending(x) = 1.0 - x                    # never turns, so only the ceiling can stop it
     turning(x) = (x - 1.0)^2                   # turns at 1, well inside the ceilings below
 
-    a, b, ya, yb, st = SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, 0.01, 2.0, 100, 5.0)
+    a, b, ya, yb, _, st = SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, 0.01, 2.0, 100, 5.0)
     @test st === :capped
     @test b == 5.0 && yb == descending(5.0)
     @test SimpleSolvers._bracket_minimum_with_fixed_point_core(turning, 0.0, 0.01, 2.0, 100, 5.0)[end] === :ok
     # …and without a ceiling the same merit is what it always was: unbracketable.
     @test SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, 0.01, 2.0, 100, Inf)[end] === :unbracketable
 
-    lo, hi, stm = SimpleSolvers._bracket_minimum_core(descending, 0.0, 0.01, 2.0, 100, 5.0)
+    lo, hi, _, stm = SimpleSolvers._bracket_minimum_core(descending, 0.0, 0.01, 2.0, 100, 5.0)
     @test stm === :capped && hi == 5.0
     @test SimpleSolvers._bracket_minimum_core(turning, 0.0, 0.01, 2.0, 100, 5.0)[end] === :ok
 
-    _, _, c, stt = SimpleSolvers._triple_point_core(descending, 0.0, 0.01, 100, 1, 5.0)
+    _, _, c, _, stt = SimpleSolvers._triple_point_core(descending, 0.0, 0.01, 100, 1, 5.0)
     @test stt === :capped && c == 5.0
     @test SimpleSolvers._triple_point_core(turning, 0.0, 0.01, 100, 1, 5.0)[end] === :ok
     # A ceiling below the initial probe still keeps every evaluation inside the admissible range.
@@ -1217,12 +1267,13 @@ end
     # fitted a polynomial, or bisected a derivative, on an interval over which the merit only
     # falls, and the whole `:capped` route was unreachable below `s`.
     for (s, ceiling) in ((1.0, 1.0), (1.0, 0.5), (0.01, 0.005), (0.01, 0.01))
-        @test SimpleSolvers._bracket_minimum_core(descending, 0.0, s, 2.0, 100, ceiling) ==
-              (0.0, ceiling, :capped)
-        let (_, b, _, _, status) = SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, s, 2.0, 100, ceiling)
+        let (lo, hi, _, status) = SimpleSolvers._bracket_minimum_core(descending, 0.0, s, 2.0, 100, ceiling)
+            @test (lo, hi, status) == (0.0, ceiling, :capped)
+        end
+        let (_, b, _, _, _, status) = SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, s, 2.0, 100, ceiling)
             @test (b, status) == (ceiling, :capped)
         end
-        let (_, _, c, status) = SimpleSolvers._triple_point_core(descending, 0.0, s, 100, 1, ceiling)
+        let (_, _, c, _, status) = SimpleSolvers._triple_point_core(descending, 0.0, s, 100, 1, ceiling)
             @test (c, status) == (ceiling, :capped)
         end
         # …and the point at the ceiling is asked for exactly once, not twice.
@@ -1239,6 +1290,33 @@ end
     # A turning point *at* the ceiling is still a genuine bracket and must not be swallowed by the
     # guard above: it is only a tie against the same point that is not one.
     @test SimpleSolvers._bracket_minimum_core(turning, 0.0, 1.0, 2.0, 100, 2.0)[end] === :ok
+
+    # A ceiling at or *below* the start leaves no admissible range at all. `_triple_point_core`
+    # clamps its first probe with `δ = min(δ, αmax - x₀)`, which is then zero or negative, so
+    # every probe landed at or left of the start: `αmax == x₀` reported `:flat` — that no line
+    # search can decrease the merit here — about a search that was never allowed to look, and
+    # `αmax < x₀` spent twelve evaluations halving a negative `δ` first.
+    for ceiling in (0.5, 1.0)
+        n = Ref(0)
+        _, _, _, nrep, status = SimpleSolvers._triple_point_core(
+            x -> (n[] += 1; descending(x)), 1.0, 0.01, 100, 1, ceiling)
+        @test status === :capped
+        @test n[] == 0 && nrep == 0        # and it costs nothing to say so
+    end
+    # Room to the right is still searched, and a negative `δ` — not a step length, and not what
+    # the ceiling is about — behaves exactly as it did.
+    @test SimpleSolvers._triple_point_core(descending, 1.0, 0.01, 100, 1, 2.0)[end] === :capped
+    @test SimpleSolvers._triple_point_core(turning, 1.5, -0.01, 100, 1)[end] ===
+          SimpleSolvers._triple_point_core(turning, 1.5, -0.01, 100, 1, Inf)[end]
+
+    # Each core reports what it spent, because for the searches that bracket the bracketing is
+    # where the work happens — see the `trials` testset for what that is for.
+    for (core, args) in ((SimpleSolvers._bracket_minimum_core, (0.0, 0.01, 2.0, 100, 5.0)),
+        (SimpleSolvers._triple_point_core, (0.0, 0.01, 100, 1, 5.0)))
+        n = Ref(0)
+        reported = core(x -> (n[] += 1; descending(x)), args...)[end-1]
+        @test reported == n[] > 0
+    end
 end
 
 # Check that `bracket_minimum_with_fixed_point` returns the
@@ -1535,9 +1613,9 @@ end
 @testset "$(rpad("trials is a real evaluation count for every method", 80))" begin
     # `trials` used to be a hardcoded 0 for Bisection/Quadratic/BierlaireQuadratic — so the
     # round-off-floor message read "in 0 trial step(s)" — and StrongWolfe counted only its
-    # expansion loop, not its zoom phase.  What each method counts is the problem evaluations of
-    # its *own* iteration: the merit, except for `Bisection`, which drives on the derivative it
-    # bisects.  See the `trials` field of `LinesearchStatus`.
+    # expansion loop, not its zoom phase.  What each method counts is the problem evaluations the
+    # search spent: the merit, except for `Bisection`, which drives on the derivative it bisects
+    # and brackets on the merit.  See the `trials` field of `LinesearchStatus`.
     function counted(m)
         nf, nd = Ref(0), Ref(0)
         prob = LinesearchProblem{Float64}((α, _) -> (nf[] += 1; 1.0 - 2α + 1000α^2),
@@ -1556,15 +1634,30 @@ end
         @test nf == trials(st) + 1
     end
 
-    # The bracketing searches additionally spend evaluations inside `bracket_minimum` /
-    # `triple_point_finder`, which are not counted, so their `trials` is a lower bound on the
-    # total cost — but it is a real count of their own iteration, never zero and never inflated.
+    # The bracketing searches spend most of their evaluations inside `bracket_minimum` /
+    # `triple_point_finder`, and those count too: the bracketing is not a helper the search calls
+    # on the side, it is where the search does its work — and on the path where a ceiling binds it
+    # is the *whole* of it, where a count that omitted it reported one trial (`Bisection`) or none
+    # at all (`Quadratic`, the same value `Static` reports for evaluating nothing) for a search of
+    # any size.  So the count is real in both directions: never zero, and never more than the
+    # evaluations that actually happened.
     for m in (Quadratic(), BierlaireQuadratic())
         st, nf, _ = counted(m)
         @test 0 < trials(st) ≤ nf
     end
-    let (st, _, nd) = counted(Bisection())
-        @test 0 < trials(st) ≤ nd
+    # `Bisection` bisects the derivative but brackets on the merit, so its count is of both.
+    let (st, nf, nd) = counted(Bisection())
+        @test 0 < trials(st) ≤ nf + nd
+    end
+
+    # And the capped path, which is the one the old count said nothing about: the ceiling is
+    # reached by the bracketing, so everything the search spent is the bracketing's.
+    for m in (Bisection(), Quadratic(), BierlaireQuadratic())
+        nf, nd = Ref(0), Ref(0)
+        prob = LinesearchProblem{Float64}((α, _) -> (nf[] += 1; 1.0 - α), (α, _) -> (nd[] += 1; -1.0))
+        st = solve_with_status(Linesearch(prob, m; verbosity=0), 1.0, (αmax=0.5,))
+        @test steplength(st) == 0.5
+        @test 0 < trials(st) ≤ nf[] + nd[]
     end
 end
 
@@ -1727,13 +1820,15 @@ end
     # A boxed counter is invisible in the result but erases the type of everything built from it, so
     # pin that too: the `trials` of a `LinesearchStatus` and the `Symbol` a bracketing attempt reports.
     probe(a) = (a - 0.5)^2 + 1.0
-    @test (@inferred SimpleSolvers._triple_point_core(probe, 0.0, 0.01, 100, 1)) isa Tuple{Float64,Float64,Float64,Symbol}
+    @test (@inferred SimpleSolvers._triple_point_core(probe, 0.0, 0.01, 100, 1)) isa Tuple{Float64,Float64,Float64,Int,Symbol}
     # The ceiling adds a third status but must not add a type: `:capped` travels the same slot.
-    @test (@inferred SimpleSolvers._triple_point_core(probe, 0.0, 0.01, 100, 1, 0.2)) isa Tuple{Float64,Float64,Float64,Symbol}
-    @test (@inferred SimpleSolvers._bracket_minimum_with_fixed_point_core(probe, 0.0, 0.01, 2.0, 100, 0.2)) isa Tuple{Float64,Float64,Float64,Float64,Symbol}
-    @test (@inferred SimpleSolvers._bracket_minimum_core(probe, 0.0, 0.01, 2.0, 100, 0.2)) isa Tuple{Float64,Float64,Symbol}
+    # The evaluation count each core reports has to stay an inferred `Int` for the same reason —
+    # it becomes the `trials` of a `LinesearchStatus`, on the line search's hot path.
+    @test (@inferred SimpleSolvers._triple_point_core(probe, 0.0, 0.01, 100, 1, 0.2)) isa Tuple{Float64,Float64,Float64,Int,Symbol}
+    @test (@inferred SimpleSolvers._bracket_minimum_with_fixed_point_core(probe, 0.0, 0.01, 2.0, 100, 0.2)) isa Tuple{Float64,Float64,Float64,Float64,Int,Symbol}
+    @test (@inferred SimpleSolvers._bracket_minimum_core(probe, 0.0, 0.01, 2.0, 100, 0.2)) isa Tuple{Float64,Float64,Int,Symbol}
     let ls = Linesearch(make_linesearch_problem(2.0), BierlaireQuadratic(); verbosity=0)
-        a, b, c = SimpleSolvers._triple_point_core(problem(ls), NullParameters(), 0.0)
+        a, b, c, _, _ = SimpleSolvers._triple_point_core(problem(ls), NullParameters(), 0.0)
         @test (@inferred SimpleSolvers._bierlaire_fit(ls, a, b, c, NullParameters(), 1.0e-16)) isa Tuple{Float64,Float64,Int}
     end
     @test (@inferred solve_with_status(Linesearch(make_linesearch_problem(2.0), StrongWolfe(); verbosity=0), 1.0)) isa LinesearchStatus

--- a/test/linesearch_tests.jl
+++ b/test/linesearch_tests.jl
@@ -1123,6 +1123,57 @@ end
     # derived from one (2π / ‖δ‖, say) degenerates to for a vanishing direction. The method's own
     # ceiling then stands, so it cannot produce an unbounded step either.
     @test steplength(solve_with_status(Linesearch(far, Quadratic(); verbosity=0), 1.0, (αmax=Inf,))) == αmax
+
+    # When the merit only falls, the ceiling *is* the best admissible step and every minimising
+    # search has to return it — including at the ceilings a caller with a geometric bound actually
+    # supplies.  `Bisection` seeds its bracketing step from the trial step (`s = clamp(|α|, 0.01, 1)`,
+    # so `1` for `α = 1`), which put every ceiling ≤ 1 on the wrong side of the first probe: the
+    # truncated bracket tied with itself, was reported as a found one, and the search fell through
+    # to a `BISECTION_NOBRACKET` and its retry.  Measured on this merit, it returned 0.32 for a
+    # ceiling of 1.0 and 0.16 for one of 0.5 — a third of the step it was allowed — for 15 merit
+    # evaluations, and `LINESEARCH_EXHAUSTED` at 0.005.
+    descending = LinesearchProblem{Float64}((α, _) -> 1.0 - α, (α, _) -> -1.0)
+    for m in minimising, ceiling in (2.0, 1.0, 0.5, 0.05, 0.005)
+        probed = Float64[]
+        watched = LinesearchProblem{Float64}((α, _) -> (push!(probed, α); 1.0 - α), (α, _) -> -1.0)
+        st = solve_with_status(Linesearch(watched, m; verbosity=0), 1.0, (αmax=ceiling,))
+        @test steplength(st) == ceiling
+        @test outcome(st) === LINESEARCH_DECREASED
+        @test st.φ == 1.0 - ceiling            # the merit at the step handed back
+        @test maximum(probed) ≤ ceiling
+    end
+    # …and the merit is not evaluated where nothing needs it: the whole search costs a handful of
+    # evaluations rather than the dozen the fall-through spent.
+    for m in minimising
+        n = Ref(0)
+        counted = LinesearchProblem{Float64}((α, _) -> (n[] += 1; 1.0 - α), (α, _) -> -1.0)
+        solve_with_status(Linesearch(counted, m; verbosity=0), 1.0, (αmax=0.5,))
+        @test n[] ≤ 6
+    end
+    @test steplength(solve_with_status(Linesearch(descending, Static(); verbosity=0), 1.0, (αmax=0.5,))) == 0.5
+end
+
+# `DEFAULT_LINESEARCH_αmax` is 2^16, which is *above* `floatmax(Float16) = 65504`, so the plain
+# `T(DEFAULT_LINESEARCH_αmax)` the constructors used overflowed to `Inf` — and a `Float16` line
+# search then carried no ceiling at all, i.e. the defect the field exists to fix was absent in the
+# one precision this package special-cases everywhere else (`armijo_ulps`, `linesearch_iterations`,
+# `default_precision`).
+@testset "$(rpad("the default ceiling survives Float16", 80))" begin
+    for T in (Float64, Float32, Float16)
+        @test isfinite(SimpleSolvers.default_linesearch_αmax(T))
+        for m in (Bisection(T), Quadratic(T), BierlaireQuadratic(T), StrongWolfe(T))
+            @test SimpleSolvers.method_αmax(m) === SimpleSolvers.default_linesearch_αmax(T)
+            @test isfinite(SimpleSolvers.method_αmax(m))
+        end
+    end
+    @test SimpleSolvers.default_linesearch_αmax(Float16) == floatmax(Float16)
+    @test SimpleSolvers.default_linesearch_αmax(Float64) == SimpleSolvers.DEFAULT_LINESEARCH_αmax
+
+    # `change_precision` saturates a finite ceiling for the same reason, but must leave an explicit
+    # `Inf` alone: that one is not an overflow but a statement — "no ceiling of my own".
+    @test SimpleSolvers.method_αmax(SimpleSolvers.change_precision(Float16, Bisection())) == floatmax(Float16)
+    @test SimpleSolvers.method_αmax(SimpleSolvers.change_precision(Float16, Bisection(; αmax=Inf))) == Inf
+    @test SimpleSolvers.method_αmax(SimpleSolvers.change_precision(Float16, StrongWolfe())) == floatmax(Float16)
 end
 
 # The bracketing helpers report a truncated bracket as such rather than as a found one: the fits
@@ -1156,6 +1207,38 @@ end
     # so only the right end is pinned to the ceiling.
     @test bracket_minimum(descending, 0.0, 0.01, 2.0, 100, 5.0)[2] == 5.0
     @test isnothing(bracket_minimum(descending, 0.0, 0.01, 2.0, 100, Inf))
+
+    # A ceiling at or *below* the bracketing step `s` is the case that matters, because it is the
+    # regime a caller with a geometric bound of its own lands in — and `Bisection` seeds `s` from
+    # the trial step, so `s = 1` for the usual `α = 1`.  The first probe is clamped to the ceiling
+    # there, so the loop's probe lands on the same point: comparing it with itself is a *tie*,
+    # and a tie satisfies `BracketMinimumCriterion` (`yc ≥ yb`), which used to report the
+    # truncation as `:ok` — a turning point that is one point counted twice.  The caller then
+    # fitted a polynomial, or bisected a derivative, on an interval over which the merit only
+    # falls, and the whole `:capped` route was unreachable below `s`.
+    for (s, ceiling) in ((1.0, 1.0), (1.0, 0.5), (0.01, 0.005), (0.01, 0.01))
+        @test SimpleSolvers._bracket_minimum_core(descending, 0.0, s, 2.0, 100, ceiling) ==
+              (0.0, ceiling, :capped)
+        let (_, b, _, _, status) = SimpleSolvers._bracket_minimum_with_fixed_point_core(descending, 0.0, s, 2.0, 100, ceiling)
+            @test (b, status) == (ceiling, :capped)
+        end
+        let (_, _, c, status) = SimpleSolvers._triple_point_core(descending, 0.0, s, 100, 1, ceiling)
+            @test (c, status) == (ceiling, :capped)
+        end
+        # …and the point at the ceiling is asked for exactly once, not twice.
+        for core in (SimpleSolvers._bracket_minimum_core,
+            SimpleSolvers._bracket_minimum_with_fixed_point_core)
+            probed = Float64[]
+            core(x -> (push!(probed, x); descending(x)), 0.0, s, 2.0, 100, ceiling)
+            @test count(==(ceiling), probed) == 1
+        end
+        probed = Float64[]
+        SimpleSolvers._triple_point_core(x -> (push!(probed, x); descending(x)), 0.0, s, 100, 1, ceiling)
+        @test count(==(ceiling), probed) == 1
+    end
+    # A turning point *at* the ceiling is still a genuine bracket and must not be swallowed by the
+    # guard above: it is only a tie against the same point that is not one.
+    @test SimpleSolvers._bracket_minimum_core(turning, 0.0, 1.0, 2.0, 100, 2.0)[end] === :ok
 end
 
 # Check that `bracket_minimum_with_fixed_point` returns the


### PR DESCRIPTION
Fixes [GeometricOptimizers issue **D6**](https://github.com/JuliaGNI/GeometricOptimizers.jl/blob/main/CHANGELOG.md), the upstream half of their **A1b**, and documents every convergence and stopping criterion in one place.

## The defect

`Quadratic` and `BierlaireQuadratic` fit a polynomial to `φ` and step to its stationary point. The fits already confine that point to the bracket — what nothing confined was the **bracket**. `bracket_minimum_with_fixed_point` and `_triple_point_core` double their probe step up to `DEFAULT_BRACKETING_nmax = 100` times, so from `s = 1e-2` the right endpoint can reach `1e28`. Measured downstream on the `St(20,3)²` SVD problem, `Quadratic` returned `α = 4.3e7` on a direction of norm 5.54 — a step of `‖αδ‖ = 2.4e8` — and did it again two steps later on a steepest-descent direction. `bracket_minimum`, and hence `Bisection`, has the same shape.

Why it went unreported is the part that makes it ours rather than downstream's. In a Euclidean problem it is self-correcting: `f(x + αp)` grows with `α`, so the search's own decrease test throws the step out. On a **compact** manifold it is not — `φ` is bounded there and at `α = 1e9` can be genuinely *lower* than at `α = 0`, so the search reports `LINESEARCH_DECREASED` on a step nine orders of magnitude too long and is telling the truth. **The merit is not a bound on the step.**

## The fix

Every method now returns `α ≤ αmax`, a sixth clause of the contract in `LinesearchMethod`, with two ways to set the ceiling:

- **The method's own** — the `αmax` field, generalised from `StrongWolfe` (which has carried exactly this field, with exactly this meaning, all along) to `Bisection`, `Quadratic` and `BierlaireQuadratic`. All four default to `DEFAULT_LINESEARCH_αmax`, which *is* `DEFAULT_WOLFE_αmax = 65536`; the latter is now defined as the former so they cannot drift.
- **The caller's** — an optional `αmax` field of `params`:
  ```julia
  solve_with_status(ls, one(T), (x = x, state = state, αmax = 2π * c / norm(δ)))
  ```
  read through the same compile-time `hasproperty` guard as `params.φ₀`. Not a keyword, so `solve_with_status(ls, α, params)` keeps the signature the contract names as the extension point — GeometricOptimizers' `DecayingStatic` is unaffected.

The caller's half has to be **per call** (the scale changes with `‖δ‖` every step) and has to be an **input** rather than a clamp on the result: clamping afterwards yields a step the search never evaluated, whose `LinesearchStatus` then describes a different step than the one taken. As an input the bracketing stops at the ceiling — so the evaluations beyond it are saved, not wasted — the merit is measured there, and the status describes what is handed back. The bound applies to *where the merit is evaluated* too, including each bracketer's first probe.

All six methods honour it, including the two with no ceiling of their own: `Backtracking` clamps its trial step and bounds its expansion phase, `Static` clamps its fixed `α`, and `check_anchor` clamps so the ceiling holds on the returns that never search.

**No new `LinesearchOutcome`.** A capped search that decreased the merit *did* decrease it; `capped_status` classifies it by the same `τ` rule as any other step. A `LINESEARCH_CAPPED` would have changed `NLINESEARCH_OUTCOMES`, the tally in `NonlinearSolverState` and every downstream read of it, to say something a caller who supplied a ceiling already knows.

## Behaviour

One case changes at default options: a merit that keeps decreasing to the right used to exhaust the bracketing budget and report `LINESEARCH_EXHAUSTED` with the caller's `α`; it now returns the ceiling as `LINESEARCH_DECREASED`, because the merit there really is lower. One test expectation moved with it, and the old behaviour is asserted alongside the new one at `αmax = Inf`.

Nothing else moves unless the ceiling binds. The six per-method evaluation canaries and every zero-allocation assertion stand unedited, a ceiling in `params` allocates nothing, and `Bisection` gains a field while keeping all four of its constructor forms.

## Measured

GeometricOptimizers' SVD problem, `_BFGS` + `Cayley`, over the eight starting points of `scripts/retraction_accuracy.jl` (cap 20 000). *On the manifold* means `check ≤ 1e-12`, that package's own `MANIFOLD_TOLERANCE`:

| search | ceiling | seeds ending on the manifold | worst `check` |
|---|---|---|---|
| `Quadratic` | none (before) | 4 of 8 | 1.3 |
| `Quadratic` | 65536 (the default) | 4 of 8 | 2.8 |
| `Quadratic` | 10 | 7 of 8 | 4.1e-9 |
| `Quadratic` | 1 | **8 of 8** | **6.2e-14** |
| `BierlaireQuadratic` | none (before) | 2 of 8 | 0.92 |
| `BierlaireQuadratic` | 65536 (the default) | 4 of 8 | 0.38 |
| `BierlaireQuadratic` | 10 | 7 of 8 | 4.7e-9 |
| `BierlaireQuadratic` | 1 | **8 of 8** | **6.4e-14** |

**The default ceiling does not close A1b, and the CHANGELOG says so.** At `‖δ‖ ≈ 5.5` a step of `α = 65536` is still `‖αδ‖ = 3.6e5`, five orders above the `2π` past which retracting a lift only adds round-off. What the default reliably does is remove the unbounded extrapolation and bound the bracketing cost. What *fixes* A1b is a ceiling of the right **magnitude** — the bottom row of each block — which is precisely why the caller's half is not optional. That ceiling is GeometricOptimizers' to choose; this PR is what lets them pass one.

Everything else downstream is unmoved: GeometricIntegrators' RK suite passes (107 assertions) and `LotkaVolterra2d` over 1000 steps is **bit-identical** for `Gauss(1)`, `Gauss(2)`, `Gauss(3)`, `ImplicitMidpoint` and `SRK3`. On the SVD sweep exactly three rows change, all under `Cayley`; every `Geodesic` and Euclidean-scaled row is identical to the digit.

## Also in this PR

**`docs/src/convergence.md`**, a new page. The criteria were spread across a dozen docstrings on unexported functions, so there was no statement of them a reader could follow end to end. It covers the line search (`τ`, all six outcomes with the test that produces each, the anchor policy, `αmin`, `αmax`, the six contract clauses), the nonlinear solver (the three residuals, the shared `residual_small` gate that both convergence branches require and both give-up branches negate — which is *why* converging and stagnating are mutually exclusive — `assess_convergence`, the four ways a solve ends without converging, the full `meets_stopping_criteria` disjunction), and **the channel between them**: how a `LinesearchStatus` becomes a `flag_stall!`, a forced Jacobian refresh, a per-solve tally, and the clause that names the cause in the solver's own failure message.

**CHANGELOG `## Open Issues`** gains what this work turned up and did not fix — chiefly that A1b stays open until GeometricOptimizers passes its own ceiling, that a binding ceiling leaves no trace in the status, and that the capped path costs one merit evaluation the bracketing already made.

## Testing

- Full suite passes: **1562** line-search and **3017** nonlinear-solver assertions, plus Aqua and JET.
- New coverage: the reproducer at the default ceiling, the caller channel across all six methods, a ceiling binding below the natural minimiser, the no-change case (step, outcome *and* evaluation count identical with a generous ceiling), input validation before any evaluation, the evaluation bound, the `:capped` bracketing units, and the allocation canary with a ceiling in `params`.
- Docs build with zero cross-reference errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: `Bisection` converges onto a minimum, never onto a maximum

Also fixes the **`Bisection` can converge onto a maximum** entry that stood under `## Open Issues` — the second of the two routes by which `Bisection` could claim `LINESEARCH_FLOOR` without having earned it. 0.12.0 closed the route through a *failed* bracket; this closes the route through a **successful** one.

### The gap

`Bisection` drives on the sign of `φ′`, so it converges to whichever crossing the sign of `φ′` at its left endpoint selects — and **that sign is invariant under the halving**: `y₀` is reassigned only on the branch where `y₀ * y > 0`, so it never changes sign, and `y₁` keeps the opposite one throughout. From `φ′(lo) < 0` the interval shrinks onto a `- → +` crossing, a minimum; from `φ′(lo) > 0` onto a `+ → -` crossing, a **maximum**.

Nothing ruled the second out. `bracket_minimum` brackets a minimum in **value** — it samples `φ` and never `φ′` — so on a non-convex ray its interval can enclose several stationary points and its left endpoint can sit past one of them. Landing on a maximum was not caught: the step was classified by the merit like any other, so it came back as `LINESEARCH_DECREASED` when it happened to improve `φ` and as `LINESEARCH_FLOOR` when it did not. The second is the overclaim, because `LINESEARCH_FLOOR` is a claim about the *direction* — that no line search can progress along it — which the outer iteration acts on through `flag_stall!` and `max_stalls`. GeometricOptimizers observed exactly this (`_BFGS` + `Bisection` + `Geodesic`: `LINESEARCH_FLOOR` with `φ(1) = φ(0)`, and the step taken regardless).

### The fix

- `_bisection_core` returns the value at its (sorted) **left endpoint** as a fourth element — returned rather than recomputed, because its sign is the invariant above and so names which crossing the bisection is heading for before it has finished heading there.
- `_bisect_for_minimum` reads it. Where `φ′(lo) > 0` it discards the interval and bisects `[0, lo]`, which brackets a minimum **by construction** — `check_anchor` has established `φ′(0) < 0`, and `φ′(lo) > 0` supplies the opposite sign at the other end. The minimum it finds is the *earlier* one, nearer the anchor, which is the one a line search wants. The same condition repairs a `BISECTION_NOBRACKET` whose interval ascends at `lo`.
- The repair's verdict **replaces** the first bisection's rather than being merged with it, unlike the negative-step retry: the two disagree because the bracket was in the wrong *place*, which is what the orientation detected — not because `φ′` is inconsistent with `φ`.

### Cost

**None on a ray that does not need it.** The orientation is read off a value `_bisection_core` computes anyway, so a correctly oriented bracket is recognised without one extra evaluation of `φ′` — a full Jacobian for the `‖F‖²` merit of a `NonlinearSolver`. Asserted directly: over three intervals the repaired path returns the same step, the same verdict and the same evaluation count, and makes the same number of derivative evaluations. The overshoot branch was always oriented by construction and now says so through the same helper rather than by implication.

### Measured

The downstream symptom, reproduced: on `φ(α) = (α-1)²` with `φ′` given its own shape (minimum at `0.3`, maximum at `2.0`), `bracket_minimum` returns `[0.64, 2.56]`, which *ascends* at `0.64` and *descends* at `2.56`. Bisecting it lands on `α = 2.0` — the maximum — where `φ(2) = φ(0)` exactly, i.e. `LINESEARCH_FLOOR`. Repaired, the search returns `α = 0.3` with `LINESEARCH_DECREASED` and `φ = 0.49` against `φ(0) = 1.0`.

And the orientation is not exotic. Over 300 random starting points on the non-convex `exp(x)(x³ − 5x² + 2x) + 2` root-finding fixture with `Bisection` as the `NewtonSolver` line search, **13 of 300 solves now converge to a different root**. Not a worse one — all 300 converge in both cases, the same eight distinct roots are reached, and the distribution of `|F|` at the returned iterate is **bit-identical** (median `6.7e-16`, p95 `1.4e-13`, worst `2.7e-12`, all below `1e-10`). Total iterations drop from 698 to 687, worst case unchanged at 4. On a merit with one minimum nothing moves at all.

Full suite still passes; docs still build with zero cross-reference errors.
